### PR TITLE
Add alternative for audio device switching and add flag to disable the use of WebAudio

### DIFF
--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -120,6 +120,9 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     'button-screen-view': false,
   };
 
+  // feature flags
+  enableWebAudio = false;
+
   constructor() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).app = this;
@@ -456,8 +459,10 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
   initializeMeetingSession(configuration: MeetingSessionConfiguration): void {
     const logger = new ConsoleLogger('SDK', LogLevel.INFO);
     const deviceController = new DefaultDeviceController(logger);
+    configuration.enableWebAudio = this.enableWebAudio;
     this.meetingSession = new DefaultMeetingSession(configuration, logger, deviceController);
     this.audioVideo = this.meetingSession.audioVideo;
+
     this.audioVideo.addDeviceChangeObserver(this);
     this.setupDeviceLabelTrigger();
     this.populateAllDeviceLists();

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.589.0",
+    "aws-sdk": "^2.591.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/src/audiovideocontroller/AudioVideoController.ts
+++ b/src/audiovideocontroller/AudioVideoController.ts
@@ -36,6 +36,12 @@ export default interface AudioVideoController extends AudioVideoControllerFacade
   restartLocalVideo(callback: () => void): void;
 
   /**
+   * Restarts the local audio. This function assumes the peer connection is established and an active
+   * audio stream must be chosen in [[DeviceController]]
+   */
+  restartLocalAudio(callback: () => void): Promise<void>;
+
+  /**
    * Restarts the peer connection and/or the session.
    */
   reconnect(status: MeetingSessionStatus): boolean;

--- a/src/audiovideocontroller/AudioVideoControllerState.ts
+++ b/src/audiovideocontroller/AudioVideoControllerState.ts
@@ -87,6 +87,8 @@ export default class AudioVideoControllerState {
 
   localVideoSender: RTCRtpSender | null = null;
 
+  localAudioSender: RTCRtpSender | null = null;
+
   videoCaptureAndEncodeParameter: VideoCaptureAndEncodeParameter | null = null;
 
   videosToReceive: VideoStreamIdSet | null = null;

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -351,6 +351,11 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     });
   }
 
+  enableWebAudio(flag: boolean): void {
+    this.deviceController.enableWebAudio(flag);
+    this.trace('enableWebAudio', flag);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private trace(name: string, input?: any, output?: any): void {
     let s = `API/DefaultAudioVideoFacade/${name}`;

--- a/src/devicecontroller/DeviceController.ts
+++ b/src/devicecontroller/DeviceController.ts
@@ -130,4 +130,9 @@ export default interface DeviceController {
     frameRate: number,
     maxBandwidthKbps: number
   ): void;
+
+  /**
+   * Sets the flag in [[DeviceController]] on whether to enable WebAudio-based device management.
+   */
+  enableWebAudio(flag: boolean): void;
 }

--- a/src/devicecontroller/NoOpDeviceController.ts
+++ b/src/devicecontroller/NoOpDeviceController.ts
@@ -57,4 +57,6 @@ export default class NoOpDeviceController extends NoOpMediaStreamBroker
     _frameRate: number,
     _maxBandwidthKbps: number
   ): void {}
+
+  enableWebAudio(_flag: boolean): void {}
 }

--- a/src/meetingsession/DefaultMeetingSession.ts
+++ b/src/meetingsession/DefaultMeetingSession.ts
@@ -39,6 +39,7 @@ export default class DefaultMeetingSession implements MeetingSession {
     this._configuration = configuration;
     this._logger = logger;
     this._deviceController = deviceController;
+    this._deviceController.enableWebAudio(configuration.enableWebAudio);
     this.audioVideoController = new DefaultAudioVideoController(
       this._configuration,
       this._logger,

--- a/src/meetingsession/MeetingSessionConfiguration.ts
+++ b/src/meetingsession/MeetingSessionConfiguration.ts
@@ -54,6 +54,11 @@ export default class MeetingSessionConfiguration {
   connectionHealthPolicyConfiguration: ConnectionHealthPolicyConfiguration = new ConnectionHealthPolicyConfiguration();
 
   /**
+   * Feature flag to enable WebAudio processing
+   */
+  enableWebAudio: boolean = false;
+
+  /**
    * Constructs a MeetingSessionConfiguration optionally with a chime:CreateMeeting and
    * chime:CreateAttendee response. You can pass in either a JSON object containing the
    * responses, or a JSON object containing the information in the Meeting and Attendee

--- a/src/task/AttachMediaInputTask.ts
+++ b/src/task/AttachMediaInputTask.ts
@@ -40,13 +40,13 @@ export default class AttachMediaInputTask extends BaseTask {
             // unclear why this does not deal with the case of removing
             // an existing track as we do in attachVideoInput
             // @ts-ignore
-            this.context.peer.addTrack(track, audioInput);
+            this.context.localAudioSender = this.context.peer.addTrack(track, audioInput);
           }
         });
       }
     } else {
       transceiverController.setAudioInput(null);
-      this.context.logger.info('no audio track');
+      this.context.logger.warn('no audio track');
     }
 
     const videoInput = this.context.activeVideoInput;

--- a/src/transceivercontroller/DefaultTransceiverController.ts
+++ b/src/transceivercontroller/DefaultTransceiverController.ts
@@ -37,6 +37,18 @@ export default class DefaultTransceiverController implements TransceiverControll
     logger.info(`set video send bandwidth to ${bitrateKbps}kbps`);
   }
 
+  static async replaceAudioTrackForSender(
+    sender: RTCRtpSender,
+    track: MediaStreamTrack
+  ): Promise<boolean> {
+    if (!sender) {
+      return false;
+    }
+
+    await sender.replaceTrack(track);
+    return true;
+  }
+
   setVideoSendingBitrateKbps(bitrateKbps: number): void {
     // this won't set bandwidth limitation for video in Chrome
     if (!this.localCameraTransceiver || this.localCameraTransceiver.direction !== 'sendrecv') {
@@ -106,6 +118,15 @@ export default class DefaultTransceiverController implements TransceiverControll
 
   setAudioInput(track: MediaStreamTrack | null): void {
     this.setTransceiverInput(this.localAudioTransceiver, track);
+  }
+
+  async replaceAudioTrack(track: MediaStreamTrack): Promise<boolean> {
+    if (!this.localAudioTransceiver || this.localAudioTransceiver.direction !== 'sendrecv') {
+      this.logger.info(`audio transceiver direction is not set up or not activated`);
+      return false;
+    }
+    await this.localAudioTransceiver.sender.replaceTrack(track);
+    return true;
   }
 
   setVideoInput(track: MediaStreamTrack | null): void {

--- a/src/transceivercontroller/TransceiverController.ts
+++ b/src/transceivercontroller/TransceiverController.ts
@@ -40,6 +40,11 @@ export default interface TransceiverController {
   setAudioInput(track: MediaStreamTrack | null): void;
 
   /**
+   * Replaces [[MediaStreamTrack]] on audio transceiver of sendrecv direction.
+   */
+  replaceAudioTrack(track: MediaStreamTrack): Promise<boolean>;
+
+  /**
    * Sets the video track.
    */
   setVideoInput(track: MediaStreamTrack | null): void;

--- a/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
+++ b/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
@@ -457,10 +457,18 @@ describe('DefaultAudioVideoFacade', () => {
       assert(spy.calledOnceWith(arg1));
     });
 
-    it('will call mixIntoAudioInput', () => {
+    it('will call mixIntoAudioInput if WebAudio feature is enabled', () => {
+      facade.enableWebAudio(true);
       const spy = sinon.spy(controller.deviceController, 'mixIntoAudioInput');
       const arg1 = new MediaStream();
       facade.mixIntoAudioInput(arg1);
+      assert(spy.calledOnceWith(arg1));
+    });
+
+    it('will call enableWebAudio', () => {
+      const spy = sinon.spy(controller.deviceController, 'enableWebAudio');
+      const arg1 = false;
+      facade.enableWebAudio(arg1);
       assert(spy.calledOnceWith(arg1));
     });
   });

--- a/test/devicecontroller/NoOpDeviceController.test.ts
+++ b/test/devicecontroller/NoOpDeviceController.test.ts
@@ -26,9 +26,15 @@ describe('NoOpDeviceController', () => {
     domMockBuilder.cleanup();
   });
 
-  describe('constructior', () => {
+  describe('constructor', () => {
     it('can be constructed', () => {
       expect(deviceController).to.exist;
+    });
+  });
+
+  describe('enableWebAudio', () => {
+    it('can be called', () => {
+      deviceController.enableWebAudio(true);
     });
   });
 

--- a/test/transceivercontroller/DefaultTransceiverController.test.ts
+++ b/test/transceivercontroller/DefaultTransceiverController.test.ts
@@ -413,4 +413,51 @@ describe('DefaultTransceiverController', () => {
       });
     });
   });
+
+  describe('replaceAudioTrack', () => {
+    it('returns false if transceiver is not set up or audio transceiver is not sending', async () => {
+      const newAudioTrack = new MediaStreamTrack();
+      let success = await tc.replaceAudioTrack(newAudioTrack);
+      expect(success).to.be.false;
+
+      // set up local transceivers
+      success = true;
+      const peer: RTCPeerConnection = new RTCPeerConnection();
+      tc.setPeer(peer);
+      tc.setupLocalTransceivers();
+      success = await tc.replaceAudioTrack(newAudioTrack);
+      expect(success).to.be.false;
+
+      // set audio input to activate transceiver
+      tc.setAudioInput(newAudioTrack);
+
+      const newAudioTrack2 = new MediaStreamTrack();
+      success = await tc.replaceAudioTrack(newAudioTrack2);
+      expect(success).to.be.true;
+      const audioTransceiver = peer.getTransceivers()[0];
+      expect(audioTransceiver.sender.track).to.equal(newAudioTrack2);
+    });
+  });
+
+  describe('replaceAudioTrackForSender', () => {
+    it('returns false if input sender is null', async () => {
+      const audioTrack = new MediaStreamTrack();
+      const success = await DefaultTransceiverController.replaceAudioTrackForSender(
+        null,
+        audioTrack
+      );
+      expect(success).to.be.false;
+    });
+
+    it('returns true if audio track is replaced', async () => {
+      const sender = new RTCRtpSender();
+      const audioTrack = new MediaStreamTrack();
+      const success = await DefaultTransceiverController.replaceAudioTrackForSender(
+        sender,
+        audioTrack
+      );
+      expect(success).to.be.true;
+      expect(sender.track).to.equal(audioTrack);
+    });
+  });
 });


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

We use `WebAudio` in `DefaultDeviceController` for audio stream/track management. It poses some problem: for example, in Safari,  audio will stop when apps running in background. 
This PR provides an alternative implementation where we use audio stream directly. 
When switching device, `replaceTrack` is used in RTCRtpSender to avoid rejoining meeting since triggering a re-subscription violates certain server assumptions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
