### PR TITLE
Fix bug that prevented device change from triggering observers

### DIFF
--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -411,8 +411,8 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
 
   private areDeviceListsEqual(a: MediaDeviceInfo[], b: MediaDeviceInfo[]): boolean {
     return (
-      JSON.stringify(a.map(device => device.deviceId).sort()) ===
-      JSON.stringify(b.map(device => device.deviceId).sort())
+      JSON.stringify(a.map(device => JSON.stringify(device)).sort()) ===
+      JSON.stringify(b.map(device => JSON.stringify(device)).sort())
     );
   }
 


### PR DESCRIPTION
*Issue #:* 
25
*Description of changes*
DefaultDeviceController now compares stringified MediaDeviceInfo object arrays rather than arrays of device IDs only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
