### PR TITLE
Handle error in screen viewing send echo response

### DIFF
--- a/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts
+++ b/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts
@@ -22,7 +22,12 @@ export default class DefaultScreenViewingMessageHandler implements ScreenViewing
   handleEchoRequest(dataView: DataView): void {
     this.logger.info('DefaultScreenViewingMessageHandler: Handling echo request message');
     dataView.setUint8(0, ScreenViewingPacketType.ECHO_RESPONSE);
-    this.client.send(new Uint8Array(dataView.buffer));
+    try {
+      this.client.send(new Uint8Array(dataView.buffer));
+    } catch (e) {
+      this.logger.warn('DefaultScreenViewingMessageHandler: Error sending echo response');
+      this.logger.warn(e);
+    }
   }
 
   handleSetup(dataView: DataView): void {

--- a/test/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.test.ts
+++ b/test/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.test.ts
@@ -66,6 +66,22 @@ describe('DefaultScreenViewingMessageHandler', () => {
         new NoOpLogger(LogLevel.DEBUG)
       ).handleEchoRequest(new DataView(data.buffer));
     });
+
+    it('send error does not bubble out', () => {
+      const data: Uint8Array = Uint8Array.of(0x04, ...dataTail);
+      new DefaultScreenViewingMessageHandler(
+        {
+          ...noOpScreenViewingSession,
+          send(_data: Uint8Array): Promise<void> {
+            throw new Error('send error');
+          },
+        },
+        noOpDeltaRenderer,
+        noOpDeltaSource,
+        noOpViewer,
+        new NoOpLogger(LogLevel.DEBUG)
+      ).handleEchoRequest(new DataView(data.buffer));
+    });
   });
 
   describe('handleSetup', () => {


### PR DESCRIPTION
*Issue #:* 

*Description of changes*
This change handles errors that happen in attempting to send an echo response message to the screen viewing service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
