### PR TITLE
Fix ios safari detection

### DIFF
--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -19,7 +19,7 @@ export default class DefaultBrowserBehavior {
   }
 
   isSafari(): boolean {
-    return this.browser.name === 'safari';
+    return this.browser.name === 'safari' || this.browser.name === 'ios';
   }
 
   isChrome(): boolean {
@@ -59,7 +59,7 @@ export default class DefaultBrowserBehavior {
   }
 
   requiresPromiseBasedWebRTCGetStats(): boolean {
-    return this.isSafari() || this.isFirefox();
+    return !this.isChrome();
   }
 
   isSupported(): boolean {


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

ios Safari is detected as 'ios'. Given that callback based getStats is getting deprecated, make the default as Promise based getStats and let only Chrome uses it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
