### PR TITLE
Set active only if still in roster

### DIFF
--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -93,7 +93,7 @@ class TestSound {
 }
 
 export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver {
-  showActiveSpeakerScores = true;
+  showActiveSpeakerScores = false;
   activeSpeakerLayout = true;
   meeting: string | null = null;
   name: string | null = null;
@@ -590,8 +590,10 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
         this.roster[attendeeId].active = false;
       }
       for (const attendeeId of attendeeIds) {
-        this.roster[attendeeId].active = true;
-        break; // only show the most active speaker
+        if (this.roster[attendeeId]) {
+          this.roster[attendeeId].active = true;
+          break; // only show the most active speaker
+        }
       }
       this.layoutVideoTiles();
     };


### PR DESCRIPTION
*Issue #:* #34

*Description of changes*

Set `active` only if still in roster. Otherwise, the handler can throw an error and halt the meeting session. This PR also disables showing the active speaker score in the roster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
