### PR TITLE
Allow for subscribing to beginning and end of attendee and volume updates

### DIFF
--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -162,6 +162,20 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     this.trace('realtimeUnsubscribeToAttendeeIdPresence');
   }
 
+  realtimeSubscribeToUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void {
+    this.realtimeController.realtimeSubscribeToUpdateStates(callback);
+    this.trace('realtimeSubscribeToUpdateStates');
+  }
+
+  realtimeUnsubscribeFromUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void {
+    this.realtimeController.realtimeUnsubscribeFromUpdateStates(callback);
+    this.trace('realtimeUnsubscribeFromUpdateStates');
+  }
+
   realtimeSetCanUnmuteLocalAudio(canUnmute: boolean): void {
     this.realtimeController.realtimeSetCanUnmuteLocalAudio(canUnmute);
     this.trace('realtimeSetCanUnmuteLocalAudio', canUnmute);

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -87,6 +87,35 @@ export default class DefaultRealtimeController implements RealtimeController {
     });
   }
 
+  // Beginning and end of attendee/volume updates
+
+  realtimeSubscribeToUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void {
+    this.wrap(() => {
+      this.state.updateStateChangeCallbacks.push(callback);
+    });
+  }
+
+  realtimeUnsubscribeFromUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void {
+    this.wrap(() => {
+      const index = this.state.updateStateChangeCallbacks.indexOf(callback);
+      if (index !== -1) {
+        this.state.updateStateChangeCallbacks.splice(index, 1);
+      }
+    });
+  }
+
+  realtimeUpdateStateChange(state: 'startedUpdate' | 'stoppedUpdate'): void {
+    this.wrap(() => {
+      for (const fn of this.state.updateStateChangeCallbacks) {
+        fn(state);
+      }
+    });
+  }
+
   // Audio Input
 
   realtimeSetLocalAudioInput(audioInput: MediaStream | null): void {

--- a/src/realtimecontroller/RealtimeController.ts
+++ b/src/realtimecontroller/RealtimeController.ts
@@ -54,6 +54,29 @@ export default interface RealtimeController {
     callback: (attendeeId: string, present: boolean) => void
   ): void;
 
+  // Attendee/volume update begins and ends
+
+  /**
+   * Subscribes to beginnings and ends of updates for
+   * attendee presence or volume indicator changes.
+   */
+  realtimeSubscribeToUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void;
+
+  /**
+   * Unsubscribes to beginnings and ends of updates for
+   * attendee presence or volume indicator changes.
+   */
+  realtimeUnsubscribeFromUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void;
+
+  /**
+   * Updates the beginning or end of attendee id and volume indicator updates
+   */
+  realtimeUpdateStateChange(state: 'startedUpdate' | 'stoppedUpdate'): void;
+
   // Audio Input
 
   /**

--- a/src/realtimecontroller/RealtimeControllerFacade.ts
+++ b/src/realtimecontroller/RealtimeControllerFacade.ts
@@ -8,6 +8,12 @@ export default interface RealtimeControllerFacade {
   realtimeUnsubscribeToAttendeeIdPresence(
     callback: (attendeeId: string, present: boolean) => void
   ): void;
+  realtimeSubscribeToUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void;
+  realtimeUnsubscribeFromUpdateStates(
+    callback: (state: 'startedUpdate' | 'stoppedUpdate') => void
+  ): void;
   realtimeSetCanUnmuteLocalAudio(canUnmute: boolean): void;
   realtimeSubscribeToSetCanUnmuteLocalAudio(callback: (canUnmute: boolean) => void): void;
   realtimeUnsubscribeToSetCanUnmuteLocalAudio(callback: (canUnmute: boolean) => void): void;

--- a/src/realtimecontroller/RealtimeState.ts
+++ b/src/realtimecontroller/RealtimeState.ts
@@ -60,6 +60,11 @@ export default class RealtimeState {
   } = {};
 
   /**
+   * Stores callbacks to be called when the state of updates changes
+   */
+  updateStateChangeCallbacks: ((state: 'startedUpdate' | 'stoppedUpdate') => void)[] = [];
+
+  /**
    * Callbacks to listen for changes to local signal strength
    */
   localSignalStrengthChangeCallbacks: ((signalStrength: number) => void)[] = [];

--- a/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
+++ b/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
@@ -25,6 +25,7 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
   ) {}
 
   sendRealtimeUpdatesForAudioStreamIdInfo(info: SdkAudioStreamIdInfoFrame): void {
+    this.realtimeController.realtimeUpdateStateChange('startedUpdate');
     for (const stream of info.streams) {
       const hasAttendeeId = !!stream.attendeeId;
       const hasMuted = stream.hasOwnProperty('muted');
@@ -43,6 +44,7 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
         this.realtimeController.realtimeSetAttendeeIdPresence(attendeeId, false);
       }
     }
+    this.realtimeController.realtimeUpdateStateChange('stoppedUpdate');
   }
 
   sendRealtimeUpdatesForAudioMetadata(metadata: SdkAudioMetadataFrame): void {

--- a/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
+++ b/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
@@ -217,6 +217,20 @@ describe('DefaultAudioVideoFacade', () => {
       assert(spy.calledOnceWith(arg1));
     });
 
+    it('will call realtimeSubscribeToUpdateStates', () => {
+      const spy = sinon.spy(controller.realtimeController, 'realtimeSubscribeToUpdateStates');
+      const arg1 = (_state: 'startedUpdate' | 'stoppedUpdate'): void => {};
+      facade.realtimeSubscribeToUpdateStates(arg1);
+      assert(spy.calledOnceWith(arg1));
+    });
+
+    it('will call realtimeUnsubscribeFromUpdateStates', () => {
+      const spy = sinon.spy(controller.realtimeController, 'realtimeUnsubscribeFromUpdateStates');
+      const arg1 = (_state: 'startedUpdate' | 'stoppedUpdate'): void => {};
+      facade.realtimeUnsubscribeFromUpdateStates(arg1);
+      assert(spy.calledOnceWith(arg1));
+    });
+
     it('will call realtimeSetCanUnmuteLocalAudio', () => {
       const spy = sinon.spy(controller.realtimeController, 'realtimeSetCanUnmuteLocalAudio');
       const arg1 = false;

--- a/test/realtimecontroller/DefaultRealtimeController.test.ts
+++ b/test/realtimecontroller/DefaultRealtimeController.test.ts
@@ -360,7 +360,7 @@ describe('DefaultRealtimeController', () => {
   });
 
   describe('volume indicators', () => {
-    it('will send volume indicator callbacks to subscribers', () => {
+    it('will send volume indicator callbacks to subscribers and update state change callbacks', () => {
       const rt: RealtimeController = new DefaultRealtimeController();
       const sentAttendeeId = 'foo-attendee';
       const sentVolume = 0.5;
@@ -783,23 +783,16 @@ describe('DefaultRealtimeController', () => {
   describe('attendee ids', () => {
     it('will send attendee id change callbacks', () => {
       const rt: RealtimeController = new DefaultRealtimeController();
-      let callbackIndex = 0;
+      let callBackPresence = false;
       const fooAttendee = 'foo-attendee';
       rt.realtimeSubscribeToAttendeeIdPresence((attendeeId: string, present: boolean) => {
-        if (callbackIndex === 0) {
-          expect(attendeeId).to.equal(fooAttendee);
-          expect(present).to.be.true;
-        } else if (callbackIndex === 1) {
-          expect(attendeeId).to.equal(fooAttendee);
-          expect(present).to.be.false;
-        }
-        callbackIndex += 1;
+        expect(attendeeId).to.equal(fooAttendee);
+        expect(present).to.equal(callBackPresence);
       });
-      expect(callbackIndex).to.equal(0);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, true);
-      expect(callbackIndex).to.equal(1);
+      callBackPresence = true;
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, callBackPresence);
+      callBackPresence = false;
       rt.realtimeSetAttendeeIdPresence(fooAttendee, false);
-      expect(callbackIndex).to.equal(2);
     });
   });
 
@@ -843,7 +836,7 @@ describe('DefaultRealtimeController', () => {
       rt.realtimeSubscribeToLocalSignalStrengthChange(LocalSignalStrengthChangeCallback);
       rt.realtimeSubscribeToFatalError(fatalErrorCallback);
 
-      // attempt to trigger a fake error after unsubscribing to fatal errors
+      // Attempt to trigger a fake error after unsubscribing to fatal errors
       rt.realtimeUnsubscribeToFatalError(fatalErrorCallback);
       rt.realtimeSetAttendeeIdPresence('unused', true);
       expect(fatalErrorCallbackRemoved).to.be.true;

--- a/test/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.test.ts
+++ b/test/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.test.ts
@@ -112,6 +112,35 @@ describe('DefaultVolumeIndicatorAdapter', () => {
     });
   });
 
+  it('Sends frame beginning and end updates', () => {
+    let state = '';
+    const rt: RealtimeController = new DefaultRealtimeController();
+    const vi: VolumeIndicatorAdapter = new DefaultVolumeIndicatorAdapter(
+      new NoOpLogger(),
+      rt,
+      minVolumeDecibels,
+      maxVolumeDecibels
+    );
+    let updateState = (currentState: 'startedUpdate' | 'stoppedUpdate'): void => {
+      state = currentState;
+    };
+    rt.realtimeSubscribeToUpdateStates(updateState);
+    rt.realtimeSubscribeToAttendeeIdPresence((_attendeeId: string, _present: boolean) => {
+      expect(state).to.equal('startedUpdate');
+    });
+    const streamInfo = SdkAudioStreamIdInfo.create();
+    const streamInfoFrame = SdkAudioStreamIdInfoFrame.create();
+    streamInfo.audioStreamId = 1;
+    streamInfo.attendeeId = fooAttendee;
+    streamInfoFrame.streams = [streamInfo];
+    vi.sendRealtimeUpdatesForAudioStreamIdInfo(streamInfoFrame);
+    expect(state).to.equal('stoppedUpdate');
+    state = '';
+    rt.realtimeUnsubscribeFromUpdateStates(updateState);
+    vi.sendRealtimeUpdatesForAudioStreamIdInfo(streamInfoFrame);
+    expect(state).to.equal('');
+  });
+
   describe('metadata frame', () => {
     it('sends volume updates when volume changes', () => {
       const streamInfo = SdkAudioStreamIdInfo.create();


### PR DESCRIPTION
*Issue #:* #71

*Description of changes*
Allow for subscribing to beginning and end of attendee and volume updates.
Verified callbacks are called by looking at console logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
