### PR TITLE
Fix Safari ICE failure issue by set bundle policy to max-bundle

### DIFF
--- a/src/browserbehavior/BrowserBehavior.ts
+++ b/src/browserbehavior/BrowserBehavior.ts
@@ -45,4 +45,9 @@ export default interface BrowserBehavior {
    * returns true if detected browser requires promise-based WebRTC getStats API
    */
   requiresPromiseBasedWebRTCGetStats(): boolean;
+
+  /**
+   * returns bundle policy for each browser, only max-bundle for Safari now
+   */
+  requiresBundlePolicy(): RTCBundlePolicy;
 }

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -50,6 +50,14 @@ export default class DefaultBrowserBehavior {
     return this.isSafari();
   }
 
+  requiresBundlePolicy(): RTCBundlePolicy {
+    if (this.isSafari()) {
+      return 'max-bundle';
+    } else {
+      return 'balanced';
+    }
+  }
+
   requiresPromiseBasedWebRTCGetStats(): boolean {
     return this.isSafari() || this.isFirefox();
   }

--- a/src/task/CreatePeerConnectionTask.ts
+++ b/src/task/CreatePeerConnectionTask.ts
@@ -49,6 +49,7 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
       ],
       iceTransportPolicy: 'relay',
     };
+    configuration.bundlePolicy = this.context.browserBehavior.requiresBundlePolicy();
     // @ts-ignore
     configuration.sdpSemantics = this.context.browserBehavior.requiresUnifiedPlan()
       ? 'unified-plan'

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -40,6 +40,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().name()).to.eq('firefox');
       expect(new DefaultBrowserBehavior().isSupported()).to.eq(true);
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(68);
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('balanced');
     });
 
     it('can detect Chrome', () => {
@@ -47,6 +48,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().name()).to.eq('chrome');
       expect(new DefaultBrowserBehavior().isSupported()).to.eq(true);
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(78);
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('balanced');
     });
 
     it('can detect Edge Chromium', () => {
@@ -54,6 +56,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().name()).to.eq('edge-chromium');
       expect(new DefaultBrowserBehavior().isSupported()).to.eq(true);
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(79);
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('balanced');
     });
 
     it('can detect Safari', () => {
@@ -61,6 +64,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().name()).to.eq('safari');
       expect(new DefaultBrowserBehavior().isSupported()).to.eq(false);
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(13);
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
     });
 
     it('can handle an unknown user agent', () => {

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -93,6 +93,7 @@ describe('CreatePeerConnectionTask', () => {
         expect(configuration.iceServers[0].credential).to.equal(credentials.password);
         expect(configuration.iceServers[0].credentialType).to.equal('password');
         expect(configuration.iceTransportPolicy).to.equal('relay');
+        expect(configuration.bundlePolicy).to.equal(context.browserBehavior.requiresBundlePolicy());
         done();
       });
     });


### PR DESCRIPTION
*Issue #: 425* 

*Description of changes*
Set Safari bundle policy to "max-bundle".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
