### PR TITLE
Improve handling of closed signaling connections

### DIFF
--- a/src/signalingclient/SignalingClient.ts
+++ b/src/signalingclient/SignalingClient.ts
@@ -73,9 +73,9 @@ export default interface SignalingClient {
   /**
    * Closes any existing connection.
    *
-   * After closing the connection, it delivers final events pertaining to the connection, and then
-   * services the connection request queue. If there is no connection to close, this function does
-   * nothing.
+   * Prior to closing, it delivers a WebSocketClosing event. Upon receipt of the final
+   * WebSocket close event, the connection request queue is serviced. If there is no connection
+   * to close, this function just services the connection request queue and returns.
    */
   closeConnection(): void;
 

--- a/src/signalingclient/SignalingClientEvent.ts
+++ b/src/signalingclient/SignalingClientEvent.ts
@@ -24,4 +24,16 @@ export default class SignalingClientEvent {
   ) {
     this.timestampMs = Date.now();
   }
+
+  isConnectionTerminated(): boolean {
+    switch (this.type) {
+      case SignalingClientEventType.WebSocketFailed:
+      case SignalingClientEventType.WebSocketError:
+      case SignalingClientEventType.WebSocketClosing:
+      case SignalingClientEventType.WebSocketClosed:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/src/task/CleanStoppedSessionTask.ts
+++ b/src/task/CleanStoppedSessionTask.ts
@@ -26,9 +26,10 @@ export default class CleanStoppedSessionTask extends BaseTask {
 
   async run(): Promise<void> {
     try {
-      this.context.signalingClient.closeConnection();
-      await this.receiveWebSocketClosedEvent();
-      this.context.logger.info('got close event');
+      if (this.context.signalingClient.ready()) {
+        this.context.signalingClient.closeConnection();
+        await this.receiveWebSocketClosedEvent();
+      }
     } catch (error) {
       throw error;
     } finally {

--- a/test/task/CleanStoppedSessionTask.test.ts
+++ b/test/task/CleanStoppedSessionTask.test.ts
@@ -119,6 +119,15 @@ describe('CleanStoppedSessionTask', () => {
       });
     });
 
+    it('does not close the connection if already closed', done => {
+      expect(context.signalingClient.ready()).to.equal(true);
+      context.signalingClient.closeConnection();
+      task.run().then(() => {
+        expect(context.signalingClient.ready()).to.equal(false);
+        done();
+      });
+    });
+
     it('sets audio and video input to null', done => {
       task.run().then(() => {
         expect(context.activeAudioInput).to.be.null;
@@ -222,6 +231,9 @@ describe('CleanStoppedSessionTask', () => {
 
     it('continues to clean up remaining audio-video state regardless of the close connection failure', done => {
       class TestSignalingClient extends DefaultSignalingClient {
+        ready(): boolean {
+          return true;
+        }
         closeConnection(): void {
           throw new Error();
         }
@@ -255,6 +267,9 @@ describe('CleanStoppedSessionTask', () => {
     it('should not close the WebSocket connection if the message is not the WebSocket closed event', done => {
       expect(context.signalingClient.ready()).to.equal(true);
       class TestSignalingClient extends DefaultSignalingClient {
+        ready(): boolean {
+          return true;
+        }
         closeConnection(): void {}
       }
       context.signalingClient = new TestSignalingClient(webSocketAdapter, context.logger);


### PR DESCRIPTION
*Issue #:* Addresses issues with handling terminal MeetingSessionStatus and cleaning up the session when the signaling socket is closed by the remote end.

*Description of changes*

* When cleaning up, do not attempt to close the socket or wait for a close event if the socket is already closed.
* Do not attempt to send a leave or wait for a leaveAck if the signaling socket is not ready. Avoids hanging and waiting for a timeout when tearing down the session.
* Handle the case where the socket is closed or we receive a socket error while waiting for a leaveAck. Again avoids hanging and waiting for a timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
