### PR TITLE
Add source node to audio graph for silent devices

### DIFF
--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -249,14 +249,15 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
   static synthesizeAudioDevice(toneHz: number): Device {
     const audioContext = DefaultDeviceController.createAudioContext();
     const outputNode = audioContext.createMediaStreamDestination();
+    const gainNode = audioContext.createGain();
+    gainNode.gain.value = 0.0;
+    gainNode.connect(outputNode);
     if (toneHz) {
-      const gainNode = audioContext.createGain();
       gainNode.gain.value = 0.1;
       const oscillatorNode = audioContext.createOscillator();
       oscillatorNode.frequency.value = toneHz;
       oscillatorNode.connect(gainNode);
       oscillatorNode.start();
-      gainNode.connect(outputNode);
     }
     outputNode.addEventListener('ended', () => {
       audioContext.close();


### PR DESCRIPTION
*Description of changes*

Add source node to audio graph for silent devices. Without a source node, the WebAudio MediaStreamDestination will not actually contain any audio. The server will not show the attendee as present unless audio data is received. To fix, it is enough to have a gain node attached to the MediaStreamDestinationNode with no input of its own and a gain of 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
