### PR TITLE
Release chosen video stream on stopVideoPreview

### DIFF
--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.596.0",
+    "aws-sdk": "^2.597.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -144,6 +144,9 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
       this.releaseMediaStream(stream);
       DefaultVideoTile.disconnectVideoStreamFromVideoElement(element);
     }
+    if (this.activeDevices['video']) {
+      this.releaseMediaStream(this.activeDevices['video'].stream);
+    }
     this.trace('stopVideoPreviewForVideoInput', element.id);
   }
 


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

`startVideoPreviewForVideoInput` expect the precedented call of `chooseVideoInputDevice`.
The `chooseVideoInputDevide` may acquire a `MediaStream`. `stopVideoPreview` should release the stream as well to stop camera LED indicator.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
