### PR TITLE
Fix chooseVideoInputDevice with null

### DIFF
--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -956,6 +956,8 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       }
       this.audioVideo.stopLocalVideoTile();
       this.toggleButton('button-camera', 'off');
+      // choose video input null is redundant since we expect stopLocalVideoTile to clean up
+      await this.audioVideo.chooseVideoInputDevice(device);
       throw new Error('no video device selected');
     }
     await this.audioVideo.chooseVideoInputDevice(device);

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -455,10 +455,14 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
     device: Device,
     fromAcquire: boolean
   ): Promise<DevicePermission> {
-    if (kind === 'video' && device === null && this.activeDevices[kind]) {
-      this.releaseMediaStream(this.activeDevices[kind].stream);
-      delete this.activeDevices[kind];
+    if (device === null && kind === 'video') {
+      if (this.activeDevices[kind]) {
+        this.releaseMediaStream(this.activeDevices[kind].stream);
+        delete this.activeDevices[kind];
+      }
+      return DevicePermission.PermissionGrantedByBrowser;
     }
+
     let proposedConstraints: MediaStreamConstraints | null = this.calculateMediaStreamConstraints(
       kind,
       device
@@ -480,7 +484,7 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
     let startTimeMs = Date.now();
     let newDevice: DeviceSelection;
     try {
-      this.logger.info(`requesting new ${kind} device`);
+      this.logger.info(`requesting new ${kind} device with constraint ${proposedConstraints}`);
       const stream = this.deviceAsMediaStream(device);
       if (kind === 'audio' && device === null) {
         newDevice = new DeviceSelection();


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

`chooseVideoInputDevice(null)` indicates no video device and it should just return.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
