### PR TITLE
Nullify screen viewing websocket before closing

### DIFF
--- a/src/screenviewing/session/DefaultScreenViewingSession.ts
+++ b/src/screenviewing/session/DefaultScreenViewingSession.ts
@@ -57,9 +57,9 @@ export default class DefaultScreenViewingSession implements ScreenViewingSession
     if (!this.webSocket) {
       return Promise.reject(new Error('No websocket to close'));
     }
-    return this.webSocket.close(DefaultScreenViewingSession.DEFAULT_TIMEOUT).then((): void => {
-      this.webSocket = null;
-    });
+    const webSocket = this.webSocket;
+    this.webSocket = null;
+    return webSocket.close(DefaultScreenViewingSession.DEFAULT_TIMEOUT).then(() => {});
   }
 
   send(data: Uint8Array): void {


### PR DESCRIPTION
*Issue #:* resolves 446

*Description of changes*
This change ensures that the screen viewing websocket is nullified before calling the possibly failing `close`, cleaning up state for a following `open`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
