### PR TITLE
Fix #60 - Set device to null when active device unplugged

### DIFF
--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -497,6 +497,14 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
         newDevice.constraints = proposedConstraints;
       } else {
         newDevice = await this.getDeviceFromBrowser(proposedConstraints);
+        newDevice.stream.getTracks()[0].addEventListener('ended', () => {
+          if (this.activeDevices[kind].stream === newDevice.stream) {
+            this.logger.warn(
+              `${kind} input device which was active is no longer available, resetting to null device`
+            );
+            this.chooseInputDevice(kind, null, false);
+          }
+        });
       }
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
*Issue #:* #60 

*Description of changes*

Set device to null when active device unplugged. It is the consuming application's responsibility to monitor device changes and react accordingly with UI to prompt the user about selecting a new device. However, this fix prevents the app from getting into a bad state in the interim. It is possible the user may never select a new device, so the meeting should continue to function with other active inputs and outputs.

Tested by unplugging an active USB mic to see that the warning is generated and the meeting continues to function. When plugging back in the device, it is then possible to reselect it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
