### PR TITLE
Fix Firefox keyframing

### DIFF
--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.592.0",
+    "aws-sdk": "^2.594.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/test/mediarecording/WebMMediaRecording.test.ts
+++ b/test/mediarecording/WebMMediaRecording.test.ts
@@ -5,6 +5,7 @@ import Substitute from '@fluffy-spoon/substitute';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
+import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
 import MediaRecordingOptions from '../../src/mediarecording/MediaRecordingOptions';
 import WebMMediaRecording from '../../src/mediarecording/WebMMediaRecording';
 import CustomEventMock from '../customeventmock/CustomEventMock';
@@ -40,6 +41,22 @@ describe('WebMMediaRecording', () => {
     describe('without start', () => {
       it('is keyed', () => {
         new WebMMediaRecording(Substitute.for<MediaStream>()).key();
+      });
+    });
+
+    describe('with Chrome', () => {
+      it('is keyed', () => {
+        const browser = Substitute.for<DefaultBrowserBehavior>();
+        const mediaStream = Substitute.for<MediaStream>();
+        const mediaTrack = Substitute.for<MediaStreamTrack>();
+        mediaTrack.stop().returns();
+        mediaStream.getTracks().returns(Array.of(mediaTrack));
+        mediaStream.clone().returns(mediaStream);
+        browser.isChrome().returns(true);
+        const subject = new WebMMediaRecording(mediaStream, {}, browser);
+        subject.key();
+        subject.key();
+        mediaTrack.received().stop();
       });
     });
   });


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Firefox does not expect us to stop the underlying MediaStreamTrack but Chrome does.  Conditionally stop the underlying tracks on Chrome only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
