### PR TITLE
Improve reconnect callback fidelity

### DIFF
--- a/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
+++ b/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
@@ -65,10 +65,12 @@ export default class ReconnectingPromisedWebSocket implements PromisedWebSocket 
         this.dispatchEvent(event);
       });
 
-      this.webSocket.open(timeoutMs).then((event: Event) => {
+      this.webSocket.addEventListener('open', (event: Event) => {
         this.didOpenWebSocket();
-        resolve(event);
+        this.dispatchEvent(event);
       });
+
+      return this.webSocket.open(timeoutMs).then(event => resolve(event));
     });
   }
 

--- a/src/screenviewing/session/DefaultScreenViewingSession.ts
+++ b/src/screenviewing/session/DefaultScreenViewingSession.ts
@@ -38,11 +38,15 @@ export default class DefaultScreenViewingSession implements ScreenViewingSession
     );
 
     this.webSocket.addEventListener('message', (event: MessageEvent) => {
-      Maybe.of(this.observer.didReceiveWebSocketMessage).map(f => f.bind(this.observer)(event));
+      Maybe.of(this.observer).map(observer => {
+        Maybe.of(observer.didReceiveWebSocketMessage).map(f => f.bind(this.observer)(event));
+      });
     });
 
     this.webSocket.addEventListener('close', (event: CloseEvent) => {
-      Maybe.of(this.observer.didCloseWebSocket).map(f => f.bind(this.observer)(event));
+      Maybe.of(this.observer).map(observer => {
+        Maybe.of(observer.didCloseWebSocket).map(f => f.bind(this.observer)(event));
+      });
     });
 
     return this.webSocket.open(request.timeoutMs);

--- a/test/promisedwebsocket/ReconnectingPromisedWebSocket.test.ts
+++ b/test/promisedwebsocket/ReconnectingPromisedWebSocket.test.ts
@@ -36,6 +36,26 @@ describe('ReconnectingPromisedWebSocket', () => {
   });
 
   describe('#open', () => {
+    describe('with error', () => {
+      it('is rejected', (done: Mocha.Done) => {
+        const webSocket = {
+          ...Substitute.for<PromisedWebSocket>(),
+          open(_timeoutMs: number): Promise<Event> {
+            throw new Error();
+          },
+        };
+        const webSocketFactory = Substitute.for<PromisedWebSocketFactory>();
+        const subject = new ReconnectingPromisedWebSocket(
+          url,
+          protocols,
+          binaryType,
+          webSocketFactory,
+          backoff
+        );
+        webSocketFactory.create(Arg.all()).returns(webSocket);
+        chai.expect(subject.open(timeoutMs)).to.eventually.be.rejected.and.notify(done);
+      });
+    });
     describe('without open', () => {
       it('is fulfilled', (done: Mocha.Done) => {
         const webSocketFactory = Substitute.for<PromisedWebSocketFactory>();

--- a/test/promisedwebsocketmock/PromisedWebSocketMock.ts
+++ b/test/promisedwebsocketmock/PromisedWebSocketMock.ts
@@ -14,11 +14,17 @@ export default class PromisedWebSocketMock implements PromisedWebSocket {
   }
 
   open(_timeoutMs: number): Promise<Event> {
-    return Promise.resolve(Substitute.for<Event>());
+    const event = Substitute.for<Event>();
+    event.type.returns('open');
+    this.dispatchEvent(event);
+    return Promise.resolve(event);
   }
 
   close(_timeoutMs: number): Promise<Event> {
-    return Promise.resolve(Substitute.for<CloseEvent>());
+    const event = Substitute.for<CloseEvent>();
+    event.type.returns('close');
+    this.dispatchEvent(event);
+    return Promise.resolve(event);
   }
 
   send(_data: string | ArrayBufferLike | Blob | ArrayBufferView): Promise<void> {

--- a/test/screensharingsession/DefaultScreenSharingSession.test.ts
+++ b/test/screensharingsession/DefaultScreenSharingSession.test.ts
@@ -39,7 +39,7 @@ describe('DefaultScreenSharingSession', function() {
   describe('#open', () => {
     describe('with open', () => {
       it('is fulfilled', (done: Mocha.Done) => {
-        const promisedWebSocket = Substitute.for<PromisedWebSocket>();
+        const promisedWebSocket = new PromisedWebSocketMock();
         const subject = new DefaultScreenSharingSession(
           promisedWebSocket,
           constraintsProvider,
@@ -50,17 +50,12 @@ describe('DefaultScreenSharingSession', function() {
           mediaRecordingFactory,
           logging
         );
-        const event = Substitute.for<Event>();
-        event.type.returns('open');
-        promisedWebSocket.open(Arg.any()).returns(Promise.resolve(event));
-        promisedWebSocket.url.returns('');
         subject.open(1000).should.eventually.be.fulfilled.and.notify(done);
-        promisedWebSocket.dispatchEvent(event);
       });
     });
 
-    it('nofifies', (done: Mocha.Done) => {
-      const promisedWebSocket = Substitute.for<PromisedWebSocket>();
+    it('notifies', (done: Mocha.Done) => {
+      const promisedWebSocket = new PromisedWebSocketMock();
       const subject = new DefaultScreenSharingSession(
         promisedWebSocket,
         constraintsProvider,
@@ -71,15 +66,11 @@ describe('DefaultScreenSharingSession', function() {
         mediaRecordingFactory,
         logging
       );
-      const event = Substitute.for<Event>();
       const observer: ScreenSharingSessionObserver = {
-        didOpen(event: Event): void {
-          chai.expect(event).to.eq(event);
+        didOpen(_event: Event): void {
           done();
         },
       };
-      promisedWebSocket.open(Arg.any()).returns(Promise.resolve(event));
-      promisedWebSocket.url.returns('');
       subject.registerObserver(observer);
       subject.open(1000).should.eventually.be.fulfilled;
     });


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Improves callback fidelity in reconnect scenarios:

- ensure open event is dispatched when a websocket reconnects
- ensure close event is dispatched if reconnect eventually fails

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
