### PR TITLE
Writing the latest canary completing time to a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable integration tests for travis builds
 - Add ping/pong to screen sharing start code path to ensure socket is viable
 - Enable integration tests for safari 12
+- Write timestamp for latest canary completion time
 
 ### Changed
 - Enforce SDP to have candidates for FinishGatheringICECandidateTask to resolve


### PR DESCRIPTION
The canary is getting stuck after completing all the tests. With this change the canary will emit a timestamp which would indicate the last time it ran and if it greater than some time, the canary can restart.