### PR TITLE
Limit WebSocket reconnect attempts

### DIFF
--- a/src/backoff/BackoffFactory.ts
+++ b/src/backoff/BackoffFactory.ts
@@ -9,4 +9,10 @@ export default interface BackoffFactory {
    * @returns {Backoff}
    */
   create(): Backoff;
+
+  /**
+   * Limited factory method
+   * @returns {Backoff}
+   */
+  createWithLimit(limit: number): Backoff;
 }

--- a/src/backoff/FullJitterBackoffFactory.ts
+++ b/src/backoff/FullJitterBackoffFactory.ts
@@ -4,6 +4,7 @@
 import Backoff from './Backoff';
 import BackoffFactory from './BackoffFactory';
 import FullJitterBackoff from './FullJitterBackoff';
+import FullJitterLimitedBackoff from './FullJitterLimitedBackoff';
 
 export default class FullJitterBackoffFactory implements BackoffFactory {
   constructor(
@@ -14,5 +15,14 @@ export default class FullJitterBackoffFactory implements BackoffFactory {
 
   create(): Backoff {
     return new FullJitterBackoff(this.fixedWaitMs, this.shortBackoffMs, this.longBackoffMs);
+  }
+
+  createWithLimit(limit: number): Backoff {
+    return new FullJitterLimitedBackoff(
+      this.fixedWaitMs,
+      this.shortBackoffMs,
+      this.longBackoffMs,
+      limit
+    );
   }
 }

--- a/src/backoff/FullJitterLimitedBackoff.ts
+++ b/src/backoff/FullJitterLimitedBackoff.ts
@@ -1,0 +1,25 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import FullJitterBackoff from './FullJitterBackoff';
+
+export default class FullJitterLimitedBackoff extends FullJitterBackoff {
+  private attempts = 0;
+
+  constructor(
+    fixedWaitMs: number,
+    shortBackoffMs: number,
+    longBackoffMs: number,
+    private limit: number
+  ) {
+    super(fixedWaitMs, shortBackoffMs, longBackoffMs);
+  }
+
+  nextBackoffAmountMs(): number {
+    this.attempts++;
+    if (this.attempts > this.limit) {
+      throw new Error('retry limit exceeded');
+    }
+    return super.nextBackoffAmountMs();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ import DragType from './dragobserver/DragType';
 import FinishGatheringICECandidatesTask from './task/FinishGatheringICECandidatesTask';
 import FullJitterBackoff from './backoff/FullJitterBackoff';
 import FullJitterBackoffFactory from './backoff/FullJitterBackoffFactory';
+import FullJitterLimitedBackoff from './backoff/FullJitterLimitedBackoff';
 import GlobalMetricReport from './clientmetricreport/GlobalMetricReport';
 import InitializeDefaultJPEGDecoderControllerTask from './task/InitializeDefaultJPEGDecoderControllerTask';
 import IntervalScheduler from './scheduler/IntervalScheduler';
@@ -373,6 +374,7 @@ export {
   FinishGatheringICECandidatesTask,
   FullJitterBackoff,
   FullJitterBackoffFactory,
+  FullJitterLimitedBackoff,
   GlobalMetricReport,
   InitializeDefaultJPEGDecoderControllerTask,
   IntervalScheduler,

--- a/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
+++ b/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
@@ -44,13 +44,17 @@ export default class ReconnectingPromisedWebSocket implements PromisedWebSocket 
 
       this.webSocket.addEventListener('close', (event: CloseEvent) => {
         if (ReconnectingPromisedWebSocket.normalClosureCodes.indexOf(event.code) <= -1) {
-          const timeout = this.backoff.nextBackoffAmountMs();
-          this.timeoutScheduler = new TimeoutScheduler(timeout);
-          this.timeoutScheduler.start(() => {
-            this.timeoutScheduler.stop();
-            this.open(timeoutMs).then(() => {});
-          });
-          this.dispatchEvent(new CustomEvent('reconnect'));
+          try {
+            const timeout = this.backoff.nextBackoffAmountMs();
+            this.timeoutScheduler = new TimeoutScheduler(timeout);
+            this.timeoutScheduler.start(() => {
+              this.timeoutScheduler.stop();
+              this.open(timeoutMs).then(() => {});
+            });
+            this.dispatchEvent(new CustomEvent('reconnect'));
+          } catch (e) {
+            this.dispatchEvent(event);
+          }
         } else {
           this.dispatchEvent(event);
         }

--- a/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts
+++ b/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts
@@ -9,7 +9,8 @@ import ReconnectingPromisedWebSocket from './ReconnectingPromisedWebSocket';
 export default class ReconnectingPromisedWebSocketFactory implements PromisedWebSocketFactory {
   constructor(
     private promisedWebSocketFactory: PromisedWebSocketFactory,
-    private backoffFactory: BackoffFactory
+    private backoffFactory: BackoffFactory,
+    private reconnectRetryLimit: number
   ) {}
 
   create(
@@ -22,7 +23,7 @@ export default class ReconnectingPromisedWebSocketFactory implements PromisedWeb
       protocols,
       binaryType,
       this.promisedWebSocketFactory,
-      this.backoffFactory.create()
+      this.backoffFactory.createWithLimit(this.reconnectRetryLimit)
     );
   }
 }

--- a/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
+++ b/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
@@ -6,6 +6,7 @@ import DefaultDOMWebSocketFactory from '../domwebsocket/DefaultDOMWebSocketFacto
 import DefaultDragObserver from '../dragobserver/DefaultDragObserver';
 import DragEvent from '../dragobserver/DragEvent';
 import Logger from '../logger/Logger';
+import Maybe from '../maybe/Maybe';
 import MeetingSessionConfiguration from '../meetingsession/MeetingSessionConfiguration';
 import DefaultPromisedWebSocketFactory from '../promisedwebsocket/DefaultPromisedWebSocketFactory';
 import ReconnectingPromisedWebSocketFactory from '../promisedwebsocket/ReconnectingPromisedWebSocketFactory';
@@ -24,7 +25,8 @@ export default class DefaultScreenShareViewFacade implements ScreenShareViewFaca
   constructor(private configuration: MeetingSessionConfiguration, private logger: Logger) {
     const reconnectingWSFactory = new ReconnectingPromisedWebSocketFactory(
       new DefaultPromisedWebSocketFactory(new DefaultDOMWebSocketFactory()),
-      new FullJitterBackoffFactory(1000, 100, 300)
+      new FullJitterBackoffFactory(1000, 100, 300),
+      Maybe.of(configuration.screenSharingSessionOptions.reconnectRetryLimit).getOrElse(5)
     );
     this.screenViewing = new DefaultScreenViewing(
       new DefaultScreenViewingComponentContext(

--- a/src/screensharingsession/ScreenSharingSessionContainer.ts
+++ b/src/screensharingsession/ScreenSharingSessionContainer.ts
@@ -86,7 +86,8 @@ export default class ScreenSharingSessionContainer {
   private reconnectingPromisedWebSocketFactory(): PromisedWebSocketFactory {
     return new ReconnectingPromisedWebSocketFactory(
       this.promisedWebSocketFactory(),
-      this.backOffFactory()
+      this.backOffFactory(),
+      Maybe.of(this.options.reconnectRetryLimit).getOrElse(5)
     );
   }
 

--- a/src/screensharingsession/ScreenSharingSessionOptions.ts
+++ b/src/screensharingsession/ScreenSharingSessionOptions.ts
@@ -3,4 +3,5 @@
 
 export default interface ScreenSharingSessionOptions {
   bitRate?: number;
+  reconnectRetryLimit?: number;
 }

--- a/test/backoff/FullJitterBackoffFactory.test.ts
+++ b/test/backoff/FullJitterBackoffFactory.test.ts
@@ -5,6 +5,7 @@ import * as chai from 'chai';
 
 import FullJitterBackoff from '../../src/backoff/FullJitterBackoff';
 import FullJitterBackoffFactory from '../../src/backoff/FullJitterBackoffFactory';
+import FullJitterLimitedBackoff from '../../src/backoff/FullJitterLimitedBackoff';
 
 describe('FullJitterBackoffFactory', () => {
   const fixed = 1000;
@@ -15,6 +16,13 @@ describe('FullJitterBackoffFactory', () => {
     it('is created', () => {
       const subject = new FullJitterBackoffFactory(fixed, short, long);
       chai.expect(subject.create()).to.be.instanceOf(FullJitterBackoff);
+    });
+  });
+
+  describe('createWithLimit', () => {
+    it('is created', () => {
+      const subject = new FullJitterBackoffFactory(fixed, short, long);
+      chai.expect(subject.createWithLimit(10)).to.be.instanceOf(FullJitterLimitedBackoff);
     });
   });
 });

--- a/test/backoff/FullJitterLimitedBackoff.test.ts
+++ b/test/backoff/FullJitterLimitedBackoff.test.ts
@@ -1,0 +1,25 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as chai from 'chai';
+
+import FullJitterLimitedBackoff from '../../src/backoff/FullJitterLimitedBackoff';
+
+describe('FullJitterLimitedBackoff', () => {
+  const fixed = 1000;
+  const short = 100;
+  const long = 300;
+  const limit = 1;
+
+  describe('nextBackoffAmountMs', () => {
+    it('is computed', () => {
+      const subject = new FullJitterLimitedBackoff(fixed, short, long, limit);
+      subject.nextBackoffAmountMs();
+      chai
+        .expect(() => {
+          subject.nextBackoffAmountMs();
+        })
+        .to.throw('retry limit exceeded');
+    });
+  });
+});

--- a/test/promisedwebsocket/ReconnectingPromisedWebSocketFactory.test.ts
+++ b/test/promisedwebsocket/ReconnectingPromisedWebSocketFactory.test.ts
@@ -15,7 +15,8 @@ describe('ReconnectingPromisedWebSocketFactory', () => {
       const webSocketFactory = Substitute.for<PromisedWebSocketFactory>();
       const subject = new ReconnectingPromisedWebSocketFactory(
         webSocketFactory,
-        Substitute.for<BackoffFactory>()
+        Substitute.for<BackoffFactory>(),
+        5
       );
       chai.expect(subject.create('ws://foo')).to.be.instanceOf(ReconnectingPromisedWebSocket);
     });


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Implement retry + jitter + retry limit to limit websocket reconnect attempts below infinite

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
