### PR TITLE
Add a ConnectionHealthPolicyConfiguration property in the meeting ses…

### DIFF
--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -264,7 +264,11 @@ export default class DefaultAudioVideoController implements AudioVideoController
 
     try {
       await new SerialGroupTask(this.logger, 'AudioVideoStart', [
-        new MonitorTask(this.meetingSessionContext, this.connectionHealthData),
+        new MonitorTask(
+          this.meetingSessionContext,
+          this.configuration.connectionHealthPolicyConfiguration,
+          this.connectionHealthData
+        ),
         new ReceiveAudioInputTask(this.meetingSessionContext),
         new TimeoutTask(
           this.logger,

--- a/src/meetingsession/MeetingSessionConfiguration.ts
+++ b/src/meetingsession/MeetingSessionConfiguration.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
+import ConnectionHealthPolicyConfiguration from '../connectionhealthpolicy/ConnectionHealthPolicyConfiguration';
 import ScreenSharingSessionOptions from '../screensharingsession/ScreenSharingSessionOptions';
 import MeetingSessionCredentials from './MeetingSessionCredentials';
 import MeetingSessionURLs from './MeetingSessionURLs';
@@ -12,17 +13,17 @@ import MeetingSessionURLs from './MeetingSessionURLs';
  */
 export default class MeetingSessionConfiguration {
   /**
-   * The id of the meeting the session is joining
+   * The id of the meeting the session is joining.
    */
   meetingId: string | null = null;
 
   /**
-   * The credentials used to authenticate the session
+   * The credentials used to authenticate the session.
    */
   credentials: MeetingSessionCredentials | null = null;
 
   /**
-   * The URLs the session uses to reach the meeting service
+   * The URLs the session uses to reach the meeting service.
    */
   urls: MeetingSessionURLs | null = null;
 
@@ -42,9 +43,15 @@ export default class MeetingSessionConfiguration {
   screenViewingTimeoutMs: number = 5000;
 
   /**
-   * Screen sharing session options
+   * Screen sharing session options.
    */
   screenSharingSessionOptions: ScreenSharingSessionOptions = {};
+
+  /**
+   * Configuration for connection health policies: reconnection, unusable audio warning connection,
+   * and signal strength bars connection.
+   */
+  connectionHealthPolicyConfiguration: ConnectionHealthPolicyConfiguration = new ConnectionHealthPolicyConfiguration();
 
   /**
    * Constructs a MeetingSessionConfiguration optionally with a chime:CreateMeeting and

--- a/src/task/MonitorTask.ts
+++ b/src/task/MonitorTask.ts
@@ -35,20 +35,21 @@ export default class MonitorTask extends BaseTask
 
   constructor(
     private context: AudioVideoControllerState,
+    connectionHealthPolicyConfiguration: ConnectionHealthPolicyConfiguration,
     private initialConnectionHealthData: ConnectionHealthData
   ) {
     super(context.logger);
     this.reconnectionHealthPolicy = new ReconnectionHealthPolicy(
       context.logger,
-      new ConnectionHealthPolicyConfiguration(),
+      { ...connectionHealthPolicyConfiguration },
       this.initialConnectionHealthData.clone()
     );
     this.unusableAudioWarningHealthPolicy = new UnusableAudioWarningConnectionHealthPolicy(
-      new ConnectionHealthPolicyConfiguration(),
+      { ...connectionHealthPolicyConfiguration },
       this.initialConnectionHealthData.clone()
     );
     this.signalStrengthBarsHealthPolicy = new SignalStrengthBarsConnectionHealthPolicy(
-      new ConnectionHealthPolicyConfiguration(),
+      { ...connectionHealthPolicyConfiguration },
       this.initialConnectionHealthData.clone()
     );
   }

--- a/test/task/MonitorTask.test.ts
+++ b/test/task/MonitorTask.test.ts
@@ -10,6 +10,7 @@ import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVi
 import AudioVideoObserver from '../../src/audiovideoobserver/AudioVideoObserver';
 import FullJitterBackoff from '../../src/backoff/FullJitterBackoff';
 import ConnectionHealthData from '../../src/connectionhealthpolicy/ConnectionHealthData';
+import ConnectionHealthPolicyConfiguration from '../../src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration';
 import ConnectionMonitor from '../../src/connectionmonitor/ConnectionMonitor';
 import Logger from '../../src/logger/Logger';
 import NoOpDebugLogger from '../../src/logger/NoOpDebugLogger';
@@ -133,7 +134,11 @@ describe('MonitorTask', () => {
       new DefaultWebSocketAdapter(context.logger),
       context.logger
     );
-    task = new MonitorTask(context, new ConnectionHealthData());
+    task = new MonitorTask(
+      context,
+      new ConnectionHealthPolicyConfiguration(),
+      new ConnectionHealthData()
+    );
   });
 
   afterEach(() => {


### PR DESCRIPTION
…sion configuration

*Issue #:* 
N/A

*Description of changes*
- Add a ConnectionHealthPolicyConfiguration property to MeetingSessionConfiguration.

  For example, you can set ```MeetingSessionConfiguration.connectionHealthPolicyConfiguration```.
  ```
  import { ConnectionHealthPolicyConfiguration } from 'amazon-chime-sdk-js';

  const policyConfiguration = new ConnectionHealthPolicyConfiguration();
  policyConfiguration.missedPongsUpperThreshold = 10;

  const meetingSessionConfiguration =  new MeetingSessionConfiguration(__YOUR_MEETING_RESPONSE__, __YOUR_ATTENDEE_RESPONSE__)
  meetingSessionConfiguration.connectionHealthPolicyConfiguration = policyConfiguration;

  const session = new DefaultMeetingSession(configuration, logger, deviceController)
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
