### PR TITLE
Fix #62 - Use async scheduler for video tile disconnect

### DIFF
--- a/src/videotile/DefaultVideoTile.ts
+++ b/src/videotile/DefaultVideoTile.ts
@@ -3,6 +3,7 @@
 
 import DevicePixelRatioMonitor from '../devicepixelratiomonitor/DevicePixelRatioMonitor';
 import DevicePixelRatioObserver from '../devicepixelratioobserver/DevicePixelRatioObserver';
+import AsyncScheduler from '../scheduler/AsyncScheduler';
 import VideoTileController from '../videotilecontroller/VideoTileController';
 import VideoTile from './VideoTile';
 import VideoTileState from './VideoTileState';
@@ -58,9 +59,9 @@ export default class DefaultVideoTile implements DevicePixelRatioObserver, Video
       mediaStream.removeTrack(track);
     }
 
-    // Need to wait one frame before clearing `srcObject` to
+    // Need to yield the message loop before clearing `srcObject` to
     // prevent Safari from crashing.
-    requestAnimationFrame(() => {
+    new AsyncScheduler().start(() => {
       videoElement.srcObject = null;
     });
   }


### PR DESCRIPTION
*Issue #:* #62

*Description of changes*

Use async scheduler for video tile disconnect

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
