### PR TITLE
Expose standard bitrate estimation metrics

### DIFF
--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -476,18 +476,23 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
 
   metricsDidReceive(clientMetricReport: ClientMetricReport): void {
     const metricReport = clientMetricReport.getObservableMetrics();
-    const availableSendBandwidth = metricReport.availableSendBandwidth;
-    const availableRecvBandwidth = metricReport.availableReceiveBandwidth;
-    if (typeof availableSendBandwidth === 'number' && !isNaN(availableSendBandwidth)) {
+    if (typeof metricReport.availableSendBandwidth === 'number' && !isNaN(metricReport.availableSendBandwidth)) {
       (document.getElementById('video-uplink-bandwidth') as HTMLSpanElement).innerHTML =
-        'Available Uplink Bandwidth: ' + String(availableSendBandwidth / 1000) + ' Kbps';
+        'Available Uplink Bandwidth: ' + String(metricReport.availableSendBandwidth / 1000) + ' Kbps';
+    } else if (typeof metricReport.availableOutgoingBitrate === 'number' && !isNaN(metricReport.availableOutgoingBitrate)) {
+      (document.getElementById('video-uplink-bandwidth') as HTMLSpanElement).innerHTML =
+      'Available Uplink Bandwidth: ' + String(metricReport.availableOutgoingBitrate / 1000) + ' Kbps';
     } else {
       (document.getElementById('video-uplink-bandwidth') as HTMLSpanElement).innerHTML =
-        'Available Uplink Bandwidth: Unknown';
+      'Available Uplink Bandwidth: Unknown';
     }
-    if (typeof availableRecvBandwidth === 'number' && !isNaN(availableRecvBandwidth)) {
+
+    if (typeof metricReport.availableReceiveBandwidth === 'number' && !isNaN(metricReport.availableReceiveBandwidth)) {
       (document.getElementById('video-downlink-bandwidth') as HTMLSpanElement).innerHTML =
-        'Available Downlink Bandwidth: ' + String(availableRecvBandwidth / 1000) + ' Kbps';
+        'Available Downlink Bandwidth: ' + String(metricReport.availableReceiveBandwidth / 1000) + ' Kbps';
+    } else if (typeof metricReport.availableIncomingBitrate === 'number' && !isNaN(metricReport.availableIncomingBitrate)) {
+      (document.getElementById('video-downlink-bandwidth') as HTMLSpanElement).innerHTML =
+      'Available Downlink Bandwidth: ' + String(metricReport.availableIncomingBitrate / 1000) + ' Kbps';
     } else {
       (document.getElementById('video-downlink-bandwidth') as HTMLSpanElement).innerHTML =
         'Available Downlink Bandwidth: Unknown';

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.594.0",
+    "aws-sdk": "^2.596.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/src/clientmetricreport/DefaultClientMetricReport.ts
+++ b/src/clientmetricreport/DefaultClientMetricReport.ts
@@ -137,6 +137,9 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
       transform: this.countPerSecond,
       type: SdkMetric.Type.SOCKET_DISCARDED_PPS,
     },
+
+    availableIncomingBitrate: { transform: this.identityValue },
+    availableOutgoingBitrate: { transform: this.identityValue },
   };
 
   readonly audioUpstreamMetricMap: {
@@ -353,6 +356,10 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
       media: MediaType.AUDIO,
       dir: Direction.DOWNSTREAM,
     },
+
+    // new getStats() API
+    availableIncomingBitrate: { source: 'availableIncomingBitrate' },
+    availableOutgoingBitrate: { source: 'availableOutgoingBitrate' },
   };
 
   getObservableMetricValue(metricName: string): number {

--- a/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts
+++ b/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts
@@ -91,7 +91,6 @@ export default class SignalingAndMetricsConnectionMonitor
     const availableRecvBandwidth = metricReport.availableReceiveBandwidth;
 
     const audioSpeakerDelayMs = metricReport.audioSpeakerDelayMs;
-
     // firefox doesn't have aggregated bandwidth estimation for now.
     if (typeof availableSendBandwidth === 'number' && !isNaN(availableSendBandwidth)) {
       this.updateAvailableSendBandwidth(availableSendBandwidth / 1000);

--- a/test/clientmetricreport/DefaultClientMetricReport.test.ts
+++ b/test/clientmetricreport/DefaultClientMetricReport.test.ts
@@ -63,7 +63,7 @@ describe('DefaultClientMetricReport', () => {
       expect(clientMetricReport.decoderLossPercent(metricName)).to.equal(0);
     });
 
-    it('returns the loss perecent', () => {
+    it('returns the loss percent', () => {
       const report = new GlobalMetricReport();
       report.currentMetrics['googDecodingNormal'] = 1;
       report.currentMetrics['googDecodingCTN'] = 2;
@@ -71,7 +71,7 @@ describe('DefaultClientMetricReport', () => {
       expect(clientMetricReport.decoderLossPercent(metricName)).to.equal((1 * 100) / 2);
     });
 
-    it('returns the loss perecent from the stream metric reports', () => {
+    it('returns the loss percent from the stream metric reports', () => {
       const ssrc = 1;
       const report = new StreamMetricReport();
       report.currentMetrics['googDecodingNormal'] = 1;
@@ -100,7 +100,7 @@ describe('DefaultClientMetricReport', () => {
       expect(clientMetricReport.packetLossPercent(metricName)).to.equal(0);
     });
 
-    it('returns the loss perecent', () => {
+    it('returns the loss percent', () => {
       const report = new GlobalMetricReport();
       report.currentMetrics[metricName] = 10;
       report.currentMetrics['packetsLost'] = 5;
@@ -108,7 +108,7 @@ describe('DefaultClientMetricReport', () => {
       expect(clientMetricReport.packetLossPercent(metricName)).to.equal((5 * 100) / 15);
     });
 
-    it('returns the loss perecent from the stream metric reports', () => {
+    it('returns the loss percent from the stream metric reports', () => {
       const ssrc = 1;
       const report = new StreamMetricReport();
       report.currentMetrics[metricName] = 10;
@@ -334,7 +334,7 @@ describe('DefaultClientMetricReport', () => {
   describe('getObservableMetrics', () => {
     it('returns the observable metrics as a JS object', () => {
       const metrics = clientMetricReport.getObservableMetrics();
-      expect(Object.keys(metrics).length).to.equal(8);
+      expect(Object.keys(metrics).length).to.equal(10);
     });
   });
 


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Expose bitrate estimation metrics from Standard getStats() API call 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
