### PR TITLE
Move screen view data connection open and close

### DIFF
--- a/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
+++ b/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts
@@ -45,26 +45,26 @@ export default class DefaultScreenShareViewFacade implements ScreenShareViewFaca
     );
   }
 
-  async open(): Promise<void> {
+  open(): Promise<void> {
     const connectionRequest: ScreenViewingSessionConnectionRequest = new ScreenViewingSessionConnectionRequest(
       this.configuration.urls.screenViewingURL,
       this.configuration.urls.screenDataURL,
       this.configuration.credentials.joinToken,
       this.configuration.screenViewingTimeoutMs
     );
-    await this.screenViewing.open(connectionRequest);
+    return this.screenViewing.open(connectionRequest);
   }
 
-  async close(): Promise<void> {
-    await this.screenViewing.close();
+  close(): Promise<void> {
+    return this.screenViewing.close();
   }
 
-  start(element: HTMLDivElement): void {
+  start(element: HTMLDivElement): Promise<void> {
     return this.screenViewing.start(element);
   }
 
-  stop(): void {
-    this.screenViewing.stop();
+  stop(): Promise<void> {
+    return this.screenViewing.stop();
   }
 
   presentScaleToFit(): void {

--- a/src/screenshareviewfacade/ScreenShareViewFacade.ts
+++ b/src/screenshareviewfacade/ScreenShareViewFacade.ts
@@ -18,12 +18,12 @@ export default interface ScreenShareViewFacade {
    * Starts viewing the screen share within an HTML element. Note that an
    * HTMLCanvas will be placed inside of this element.
    */
-  start(element: HTMLDivElement): void;
+  start(element: HTMLDivElement): Promise<void>;
 
   /**
    * Stops viewing the screen share.
    */
-  stop(): void;
+  stop(): Promise<void>;
 
   /**
    * Changes the presentation policy to scale-to-fit

--- a/src/screenviewing/ScreenViewing.ts
+++ b/src/screenviewing/ScreenViewing.ts
@@ -19,12 +19,12 @@ export default interface ScreenViewing {
    * Starts the screen viewing given a div to create a canvas within
    * @param canvasContainer
    */
-  start(canvasContainer: HTMLDivElement): void;
+  start(canvasContainer: HTMLDivElement): Promise<void>;
 
   /**
    * Stops the screen viewing
    */
-  stop(): void;
+  stop(): Promise<void>;
 
   /**
    * Changes the presentation policy to scale-to-fit

--- a/test/screenviewing/DefaultScreenViewing.test.ts
+++ b/test/screenviewing/DefaultScreenViewing.test.ts
@@ -8,7 +8,7 @@ import DefaultJPEGDecoderController from '../../src/jpegdecoder/controller/Defau
 import ScreenViewingComponentContext from '../../src/screenviewing/context/ScreenViewingComponentContext';
 import DefaultScreenViewing from '../../src/screenviewing/DefaultScreenViewing';
 import ScreenObserver from '../../src/screenviewing/observer/ScreenObserver';
-import ScreenViewingSession from '../../src/screenviewing/session/ScreenViewingSession';
+import ScreenViewingSessionConnectionRequest from '../../src/screenviewing/session/ScreenViewingSessionConnectionRequest';
 import SignalingSession from '../../src/screenviewing/signalingsession/SignalingSession';
 
 describe('DefaultScreenViewing', () => {
@@ -22,9 +22,6 @@ describe('DefaultScreenViewing', () => {
       const signalingSession: SubstituteOf<SignalingSession> = Substitute.for();
       signalingSession.open(Arg.any()).returns(Promise.resolve());
 
-      const viewingSession: SubstituteOf<ScreenViewingSession> = Substitute.for();
-      viewingSession.openConnection(Arg.any()).returns(Promise.resolve(Substitute.for()));
-
       const context: SubstituteOf<ScreenViewingComponentContext> = Substitute.for();
       context.jpegDecoderController.returns(controller);
       assert.exists(new DefaultScreenViewing(context).open(Substitute.for()));
@@ -32,20 +29,23 @@ describe('DefaultScreenViewing', () => {
   });
 
   describe('close', () => {
-    it('calls viewer close', (done: MochaDone) => {
+    it('calls viewer close', () => {
       return new DefaultScreenViewing({
         ...Substitute.for(),
+        viewer: {
+          ...Substitute.for(),
+          stop(): void {},
+        },
         signalingSession: {
           ...Substitute.for(),
           close(): Promise<void> {
-            done();
-            return;
+            return Promise.resolve();
           },
         },
         viewingSession: {
           ...Substitute.for(),
           closeConnection(): Promise<void> {
-            return;
+            return Promise.resolve();
           },
         },
       }).close();
@@ -53,13 +53,17 @@ describe('DefaultScreenViewing', () => {
   });
 
   describe('start', () => {
-    it('calls viewer start', (done: MochaDone) => {
-      new DefaultScreenViewing({
+    it('calls viewer start', () => {
+      return new DefaultScreenViewing({
         ...Substitute.for(),
         viewer: {
           ...Substitute.for(),
-          start(_canvasContainer: HTMLDivElement): void {
-            done();
+          start(_canvasContainer: HTMLDivElement): void {},
+        },
+        viewingSession: {
+          ...Substitute.for(),
+          openConnection(_request: ScreenViewingSessionConnectionRequest): Promise<Event> {
+            return Promise.resolve(Substitute.for());
           },
         },
       }).start(Substitute.for());


### PR DESCRIPTION
*Issue #:* 

*Description of changes*
This change ensures we only open the screen viewing data connection when the user requests to view the shared screen and closes the connection when the user requests to stop viewing the shared screen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
