### PR TITLE
Implement keyframe request handling

### DIFF
--- a/src/mediarecording/MediaRecording.ts
+++ b/src/mediarecording/MediaRecording.ts
@@ -9,6 +9,11 @@ export default interface MediaRecording extends EventTarget {
   start(timeSliceMs?: number): void;
 
   /**
+   * Key the recording
+   */
+  key(): void;
+
+  /**
    * Stop the media recorder instance
    */
   stop(): Promise<void>;

--- a/src/mediarecording/WebMMediaRecording.ts
+++ b/src/mediarecording/WebMMediaRecording.ts
@@ -1,23 +1,33 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import Maybe from '../maybe/Maybe';
 import MediaRecording from './MediaRecording';
 import MediaRecordingEvent from './MediaRecordingEvent';
 import MediaRecordingOptions from './MediaRecordingOptions';
 
 export default class WebMMediaRecording implements MediaRecording {
-  private static options: MediaRecorderOptions = {
+  static readonly options: MediaRecorderOptions = {
     mimeType: 'video/webm; codecs=vp8',
   };
 
-  private delegate: MediaRecorder;
+  private delegate: MediaRecorder | null = null;
+  readonly options: MediaRecorderOptions;
+  readonly mediaStream: MediaStream;
+  private timeSliceMs: number;
+  private listeners = new Map<string, Set<EventListener>>();
 
   constructor(mediaStream: MediaStream, options: MediaRecordingOptions = {}) {
-    const mediaRecorderOptions = { ...options, ...WebMMediaRecording.options };
-    this.delegate = new MediaRecorder(mediaStream, mediaRecorderOptions);
+    this.options = { ...options, ...WebMMediaRecording.options };
+    this.mediaStream = mediaStream;
   }
 
-  start(timeSliceMs?: number): void {
+  key(): void {
+    const delegate = this.delegate;
+    this.delegate = new MediaRecorder(this.mediaStream.clone(), this.options);
+    this.delegate.addEventListener('dataavailable', (event: BlobEvent) => {
+      this.dispatchEvent(event);
+    });
     /**
      * Chrome 'ended' callback:
      * This is a Chrome-specific callback that we receive when the user clicks the "Stop Sharing" button
@@ -29,11 +39,22 @@ export default class WebMMediaRecording implements MediaRecording {
         this.dispatchEvent(event);
       });
     });
-    this.delegate.start(timeSliceMs);
+    if (delegate !== null) {
+      delegate.stop();
+    }
+    this.delegate.start(this.timeSliceMs);
+  }
+
+  start(timeSliceMs?: number): void {
+    this.timeSliceMs = timeSliceMs;
+    this.key();
   }
 
   stop(): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
+      if (this.delegate === null) {
+        reject(new Error('not started'));
+      }
       // this event should fire after any data is de-queued
       this.delegate.addEventListener('stop', () => {
         resolve();
@@ -46,18 +67,20 @@ export default class WebMMediaRecording implements MediaRecording {
   }
 
   addEventListener(type: string, listener: EventListener): void {
-    this.delegate.addEventListener(type, listener);
+    Maybe.of(this.listeners.get(type))
+      .defaulting(new Set<EventListener>())
+      .map(listeners => listeners.add(listener))
+      .map(listeners => this.listeners.set(type, listeners));
   }
 
   dispatchEvent(event: Event): boolean {
-    return this.delegate.dispatchEvent(event);
+    Maybe.of(this.listeners.get(event.type)).map(listeners => {
+      listeners.forEach(listener => listener(event));
+    });
+    return event.defaultPrevented;
   }
 
-  removeEventListener(
-    type: string,
-    listener?: EventListenerOrEventListenerObject | null,
-    options?: EventListenerOptions | boolean
-  ): void {
-    this.delegate.removeEventListener(type, listener, options);
+  removeEventListener(type: string, listener: EventListener): void {
+    Maybe.of(this.listeners.get(type)).map(f => f.delete(listener));
   }
 }

--- a/src/screensharestreaming/ScreenShareStream.ts
+++ b/src/screensharestreaming/ScreenShareStream.ts
@@ -14,6 +14,10 @@ export default class ScreenShareStream implements ScreenShareStreaming {
 
   constructor(private mediaRecording: MediaRecording) {}
 
+  key(): void {
+    return this.mediaRecording.key();
+  }
+
   start(timeSliceMs?: number): void {
     this.mediaRecording.addEventListener('dataavailable', (event: BlobEvent) => {
       this.onDataAvailable(event);

--- a/src/screensharestreaming/ScreenShareStreaming.ts
+++ b/src/screensharestreaming/ScreenShareStreaming.ts
@@ -14,4 +14,9 @@ export default interface ScreenShareStreaming extends EventTarget {
    * @returns {Promise<void>}
    */
   stop(): Promise<void>;
+
+  /**
+   * Key the stream
+   */
+  key(): void;
 }

--- a/src/screensharingmessage/ScreenSharingMessageType.ts
+++ b/src/screensharingmessage/ScreenSharingMessageType.ts
@@ -13,6 +13,7 @@ export enum ScreenSharingMessageType {
   StreamStop = 'StreamStop',
   WebM = 'WebM',
   PresenterSwitch = 'PresenterSwitch',
+  KeyRequest = 'KeyRequest',
 }
 
 export default ScreenSharingMessageType;

--- a/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts
+++ b/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts
@@ -10,6 +10,7 @@ import ScreenSharingMessageTypeSerialization from './ScreenSharingMessageTypeSer
 export default class ScreenSharingMessageTypeSerializer
   implements ScreenSharingMessageTypeSerialization {
   private static readonly fromNumberMap = new Map<number, ScreenSharingMessageType>([
+    [0x02, ScreenSharingMessageType.KeyRequest],
     [0x03, ScreenSharingMessageType.StreamStart],
     [0x04, ScreenSharingMessageType.StreamEnd],
     [0x05, ScreenSharingMessageType.StreamStop],

--- a/src/screensharingsession/DefaultScreenSharingSession.ts
+++ b/src/screensharingsession/DefaultScreenSharingSession.ts
@@ -149,9 +149,16 @@ export default class DefaultScreenSharingSession implements ScreenSharingSession
         return this.didReceiveHeartbeatRequestMessage();
       case ScreenSharingMessageType.StreamStop:
         return this.didReceiveStreamStopMessage();
+      case ScreenSharingMessageType.KeyRequest:
+        return this.didReceiveKeyRequest();
       default:
         return this.didReceiveUnknownMessage();
     }
+  }
+
+  private didReceiveKeyRequest(): void {
+    this.logger.info('received key request message');
+    this.stream.key();
   }
 
   private didReceiveStreamStopMessage(): void {

--- a/test/dommediarecordermock/DOMMediaRecorderMock.ts
+++ b/test/dommediarecordermock/DOMMediaRecorderMock.ts
@@ -4,7 +4,11 @@
 export default class DOMMediaRecorderMock implements EventTarget {
   private listeners = new Map<string, Set<EventListener>>();
 
-  constructor(readonly stream: MediaStream, _options?: MediaRecorderOptions) {}
+  constructor(readonly stream: MediaStream, _options?: MediaRecorderOptions) {
+    stream.addEventListener('dataavailable', (event: BlobEvent) => {
+      this.dispatchEvent(event);
+    });
+  }
 
   start(_timeSliceMs: number): void {}
 

--- a/test/mediarecordingmock/MediaRecordingMock.ts
+++ b/test/mediarecordingmock/MediaRecordingMock.ts
@@ -6,6 +6,8 @@ import MediaRecording from '../../src/mediarecording/MediaRecording';
 export default class MediaRecordingMock implements MediaRecording {
   private listeners = new Map<string, Set<EventListener>>();
 
+  key(): void {}
+
   start(_timeSliceMs: number): void {}
 
   stop(): Promise<void> {

--- a/test/screensharestreaming/ScreenShareStream.test.ts
+++ b/test/screensharestreaming/ScreenShareStream.test.ts
@@ -26,6 +26,15 @@ describe('ScreenShareStream', () => {
     GlobalAny.CustomEvent = undefined;
   });
 
+  describe('#key', () => {
+    it('is keyed', () => {
+      const mediaRecording = Substitute.for<MediaRecording>();
+      const subject = new ScreenShareStream(mediaRecording);
+      subject.key();
+      mediaRecording.received().key();
+    });
+  });
+
   describe('#start', () => {
     it('exists', () => {
       const recorder = Substitute.for<MediaRecording>();

--- a/test/screensharestreamingmock/ScreenShareStreamingMock.ts
+++ b/test/screensharestreamingmock/ScreenShareStreamingMock.ts
@@ -37,4 +37,6 @@ export default class ScreenShareStreamingMock implements ScreenShareStreaming {
   stop(): Promise<void> {
     return Promise.resolve();
   }
+
+  key(): void {}
 }

--- a/test/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.test.ts
+++ b/test/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.test.ts
@@ -16,6 +16,7 @@ describe('ScreenSharingMessageTypeSerializer', () => {
   describe('#serialize', () => {
     const expected = [
       [ScreenSharingMessageType.UnknownType, 0x0],
+      [ScreenSharingMessageType.KeyRequest, 0x02],
       [ScreenSharingMessageType.StreamStart, 0x03],
       [ScreenSharingMessageType.StreamEnd, 0x04],
       [ScreenSharingMessageType.StreamStop, 0x05],
@@ -34,6 +35,7 @@ describe('ScreenSharingMessageTypeSerializer', () => {
   describe('#deserialize', () => {
     const expected = [
       [0x00, ScreenSharingMessageType.UnknownType],
+      [0x02, ScreenSharingMessageType.KeyRequest],
       [0x03, ScreenSharingMessageType.StreamStart],
       [0x04, ScreenSharingMessageType.StreamEnd],
       [0x05, ScreenSharingMessageType.StreamStop],


### PR DESCRIPTION
- Add handler for keyframe requests that recycles the MediaRecorder
  instance that wraps the MediaStream.  The first frame the new instance
  emits will always be a keyframe

*Issue #:*

*Description of changes*
Adds a keyframe request handler to enable the SDK to respond to keyframe requests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
