### PR TITLE
Reset connectionHealthData before (re)connection

### DIFF
--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -122,6 +122,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
       this._audioMixController,
       this._deviceController
     );
+    this.meetingSessionContext.logger = this._logger;
   }
 
   get configuration(): MeetingSessionConfiguration {
@@ -191,6 +192,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
   }
 
   private async actionConnect(reconnecting: boolean): Promise<void> {
+    this.connectionHealthData.reset();
     this.meetingSessionContext = new AudioVideoControllerState();
     this.meetingSessionContext.logger = this.logger;
     this.meetingSessionContext.browserBehavior = new DefaultBrowserBehavior();
@@ -296,7 +298,6 @@ export default class DefaultAudioVideoController implements AudioVideoController
           this.configuration.connectionTimeoutMs
         ),
       ]).run();
-
       this.sessionStateController.perform(SessionStateControllerAction.FinishConnecting, () => {
         this.actionFinishConnecting();
       });
@@ -313,6 +314,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
         }
       });
     }
+    this.connectionHealthData.setConnectionStartTime();
   }
 
   private actionFinishConnecting(): void {
@@ -359,7 +361,6 @@ export default class DefaultAudioVideoController implements AudioVideoController
     } catch (error) {
       this.logger.info('fail to clean');
     }
-
     this.sessionStateController.perform(SessionStateControllerAction.FinishDisconnecting, () => {
       if (!reconnecting) {
         this.forEachObserver(observer => {
@@ -479,6 +480,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
       });
     }
 
+    this.connectionHealthData.reset();
     try {
       await new SerialGroupTask(this.logger, 'AudioVideoReconnect', [
         new TimeoutTask(
@@ -526,6 +528,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
         );
       });
     }
+    this.connectionHealthData.setConnectionStartTime();
   }
 
   private getMeetingStatusCode(error: Error): MeetingSessionStatusCode | null {

--- a/src/connectionhealthpolicy/ConnectionHealthData.ts
+++ b/src/connectionhealthpolicy/ConnectionHealthData.ts
@@ -20,6 +20,27 @@ export default class ConnectionHealthData {
   private static isTimestampRecent(timestampMs: number, recentDurationMs: number): boolean {
     return Date.now() < timestampMs + recentDurationMs;
   }
+
+  setConnectionStartTime(): void {
+    this.connectionStartTimestampMs = Date.now();
+    this.lastGoodSignalTimestampMs = Date.now();
+  }
+
+  reset(): void {
+    this.connectionStartTimestampMs = 0;
+    this.consecutiveStatsWithNoPackets = 0;
+    this.lastPacketLossInboundTimestampMs = 0;
+    this.lastGoodSignalTimestampMs = 0;
+    this.lastWeakSignalTimestampMs = 0;
+    this.lastNoSignalTimestampMs = 0;
+    this.consecutiveMissedPongs = 0;
+    this.packetsReceivedInLastMinute = [];
+    this.fractionPacketsLostInboundInLastMinute = [];
+    this.audioSpeakerDelayMs = 0;
+    this.connectionStartTimestampMs = Date.now();
+    this.lastGoodSignalTimestampMs = Date.now();
+  }
+
   isConnectionStartRecent(recentDurationMs: number): boolean {
     return ConnectionHealthData.isTimestampRecent(
       this.connectionStartTimestampMs,

--- a/test/task/CleanRestartedSessionTask.test.ts
+++ b/test/task/CleanRestartedSessionTask.test.ts
@@ -5,7 +5,13 @@ import * as chai from 'chai';
 
 import AudioVideoControllerState from '../../src/audiovideocontroller/AudioVideoControllerState';
 import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
+import ConnectionHealthData from '../../src/connectionhealthpolicy/ConnectionHealthData';
+import SignalingAndMetricsConnectionMonitor from '../../src/connectionmonitor/SignalingAndMetricsConnectionMonitor';
+import NoOpDebugLogger from '../../src/logger/NoOpDebugLogger';
+import PingPong from '../../src/pingpong/PingPong';
+import PingPongObserver from '../../src/pingpongobserver/PingPongObserver';
 import TimeoutScheduler from '../../src/scheduler/TimeoutScheduler';
+import DefaultStatsCollector from '../../src/statscollector/DefaultStatsCollector';
 import CleanRestartedSessionTask from '../../src/task/CleanRestartedSessionTask';
 import Task from '../../src/task/Task';
 import DefaultTransceiverController from '../../src/transceivercontroller/DefaultTransceiverController';
@@ -13,6 +19,13 @@ import DefaultVideoTileController from '../../src/videotilecontroller/DefaultVid
 import DefaultVideoTileFactory from '../../src/videotilefactory/DefaultVideoTileFactory';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
+class TestPingPong implements PingPong {
+  addObserver(_observer: PingPongObserver): void {}
+  removeObserver(_observer: PingPongObserver): void {}
+  forEachObserver(_observerFunc: (_observer: PingPongObserver) => void): void {}
+  start(): void {}
+  stop(): void {}
+}
 
 describe('CleanRestartedSessionTask', () => {
   const expect: Chai.ExpectStatic = chai.expect;
@@ -32,6 +45,14 @@ describe('CleanRestartedSessionTask', () => {
       new DefaultVideoTileFactory(),
       context.audioVideoController,
       context.audioVideoController.logger
+    );
+    context.connectionMonitor = new SignalingAndMetricsConnectionMonitor(
+      context.audioVideoController,
+      context.audioVideoController.realtimeController,
+      context.audioVideoController.videoTileController,
+      new ConnectionHealthData(),
+      new TestPingPong(),
+      new DefaultStatsCollector(context.audioVideoController, new NoOpDebugLogger())
     );
 
     task = new CleanRestartedSessionTask(context);


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

ReconnectionHealthPolicy relies on ConnectionHealthData to determine whether connection is healthy. This ConnectionHealthData object is persistent in AudioVideoController and shared across several objects. We need to reset the data and set the correct timestamp to avoid redundantly triggering re-connection.
This PR is a minimum fix. 

There will be following PR to refactor the object lifecycle of MonitorTask and ConnectionMonitor to be more persistent instead of re-allocating.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
