### PR TITLE
Fix null or empty device handling

### DIFF
--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -410,16 +410,16 @@ export default class DefaultAudioVideoController implements AudioVideoController
     } catch (error) {
       this.logger.info('could not acquire audio stream from mediaStreamBroker');
     }
-    if (!audioStream || audioStream.getTracks().length < 1) {
-      return Promise.reject('could not acquire audio track');
+    if (!audioStream || audioStream.getAudioTracks().length < 1) {
+      throw new Error('could not acquire audio track');
     }
 
     this.connectionHealthData.reset();
     this.connectionHealthData.setConnectionStartTime();
 
-    const audioTrack = audioStream.getTracks()[0];
+    const audioTrack = audioStream.getAudioTracks()[0];
     if (!this.meetingSessionContext || !this.meetingSessionContext.peer) {
-      return Promise.reject('no active meeting and peer connection');
+      throw new Error('no active meeting and peer connection');
     }
     let replaceTrackSuccess = false;
 
@@ -433,6 +433,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
         audioTrack
       );
     }
+    this.meetingSessionContext.activeAudioInput = audioStream;
     callback();
     if (replaceTrackSuccess) {
       return Promise.resolve();

--- a/src/meetingsession/MeetingSessionStatusCode.ts
+++ b/src/meetingsession/MeetingSessionStatusCode.ts
@@ -108,6 +108,11 @@ export enum MeetingSessionStatusCode {
    * A task failed for an unknown reason.
    */
   TaskFailed = 19,
+
+  /**
+   * Audio device has switched.
+   */
+  AudioDeviceSwitched = 20,
 }
 
 export default MeetingSessionStatusCode;


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Fix null or empty device handling. For audio, an empty device is created which sends a loop of silent audio data. For video, we now explicitly prevent starting video with a null device.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
