### PR TITLE
Add cleanup code for failed open

### DIFF
--- a/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
+++ b/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts
@@ -74,7 +74,10 @@ export default class ReconnectingPromisedWebSocket implements PromisedWebSocket 
       this.dispatchEvent(event);
     });
 
-    return this.webSocket.open(timeoutMs);
+    return this.webSocket.open(timeoutMs).catch(error => {
+      this.webSocket = null;
+      throw error;
+    });
   }
 
   send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {

--- a/src/screensharingsession/DefaultScreenSharingSession.ts
+++ b/src/screensharingsession/DefaultScreenSharingSession.ts
@@ -1,9 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
 import Logger from '../logger/Logger';
 import Maybe from '../maybe/Maybe';
-import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
 import MediaRecording from '../mediarecording/MediaRecording';
 import MediaRecordingFactory from '../mediarecording/MediaRecordingFactory';
 import MediaStreamBroker from '../mediastreambroker/MediaStreamBroker';

--- a/test/screensharingsession/DefaultScreenSharingSession.test.ts
+++ b/test/screensharingsession/DefaultScreenSharingSession.test.ts
@@ -5,13 +5,13 @@ import { Arg, Substitute } from '@fluffy-spoon/substitute';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
+import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
 import DOMWebSocket from '../../src/domwebsocket/DOMWebSocket';
 import LogLevel from '../../src/logger/LogLevel';
 import NoOpLogger from '../../src/logger/NoOpLogger';
 import Maybe from '../../src/maybe/Maybe';
 import MediaRecordingFactory from '../../src/mediarecording/MediaRecordingFactory';
 import MediaStreamBroker from '../../src/mediastreambroker/MediaStreamBroker';
-import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
 import DefaultPromisedWebSocket from '../../src/promisedwebsocket/DefaultPromisedWebSocket';
 import PromisedWebSocket from '../../src/promisedwebsocket/PromisedWebSocket';
 import ScreenShareStreaming from '../../src/screensharestreaming/ScreenShareStreaming';


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Adding cleanup routine for failed `open()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
