### PR TITLE
Ensure that screen connection is made only on view request

### DIFF
--- a/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
+++ b/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
@@ -45,7 +45,11 @@ export default class DefaultScreenShareViewFacade implements ScreenShareViewFaca
     );
   }
 
-  async open(): Promise<void> {
+  async open(): Promise<void> {}
+
+  async close(): Promise<void> {}
+
+  async start(element: HTMLDivElement): Promise<void> {
     const connectionRequest: ScreenViewingSessionConnectionRequest = new ScreenViewingSessionConnectionRequest(
       this.configuration.urls.screenViewingURL,
       this.configuration.urls.screenDataURL,
@@ -53,18 +57,12 @@ export default class DefaultScreenShareViewFacade implements ScreenShareViewFaca
       this.configuration.screenViewingTimeoutMs
     );
     await this.screenViewing.open(connectionRequest);
-  }
-
-  async close(): Promise<void> {
-    await this.screenViewing.close();
-  }
-
-  start(element: HTMLDivElement): void {
     return this.screenViewing.start(element);
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.screenViewing.stop();
+    await this.screenViewing.close();
   }
 
   presentScaleToFit(): void {

--- a/src/screenshareviewfacade/ScreenShareViewFacade.ts
+++ b/src/screenshareviewfacade/ScreenShareViewFacade.ts
@@ -6,11 +6,15 @@ import ScreenObserver from '../screenviewing/observer/ScreenObserver';
 export default interface ScreenShareViewFacade {
   /**
    * Opens the connections, must be called after the ScreenShareViewFacade is constructed
+   *
+   * @deprecated Use start when the user wants to start viewing screen
    */
   open(): Promise<void>;
 
   /**
    * Closes screen viewing connection
+   *
+   * @deprecated Use stop when the user wants to stop viewing screen
    */
   close(): Promise<void>;
 
@@ -18,12 +22,12 @@ export default interface ScreenShareViewFacade {
    * Starts viewing the screen share within an HTML element. Note that an
    * HTMLCanvas will be placed inside of this element.
    */
-  start(element: HTMLDivElement): void;
+  start(element: HTMLDivElement): Promise<void>;
 
   /**
    * Stops viewing the screen share.
    */
-  stop(): void;
+  stop(): Promise<void>;
 
   /**
    * Changes the presentation policy to scale-to-fit


### PR DESCRIPTION
*Issue #:* Resolves an issue outside this repo.

*Description of changes*
This change ensures that a wsv connection is only made when the user elects to view screen.  This provides bandwidth improvements for the sharer and non-viewers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
