### PR TITLE
Fix ReconnectingPromisedWebSocket timeout handling

### DIFF
--- a/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
+++ b/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
@@ -26,13 +26,13 @@ export default class ReconnectingPromisedWebSocket implements PromisedWebSocket 
   ) {}
 
   close(timeoutMs: number, code?: number, reason?: string): Promise<Event> {
-    return new Promise((resolve, reject) => {
-      if (this.webSocket === null) {
-        reject(new Error('closed'));
-      }
-      this.willCloseWebSocket();
-      this.webSocket.close(timeoutMs, code, reason).then(resolve);
-    });
+    if (this.webSocket === null) {
+      return Promise.reject(new Error('closed'));
+    }
+    this.willCloseWebSocket();
+    const webSocket = this.webSocket;
+    this.webSocket = null;
+    return webSocket.close(timeoutMs, code, reason);
   }
 
   open(timeoutMs: number): Promise<Event> {

--- a/test/promisedwebsocket/ReconnectingPromisedWebSocket.test.ts
+++ b/test/promisedwebsocket/ReconnectingPromisedWebSocket.test.ts
@@ -91,6 +91,24 @@ describe('ReconnectingPromisedWebSocket', () => {
   });
 
   describe('#close', () => {
+    describe('with timeout', () => {
+      it('is rejected', (done: Mocha.Done) => {
+        const webSocketFactory = Substitute.for<PromisedWebSocketFactory>();
+        const subject = new ReconnectingPromisedWebSocket(
+          url,
+          protocols,
+          binaryType,
+          webSocketFactory,
+          backoff
+        );
+        const webSocket = new PromisedWebSocketMock(1000);
+        webSocketFactory.create(Arg.all()).returns(webSocket);
+        subject.open(100).then(() => {
+          chai.expect(subject.close(0)).to.eventually.be.rejected.and.notify(done);
+        });
+      });
+    });
+
     describe('without open', () => {
       it('is rejected', (done: Mocha.Done) => {
         const webSocketFactory = Substitute.for<PromisedWebSocketFactory>();


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

- Fix wrapper implementation that prevented catch() from working properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
