### PR TITLE
Ignore error on courtesy stop()

### DIFF
--- a/src/screenviewing/DefaultScreenViewing.ts
+++ b/src/screenviewing/DefaultScreenViewing.ts
@@ -29,7 +29,11 @@ export default class DefaultScreenViewing implements ScreenViewing {
    * Stops screen viewing and closes the screen signaling connection
    */
   close(): Promise<void> {
-    return this.stop().then(() => this.componentContext.signalingSession.close());
+    return this.stop()
+      .catch(() => {})
+      .finally(() => {
+        return this.componentContext.signalingSession.close();
+      });
   }
 
   /**

--- a/test/screenviewing/DefaultScreenViewing.test.ts
+++ b/test/screenviewing/DefaultScreenViewing.test.ts
@@ -29,6 +29,30 @@ describe('DefaultScreenViewing', () => {
   });
 
   describe('close', () => {
+    describe('with error', () => {
+      it('is closed', () => {
+        return new DefaultScreenViewing({
+          ...Substitute.for(),
+          viewer: {
+            ...Substitute.for(),
+            stop(): void {},
+          },
+          signalingSession: {
+            ...Substitute.for(),
+            close(): Promise<void> {
+              return Promise.resolve();
+            },
+          },
+          viewingSession: {
+            ...Substitute.for(),
+            closeConnection(): Promise<void> {
+              return Promise.reject(new Error('bummers'));
+            },
+          },
+        }).close();
+      });
+    });
+
     it('calls viewer close', () => {
       return new DefaultScreenViewing({
         ...Substitute.for(),


### PR DESCRIPTION
- This raises an error if the viewer was not previously started; ignore
  such errors on courtesy-stop

*Issue #:* 

*Description of changes*

The courtesy `stop()` on `close()` can raise an error if the viewer was not previously started.  Ignore such errors from `stop()` when closing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
