### PR TITLE
Pass VideoSubscribeContext to update in AudioVideoController

### DIFF
--- a/src/audiovideocontroller/AudioVideoController.ts
+++ b/src/audiovideocontroller/AudioVideoController.ts
@@ -12,6 +12,7 @@ import MediaStreamBroker from '../mediastreambroker/MediaStreamBroker';
 import MeetingSessionConfiguration from '../meetingsession/MeetingSessionConfiguration';
 import MeetingSessionStatus from '../meetingsession/MeetingSessionStatus';
 import RealtimeController from '../realtimecontroller/RealtimeController';
+import VideoSubscribeContext from '../videosubscribecontext/VideoSubscribeContext';
 import VideoTileController from '../videotilecontroller/VideoTileController';
 
 /**
@@ -27,7 +28,7 @@ export default interface AudioVideoController extends AudioVideoControllerFacade
   /**
    * Updates the peer connection when video tiles have changed.
    */
-  update(): boolean;
+  update(videoSubscribeContext: VideoSubscribeContext): boolean;
 
   /**
    * Restarts the local video device. The callback is called when the device

--- a/src/audiovideocontroller/AudioVideoControllerState.ts
+++ b/src/audiovideocontroller/AudioVideoControllerState.ts
@@ -21,8 +21,7 @@ import StatsCollector from '../statscollector/StatsCollector';
 import TransceiverController from '../transceivercontroller/TransceiverController';
 import VideoCaptureAndEncodeParameter from '../videocaptureandencodeparameter/VideoCaptureAndEncodeParameter';
 import VideoDownlinkBandwidthPolicy from '../videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy';
-import VideoStreamIdSet from '../videostreamidset/VideoStreamIdSet';
-import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
+import VideoSubscribeContext from '../videosubscribecontext/VideoSubscribeContext';
 import VideoTileController from '../videotilecontroller/VideoTileController';
 import VideoUplinkBandwidthPolicy from '../videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy';
 import VolumeIndicatorAdapter from '../volumeindicatoradapter/VolumeIndicatorAdapter';
@@ -77,8 +76,6 @@ export default class AudioVideoControllerState {
 
   removableObservers: RemovableObserver[] = [];
 
-  videoStreamIndex: VideoStreamIndex | null = null;
-
   videoDownlinkBandwidthPolicy: VideoDownlinkBandwidthPolicy | null = null;
 
   videoUplinkBandwidthPolicy: VideoUplinkBandwidthPolicy | null = null;
@@ -91,11 +88,9 @@ export default class AudioVideoControllerState {
 
   videoCaptureAndEncodeParameter: VideoCaptureAndEncodeParameter | null = null;
 
-  videosToReceive: VideoStreamIdSet | null = null;
+  videoSubscribeContext: VideoSubscribeContext;
 
-  videoSubscriptions: number[] | null = null;
-
-  videosPaused: VideoStreamIdSet | null = null;
+  nextVideoSubscribeContext: VideoSubscribeContext;
 
   videoDuplexMode: SdkStreamServiceType | null = null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import DefaultTransceiverController from './transceivercontroller/DefaultTransce
 import DefaultVideoCaptureAndEncodeParameter from './videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter';
 import DefaultVideoStreamIdSet from './videostreamidset/DefaultVideoStreamIdSet';
 import DefaultVideoStreamIndex from './videostreamindex/DefaultVideoStreamIndex';
+import DefaultVideoSubscribeContext from './videosubscribecontext/DefaultVideoSubscribeContext';
 import DefaultVideoTile from './videotile/DefaultVideoTile';
 import DefaultVideoTileController from './videotilecontroller/DefaultVideoTileController';
 import DefaultVideoTileFactory from './videotilefactory/DefaultVideoTileFactory';
@@ -261,6 +262,7 @@ import VideoElementFactory from './videoelementfactory/VideoElementFactory';
 import VideoLogEvent from './statscollector/VideoLogEvent';
 import VideoStreamIdSet from './videostreamidset/VideoStreamIdSet';
 import VideoStreamIndex from './videostreamindex/VideoStreamIndex';
+import VideoSubscribeContext from './videosubscribecontext/VideoSubscribeContext';
 import VideoTile from './videotile/VideoTile';
 import VideoTileController from './videotilecontroller/VideoTileController';
 import VideoTileControllerFacade from './videotilecontroller/VideoTileControllerFacade';
@@ -352,6 +354,7 @@ export {
   DefaultVideoCaptureAndEncodeParameter,
   DefaultVideoStreamIdSet,
   DefaultVideoStreamIndex,
+  DefaultVideoSubscribeContext,
   DefaultVideoTile,
   DefaultVideoTileController,
   DefaultVideoTileFactory,
@@ -537,6 +540,7 @@ export {
   VideoLogEvent,
   VideoStreamIdSet,
   VideoStreamIndex,
+  VideoSubscribeContext,
   VideoTile,
   VideoTileController,
   VideoTileControllerFacade,

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -1,12 +1,11 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
 import ClientMetricReport from '../clientmetricreport/ClientMetricReport';
 import MeetingSessionLifecycleEvent from '../meetingsession/MeetingSessionLifecycleEvent';
 import MeetingSessionLifecycleEventCondition from '../meetingsession/MeetingSessionLifecycleEventCondition';
 import MeetingSessionStatus from '../meetingsession/MeetingSessionStatus';
-import SignalingClient from '../signalingclient/SignalingClient';
-import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
 import AudioLogEvent from './AudioLogEvent';
 import VideoLogEvent from './VideoLogEvent';
 
@@ -18,8 +17,7 @@ export default interface StatsCollector {
    * Starts collecting statistics.
    */
   start(
-    signalingClient: SignalingClient,
-    videoStreamIndex: VideoStreamIndex,
+    meetingSessionContext: AudioVideoControllerState,
     clientMetricReport?: ClientMetricReport
   ): boolean;
 

--- a/src/task/AttachMediaInputTask.ts
+++ b/src/task/AttachMediaInputTask.ts
@@ -3,6 +3,7 @@
 
 import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
 import VideoLogEvent from '../statscollector/VideoLogEvent';
+import DefaultVideoStreamIndex from '../videostreamindex/DefaultVideoStreamIndex';
 import BaseTask from './BaseTask';
 
 /*
@@ -92,9 +93,14 @@ export default class AttachMediaInputTask extends BaseTask {
       }
     }
 
-    this.context.videoSubscriptions = transceiverController.updateVideoTransceivers(
-      this.context.videoStreamIndex,
-      this.context.videosToReceive
+    const currentVideoStreamIndex =
+      this.context.videoSubscribeContext.videoStreamIndex() ||
+      new DefaultVideoStreamIndex(this.context.logger);
+    const currentVideosToReceive = this.context.videoSubscribeContext.videosToReceive();
+    const videoSubscriptions = transceiverController.updateVideoTransceivers(
+      currentVideoStreamIndex,
+      currentVideosToReceive
     );
+    this.context.videoSubscribeContext.updateVideoSubscriptions(videoSubscriptions);
   }
 }

--- a/src/task/CleanStoppedSessionTask.ts
+++ b/src/task/CleanStoppedSessionTask.ts
@@ -7,6 +7,7 @@ import SignalingClientEvent from '../signalingclient/SignalingClientEvent';
 import SignalingClientEventType from '../signalingclient/SignalingClientEventType';
 import SignalingClientObserver from '../signalingclientobserver/SignalingClientObserver';
 import TaskCanceler from '../taskcanceler/TaskCanceler';
+import DefaultVideoSubscribeContext from '../videosubscribecontext/DefaultVideoSubscribeContext';
 import BaseTask from './BaseTask';
 
 export default class CleanStoppedSessionTask extends BaseTask {
@@ -53,7 +54,7 @@ export default class CleanStoppedSessionTask extends BaseTask {
       this.context.iceCandidateHandler = null;
       this.context.iceCandidates = [];
       this.context.turnCredentials = null;
-      this.context.videoSubscriptions = null;
+      this.context.videoSubscribeContext = new DefaultVideoSubscribeContext();
       this.context.transceiverController.reset();
       this.context.mediaStreamBroker.releaseMediaStream(this.context.activeAudioInput);
       this.context.activeAudioInput = null;

--- a/src/task/CreatePeerConnectionTask.ts
+++ b/src/task/CreatePeerConnectionTask.ts
@@ -109,7 +109,9 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
       stream = new MediaStream([track]);
       trackId = track.id;
     }
-    const attendeeId = this.context.videoStreamIndex.attendeeIdForTrack(trackId);
+    const attendeeId = this.context.videoSubscribeContext
+      .videoStreamIndexRef()
+      .attendeeIdForTrack(trackId);
 
     // TODO: in case a previous tile with the same attendee id hasn't been cleaned up
     // we do it here to avoid showing a duplicate tile. We should try to understand
@@ -122,7 +124,9 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     }
 
     const tile = this.context.videoTileController.addVideoTile();
-    let streamId: number | null = this.context.videoStreamIndex.streamIdForTrack(trackId);
+    let streamId:
+      | number
+      | null = this.context.videoSubscribeContext.videoStreamIndexRef().streamIdForTrack(trackId);
     if (typeof streamId === 'undefined') {
       this.logger.warn(`stream not found for tile=${tile.id()} track=${trackId}`);
       streamId = null;
@@ -196,7 +200,7 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     );
 
     if (tileState.streamId) {
-      this.context.videosPaused.remove(tileState.streamId);
+      this.context.videoSubscribeContext.videosPausedSetRef().remove(tileState.streamId);
     } else {
       this.logger.warn(`no stream found for tile=${tileState.tileId}`);
     }

--- a/src/task/CreateSDPTask.ts
+++ b/src/task/CreateSDPTask.ts
@@ -28,7 +28,9 @@ export default class CreateSDPTask extends BaseTask {
   sessionUsesVideo(): boolean {
     const enabled = true;
     const sending = this.context.videoTileController.hasStartedLocalVideoTile();
-    const receiving = !!this.context.videosToReceive && !this.context.videosToReceive.empty();
+    const receiving =
+      !!this.context.videoSubscribeContext &&
+      this.context.videoSubscribeContext.wantsReceiveVideo();
     const usesVideo = enabled && (sending || receiving);
     this.context.logger.info(
       `uses video: ${usesVideo} (enabled: ${enabled}, sending: ${sending}, receiving: ${receiving})`

--- a/src/task/MonitorTask.ts
+++ b/src/task/MonitorTask.ts
@@ -68,7 +68,7 @@ export default class MonitorTask extends BaseTask
     );
 
     this.context.connectionMonitor.start();
-    this.context.statsCollector.start(this.context.signalingClient, this.context.videoStreamIndex);
+    this.context.statsCollector.start(this.context);
     this.context.signalingClient.registerObserver(this);
   }
 
@@ -117,11 +117,13 @@ export default class MonitorTask extends BaseTask
 
       const resubscribeForDownlink = this.context.videoDownlinkBandwidthPolicy.wantsResubscribe();
       if (resubscribeForDownlink) {
-        this.context.videosToReceive = this.context.videoDownlinkBandwidthPolicy.chooseSubscriptions();
+        const videosToReceive = this.context.videoDownlinkBandwidthPolicy.chooseSubscriptions();
         this.logger.info(
-          `trigger resubscribe for down=${resubscribeForDownlink}; videosToReceive=[${this.context.videosToReceive.array()}]`
+          `trigger resubscribe for down=${resubscribeForDownlink}; videosToReceive=[${videosToReceive.array()}]`
         );
-        this.context.audioVideoController.update();
+        this.context.nextVideoSubscribeContext = this.context.videoSubscribeContext.clone();
+        this.context.nextVideoSubscribeContext.updateVideosToReceive(videosToReceive);
+        this.context.audioVideoController.update(this.context.nextVideoSubscribeContext);
       }
     }
   }

--- a/src/task/SetRemoteDescriptionTask.ts
+++ b/src/task/SetRemoteDescriptionTask.ts
@@ -42,7 +42,8 @@ export default class SetRemoteDescriptionTask extends BaseTask {
       // provide a video m-line when there are no videos available under Plan B,
       // thus we need to synthesize a video m-line by copying the one from the offer.
       this.logger.info('checking for no videos (plan-b)');
-      if (this.context.videosToReceive.empty() && this.context.peer.remoteDescription) {
+      const videosToReceive = this.context.videoSubscribeContext.videosToReceive();
+      if (videosToReceive.empty() && this.context.peer.remoteDescription) {
         this.logger.info('have no videos and have remote description (plan-b)');
         const sdpInactiveVideoOffer = this.context.peer.localDescription.sdp;
         const sdpInactiveVideoAnswer = sdp;

--- a/src/task/SubscribeAndReceiveSubscribeAckTask.ts
+++ b/src/task/SubscribeAndReceiveSubscribeAckTask.ts
@@ -63,7 +63,7 @@ export default class SubscribeAndReceiveSubscribeAckTask extends BaseTask {
       this.context.meetingSessionConfiguration.urls.audioHostURL,
       this.context.realtimeController.realtimeIsLocalAudioMuted(),
       false,
-      this.context.videoSubscriptions,
+      this.context.videoSubscribeContext.videoSubscriptions(),
       isSendingStreams,
       frameRate,
       maxEncodeBitrateKbps,
@@ -76,7 +76,12 @@ export default class SubscribeAndReceiveSubscribeAckTask extends BaseTask {
     const subscribeAckFrame = await this.receiveSubscribeAck();
     this.context.logger.info(`got subscribe ack: ${JSON.stringify(subscribeAckFrame)}`);
     this.context.sdpAnswer = subscribeAckFrame.sdpAnswer;
-    this.context.videoStreamIndex.integrateSubscribeAckFrame(subscribeAckFrame);
+
+    if (this.context.videoSubscribeContext.videoStreamIndexRef()) {
+      this.context.videoSubscribeContext
+        .videoStreamIndexRef()
+        .integrateSubscribeAckFrame(subscribeAckFrame);
+    }
   }
 
   private receiveSubscribeAck(): Promise<SdkSubscribeAckFrame> {

--- a/src/videosubscribecontext/DefaultVideoSubscribeContext.ts
+++ b/src/videosubscribecontext/DefaultVideoSubscribeContext.ts
@@ -1,0 +1,67 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import DefaultVideoStreamIdSet from '../videostreamidset/DefaultVideoStreamIdSet';
+import DefaultVideoStreamIndex from '../videostreamindex/DefaultVideoStreamIndex';
+import VideoSubscribeContext from './VideoSubscribeContext';
+
+export default class DefaultVideoSubscribeContext implements VideoSubscribeContext {
+  private _videoSubscriptions: number[] = [];
+  private _videoStreamIndex: DefaultVideoStreamIndex | null = null;
+  private _videosToReceive: DefaultVideoStreamIdSet = new DefaultVideoStreamIdSet();
+  private _videosPaused: DefaultVideoStreamIdSet = new DefaultVideoStreamIdSet();
+
+  constructor() {}
+
+  videoSubscriptions(): number[] {
+    return this._videoSubscriptions;
+  }
+
+  videoStreamIndex(): DefaultVideoStreamIndex {
+    return this._videoStreamIndex;
+  }
+
+  videosToReceive(): DefaultVideoStreamIdSet {
+    return this._videosToReceive.clone();
+  }
+
+  videosPausedSet(): DefaultVideoStreamIdSet {
+    return this._videosPaused.clone();
+  }
+
+  updateVideoSubscriptions(videoIndices: number[]): void {
+    this._videoSubscriptions = videoIndices;
+  }
+
+  updateVideoStreamIndex(videoStreamIndex: DefaultVideoStreamIndex): void {
+    this._videoStreamIndex = videoStreamIndex;
+  }
+
+  updateVideosToReceive(videosToReceive: DefaultVideoStreamIdSet): void {
+    this._videosToReceive = videosToReceive.clone();
+  }
+
+  updateVideoPausedSet(videoPaused: DefaultVideoStreamIdSet): void {
+    this._videosPaused = videoPaused;
+  }
+
+  wantsReceiveVideo(): boolean {
+    return !!this._videosToReceive && !this._videosToReceive.empty();
+  }
+
+  videoStreamIndexRef(): DefaultVideoStreamIndex {
+    return this._videoStreamIndex;
+  }
+
+  videosPausedSetRef(): DefaultVideoStreamIdSet {
+    return this._videosPaused;
+  }
+
+  clone(): VideoSubscribeContext {
+    const newContext = new DefaultVideoSubscribeContext();
+    newContext.updateVideoStreamIndex(this._videoStreamIndex);
+    newContext.updateVideoSubscriptions(this._videoSubscriptions);
+    newContext.updateVideosToReceive(this._videosToReceive.clone());
+    return newContext;
+  }
+}

--- a/src/videosubscribecontext/VideoSubscribeContext.ts
+++ b/src/videosubscribecontext/VideoSubscribeContext.ts
@@ -1,0 +1,62 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import VideoStreamIdSet from '../videostreamidset/VideoStreamIdSet';
+import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
+
+export default interface VideoSubscribeContext {
+  /**
+   * returns
+   */
+  videoSubscriptions(): number[];
+  /**
+   * returns
+   */
+  videosToReceive(): VideoStreamIdSet;
+  /**
+   * returns
+   */
+  videoStreamIndex(): VideoStreamIndex;
+  /**
+   * returns
+   */
+  videosPausedSet(): VideoStreamIdSet;
+  /**
+   * returns
+   */
+  videosPausedSetRef(): VideoStreamIdSet;
+  /**
+   * returns
+   */
+  videoStreamIndexRef(): VideoStreamIndex;
+
+  /**
+   * returns
+   */
+  clone(): VideoSubscribeContext;
+
+  /**
+   * returns
+   */
+  updateVideoSubscriptions(videoIndices: number[]): void;
+
+  /**
+   * returns
+   */
+  updateVideoStreamIndex(videoStreamIndex: VideoStreamIndex): void;
+
+  /**
+   * returns
+   */
+  updateVideosToReceive(videosToReceive: VideoStreamIdSet): void;
+
+  /**
+   * returns
+   */
+  updateVideoPausedSet(videoPaused: VideoStreamIdSet): void;
+
+  /**
+   * returns
+   */
+  wantsReceiveVideo(): boolean;
+}

--- a/src/videotilecontroller/DefaultVideoTileController.ts
+++ b/src/videotilecontroller/DefaultVideoTileController.ts
@@ -46,7 +46,7 @@ export default class DefaultVideoTileController implements VideoTileController {
   startLocalVideoTile(): number {
     const tile = this.findOrCreateLocalVideoTile();
     this.currentLocalTile.stateRef().localTileStarted = true;
-    this.audioVideoController.update();
+    this.audioVideoController.update(null);
     return tile.id();
   }
 
@@ -63,7 +63,7 @@ export default class DefaultVideoTileController implements VideoTileController {
       null,
       null
     );
-    this.audioVideoController.update();
+    this.audioVideoController.update(null);
   }
 
   hasStartedLocalVideoTile(): boolean {

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -570,7 +570,7 @@ describe('DefaultAudioVideoController', () => {
 
       await start();
       configuration.connectionTimeoutMs = 100;
-      audioVideoController.update();
+      audioVideoController.update(null);
       configuration.connectionTimeoutMs = 15000;
       // At this point, the update operation failed, performing the Reconnect action.
       // Finish the reconnect operation by sending required frames and events.

--- a/test/task/AttachMediaInputTask.test.ts
+++ b/test/task/AttachMediaInputTask.test.ts
@@ -14,8 +14,7 @@ import DefaultStatsCollector from '../../src/statscollector/DefaultStatsCollecto
 import AttachMediaInputTask from '../../src/task/AttachMediaInputTask';
 import Task from '../../src/task/Task';
 import DefaultTransceiverController from '../../src/transceivercontroller/DefaultTransceiverController';
-import DefaultVideoStreamIdSet from '../../src/videostreamidset/DefaultVideoStreamIdSet';
-import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStreamIndex';
+import DefaultVideoSubscribeContext from '../../src/videosubscribecontext/DefaultVideoSubscribeContext';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
 
@@ -55,13 +54,11 @@ describe('AttachMediaInputTask', () => {
     const audioTrack = new MediaStreamTrack('attach-media-input-task-audio-track-id', 'audio');
     // @ts-ignore
     const videoTrack = new MediaStreamTrack('attach-media-input-task-video-track-id', 'video');
+    context.videoSubscribeContext = new DefaultVideoSubscribeContext();
     context.activeAudioInput = new MediaStream();
     context.activeAudioInput.addTrack(audioTrack);
     context.activeVideoInput = new MediaStream();
     context.activeVideoInput.addTrack(videoTrack);
-    context.videoStreamIndex = new DefaultVideoStreamIndex(logger);
-    context.videosToReceive = new DefaultVideoStreamIdSet();
-    context.videoSubscriptions = [];
     context.statsCollector = new DefaultStatsCollector(context.audioVideoController, logger);
     context.browserBehavior = new DefaultBrowserBehavior();
     task = new AttachMediaInputTask(context);

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -16,6 +16,7 @@ import Task from '../../src/task/Task';
 import DefaultTransceiverController from '../../src/transceivercontroller/DefaultTransceiverController';
 import DefaultVideoStreamIdSet from '../../src/videostreamidset/DefaultVideoStreamIdSet';
 import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStreamIndex';
+import DefaultVideoSubscribeContext from '../../src/videosubscribecontext/DefaultVideoSubscribeContext';
 import VideoTile from '../../src/videotile/VideoTile';
 import DefaultVideoTileController from '../../src/videotilecontroller/DefaultVideoTileController';
 import DefaultVideoTileFactory from '../../src/videotilefactory/DefaultVideoTileFactory';
@@ -59,9 +60,7 @@ describe('CreatePeerConnectionTask', () => {
       context.audioVideoController,
       logger
     );
-    context.videosPaused = new DefaultVideoStreamIdSet();
-    context.videosToReceive = new DefaultVideoStreamIdSet();
-    context.videoStreamIndex = new DefaultVideoStreamIndex(logger);
+    context.videoSubscribeContext = new DefaultVideoSubscribeContext();
     context.activeVideoInput = null;
     context.transceiverController = new DefaultTransceiverController(logger);
     context.audioMixController = new DefaultAudioMixController();
@@ -178,7 +177,7 @@ describe('CreatePeerConnectionTask', () => {
           }
         }
         context.transceiverController = new TestTransceiverController(logger);
-
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         // @ts-ignore
         const videoTrack = new MediaStreamTrack('local-track-id', 'video');
         const activeVideoInput = new MediaStream();
@@ -202,7 +201,8 @@ describe('CreatePeerConnectionTask', () => {
             return attendeeIdForTrack;
           }
         }
-        context.videoStreamIndex = new TestVideoStreamIndex(logger);
+
+        context.videoSubscribeContext.updateVideoStreamIndex(new TestVideoStreamIndex(logger));
 
         class TestVideoTileController extends DefaultVideoTileController {
           removeVideoTilesByAttendeeId(attendeeId: string): number[] {
@@ -234,8 +234,8 @@ describe('CreatePeerConnectionTask', () => {
             return streamId;
           }
         }
-        context.videoStreamIndex = new TestVideoStreamIndex(logger);
 
+        context.videoSubscribeContext.updateVideoStreamIndex(new TestVideoStreamIndex(logger));
         class TestVideoTileController extends DefaultVideoTileController {
           addVideoTile(): VideoTile {
             return (tile = super.addVideoTile());
@@ -268,6 +268,7 @@ describe('CreatePeerConnectionTask', () => {
             return (tile = super.addVideoTile());
           }
         }
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         context.videoTileController = new TestVideoTileController(
           new DefaultVideoTileFactory(),
           context.audioVideoController,
@@ -308,6 +309,7 @@ describe('CreatePeerConnectionTask', () => {
             return (tile = super.addVideoTile());
           }
         }
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         context.videoTileController = new TestVideoTileController(
           new DefaultVideoTileFactory(),
           context.audioVideoController,
@@ -334,6 +336,7 @@ describe('CreatePeerConnectionTask', () => {
           }
         }
         context.logger = new TestLogger();
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         domMockBehavior.setRemoteDescriptionAddTrackSucceeds = false;
 
         await task.run();
@@ -366,8 +369,7 @@ describe('CreatePeerConnectionTask', () => {
             return 'attendee-id';
           }
         }
-        context.videoStreamIndex = new TestVideoStreamIndex(logger);
-
+        context.videoSubscribeContext.updateVideoStreamIndex(new TestVideoStreamIndex(logger));
         await task.run();
         await context.peer.setRemoteDescription(videoRemoteDescription);
         await new Promise(resolve =>
@@ -387,7 +389,8 @@ describe('CreatePeerConnectionTask', () => {
             return 1;
           }
         }
-        context.videoStreamIndex = new TestVideoStreamIndex(logger);
+
+        context.videoSubscribeContext.updateVideoStreamIndex(new TestVideoStreamIndex(logger));
 
         let tile: VideoTile;
         class TestVideoTileController extends DefaultVideoTileController {
@@ -416,8 +419,7 @@ describe('CreatePeerConnectionTask', () => {
             called = true;
           }
         }
-        context.videosPaused = new TestVideoStreamIdSet();
-
+        context.videoSubscribeContext.updateVideoPausedSet(new TestVideoStreamIdSet());
         task.run().then(() => {
           context.peer.addEventListener('track', (event: RTCTrackEvent) => {
             const track = event.track;
@@ -434,6 +436,7 @@ describe('CreatePeerConnectionTask', () => {
             return true;
           }
         }
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         context.transceiverController = new TestTransceiverController(logger);
 
         let tile: VideoTile;
@@ -478,6 +481,7 @@ describe('CreatePeerConnectionTask', () => {
             done();
           }
         }
+        context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
         context.videoTileController = new TestVideoTileController(
           new DefaultVideoTileFactory(),
           context.audioVideoController,
@@ -517,8 +521,8 @@ describe('CreatePeerConnectionTask', () => {
           return 'attendee-id';
         }
       }
-      context.videoStreamIndex = new TestVideoStreamIndex(logger);
 
+      context.videoSubscribeContext.updateVideoStreamIndex(new TestVideoStreamIndex(logger));
       await task.run();
       context.removableObservers[0].removeObserver();
       await context.peer.setRemoteDescription(videoRemoteDescription);
@@ -536,6 +540,7 @@ describe('CreatePeerConnectionTask', () => {
           called = true;
         }
       }
+      context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
       context.videoTileController = new TestVideoTileController(
         new DefaultVideoTileFactory(),
         context.audioVideoController,
@@ -569,6 +574,7 @@ describe('CreatePeerConnectionTask', () => {
           called = true;
         }
       }
+      context.videoSubscribeContext.updateVideoStreamIndex(new DefaultVideoStreamIndex(logger));
       context.videoTileController = new TestVideoTileController(
         new DefaultVideoTileFactory(),
         context.audioVideoController,

--- a/test/task/CreateSDPTask.test.ts
+++ b/test/task/CreateSDPTask.test.ts
@@ -8,7 +8,6 @@ import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVi
 import TimeoutScheduler from '../../src/scheduler/TimeoutScheduler';
 import CreateSDPTask from '../../src/task/CreateSDPTask';
 import Task from '../../src/task/Task';
-import DefaultVideoStreamIdSet from '../../src/videostreamidset/DefaultVideoStreamIdSet';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
 
@@ -26,7 +25,6 @@ describe('CreateSDPTask', () => {
     context.audioVideoController = new NoOpAudioVideoController();
     context.videoTileController = context.audioVideoController.videoTileController;
     context.logger = context.audioVideoController.logger;
-    context.videosToReceive = new DefaultVideoStreamIdSet();
     const peer: RTCPeerConnection = new RTCPeerConnection();
     context.peer = peer;
     task = new CreateSDPTask(context);

--- a/test/task/MonitorTask.test.ts
+++ b/test/task/MonitorTask.test.ts
@@ -4,6 +4,7 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 
+import { DefaultVideoSubscribeContext } from '../../src';
 import AudioVideoController from '../../src/audiovideocontroller/AudioVideoController';
 import AudioVideoControllerState from '../../src/audiovideocontroller/AudioVideoControllerState';
 import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
@@ -116,7 +117,6 @@ describe('MonitorTask', () => {
       logger
     );
     context.videoDownlinkBandwidthPolicy = new NoVideoDownlinkBandwidthPolicy();
-    context.videosToReceive = context.videoDownlinkBandwidthPolicy.chooseSubscriptions().clone();
     context.statsCollector = new DefaultStatsCollector(context.audioVideoController, logger);
     context.reconnectController = new DefaultReconnectController(
       RECONNECT_TIMEOUT_MS,
@@ -276,6 +276,7 @@ describe('MonitorTask', () => {
           return new DefaultVideoStreamIdSet([1, 2, 3]);
         }
       }
+      context.videoSubscribeContext = new DefaultVideoSubscribeContext();
       context.videoDownlinkBandwidthPolicy = new TestVideoDownlinkBandwidthPolicy();
       task.videoReceiveBandwidthDidChange(10, 20);
       expect(spy.called).to.be.true;

--- a/test/task/SetRemoteDescriptionTask.test.ts
+++ b/test/task/SetRemoteDescriptionTask.test.ts
@@ -11,6 +11,7 @@ import SetRemoteDescriptionTask from '../../src/task/SetRemoteDescriptionTask';
 import Task from '../../src/task/Task';
 import DefaultVideoAndCaptureParameter from '../../src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter';
 import DefaultVideoStreamIdSet from '../../src/videostreamidset/DefaultVideoStreamIdSet';
+import DefaultVideoSubscribeContext from '../../src/videosubscribecontext/DefaultVideoSubscribeContext';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
 import SDPMock from '../sdp/SDPMock';
@@ -52,6 +53,7 @@ describe('SetRemoteDescriptionTask', () => {
     context.sdpAnswer = SDPMock.VIDEO_HOST_AUDIO_ANSWER;
     context.turnCredentials = turnCredentials;
     context.videoCaptureAndEncodeParameter = new DefaultVideoAndCaptureParameter(0, 0, 0, 0, false);
+    context.videoSubscribeContext = new DefaultVideoSubscribeContext();
     context.browserBehavior = new DefaultBrowserBehavior();
     // @ts-ignore
     task = new SetRemoteDescriptionTask(context);
@@ -134,7 +136,6 @@ describe('SetRemoteDescriptionTask', () => {
         toJSON: null,
       };
       context.peer.setRemoteDescription(remoteDescription);
-      context.videosToReceive = new DefaultVideoStreamIdSet();
 
       task.run().then(() => {
         expect(context.peer.currentRemoteDescription.sdp).to.equal(
@@ -158,7 +159,7 @@ describe('SetRemoteDescriptionTask', () => {
         toJSON: null,
       };
       context.peer.setRemoteDescription(remoteDescription);
-      context.videosToReceive = new DefaultVideoStreamIdSet();
+      context.videoSubscribeContext.updateVideosToReceive(new DefaultVideoStreamIdSet());
 
       task.run().then(() => {
         expect(context.peer.currentRemoteDescription.sdp).to.equal(context.sdpAnswer);
@@ -180,7 +181,6 @@ describe('SetRemoteDescriptionTask', () => {
         toJSON: null,
       };
       context.peer.setRemoteDescription(remoteDescription);
-      context.videosToReceive = new DefaultVideoStreamIdSet();
 
       task.run().then(() => {
         expect(context.peer.currentRemoteDescription.sdp).to.equal(context.sdpAnswer);
@@ -189,8 +189,6 @@ describe('SetRemoteDescriptionTask', () => {
     });
 
     it('uses the sdp answer if the remote description is not set before', done => {
-      context.videosToReceive = new DefaultVideoStreamIdSet();
-
       task.run().then(() => {
         expect(context.peer.currentRemoteDescription.sdp).to.equal(context.sdpAnswer);
         done();

--- a/test/task/SubscribeAndReceiveSubscribeAckTask.test.ts
+++ b/test/task/SubscribeAndReceiveSubscribeAckTask.test.ts
@@ -3,6 +3,7 @@
 
 import * as chai from 'chai';
 
+import { DefaultVideoStreamIndex, DefaultVideoSubscribeContext, NoOpLogger } from '../../src';
 import AudioVideoControllerState from '../../src/audiovideocontroller/AudioVideoControllerState';
 import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
@@ -20,7 +21,6 @@ import {
 } from '../../src/signalingprotocol/SignalingProtocol.js';
 import SubscribeAndReceiveSubscribeAckTask from '../../src/task/SubscribeAndReceiveSubscribeAckTask';
 import DefaultVideoAndCaptureParameter from '../../src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter';
-import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStreamIndex';
 import DefaultWebSocketAdapter from '../../src/websocketadapter/DefaultWebSocketAdapter';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
@@ -79,8 +79,10 @@ describe('SubscribeAndReceiveSubscribeAckTask', () => {
     context.browserBehavior = new DefaultBrowserBehavior();
     const captureAndEncodeParameters = new DefaultVideoAndCaptureParameter(0, 0, 0, 0, false);
     context.videoCaptureAndEncodeParameter = captureAndEncodeParameters;
-    const videoStreamIndex = new DefaultVideoStreamIndex(context.logger);
-    context.videoStreamIndex = videoStreamIndex;
+    context.videoSubscribeContext = new DefaultVideoSubscribeContext();
+    context.videoSubscribeContext.updateVideoStreamIndex(
+      new DefaultVideoStreamIndex(new NoOpLogger())
+    );
     const frame = SdkSubscribeAckFrame.create();
     frame.sdpAnswer = sdpAnswer;
 


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Abstract out a `VideoSubscribeContext` to hold relevant video stream data.
Update should take a parameter instead of using meetingSessionContext.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
