### PR TITLE
Adding a travis deploy step to workspace skip cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ addons:
 deploy:
   provider: script
   script: script/deploy-canary-demo
+  skip_cleanup: true
   on:
     branch: master

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -1,4 +1,5 @@
-#!/bin/bash -i
+#!/bin/bash
+set -o xtrace
 
 repo_path=~/build/aws/amazon-chime-sdk-js
 cd $repo_path/demos/browser


### PR DESCRIPTION
Travis build after mergin a PR is failing at the deploy step. This PR is to fix the failure:
https://travis-ci.org/aws/amazon-chime-sdk-js/builds/622837538?utm_medium=notification&utm_source=github_status