### PR TITLE
Add an option to manually specify version to publish script and auto …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Automatically patch a version for each commit
+- Allow to specify manual version in publish script
+
+### Fixed
+- Fix publish script to use npm version
+
 ## [1.1.0] - 2020-02-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/prebuild
+++ b/script/prebuild
@@ -1,4 +1,10 @@
 #!/usr/bin/env ruby
+require 'json'
+
+def verbose command
+  puts("--> #{command}") || system(command) || fail("Failed: #{command}")
+end
+
 Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..')))
 base = File.read('.base-branch').strip
 commits = `git rev-list #{base}..`.strip.split("\n")
@@ -8,10 +14,36 @@ if commits.size == 0
 elsif commits.size == 1
   puts "OK: branch contains one commit on top of #{base}"
   commit_files = `git diff-tree --no-commit-id --name-only -r #{commits[0]}`.strip.split("\n")
-  unless commit_files.include?('CHANGELOG.md')
+  uncommitted_files = `git status -s`.strip
+  unless uncommitted_files.length == 0
+    STDERR.puts "Error: there are uncommitted changes:\n #{uncommitted_files}"
+    exit 1
+  end
+  if commit_files.include?('CHANGELOG.md')
+    puts "OK: branch contains CHANGELOG.md"
+  else
     STDERR.puts "Error: Does not contain CHANGELOG.md in the commit #{commits[0]}"
     exit 1
   end
+  version_file = 'src/versioning/Versioning.ts'
+
+  #Reset to the base version
+  base_version = JSON.parse(`git show #{`cat .base-branch`.strip}:package.json`)['version']
+  package_json = JSON.parse(File.read('package.json'))
+  package_json['version'] = base_version
+  File.write('package.json', JSON.pretty_generate(package_json))
+
+  #Increase to new version
+  verbose("npm version patch --no-git-tag-version")
+  package_json = JSON.parse(File.read('package.json'))
+  new_version = package_json['version']
+  puts "Increasing patch version from #{base_version} to #{new_version}"
+  File.write(version_file, File.read(version_file).gsub(/return '[.0-9]+';/, "return '#{new_version}';"))
+
+  verbose("git add #{version_file}")
+  verbose("git add package.json")
+  verbose("git add package-lock.json")
+  verbose("git commit --amend --no-edit")
 elsif commits.size == 2 && `git diff #{commits[0]} #{commits[1]}`.strip == ''
   puts "OK: branch contains empty merge commit followed by one commit on top of #{base}"
 else

--- a/script/publish
+++ b/script/publish
@@ -26,25 +26,31 @@ puts "Choose one of the following bumping version options:"
 puts "1. Patch"
 puts "2. Minor"
 puts "3. Major"
+puts "4. Manual"
 x = STDIN.gets.strip
-exit(1) unless ["1", "2", "3"].include?(x)
+exit(1) unless ["1", "2", "3", "4"].include?(x)
 puts
 
 case x
 when "1"
   version[2] += 1
+  version_string = version.join('.')
 when "2"
   version[1] += 1
   version[2] = 0
+  version_string = version.join('.')
 when "3"
   version[0] += 1
   version[1] = 0
   version[2] = 0
+  version_string = version.join('.')
+when "4"
+  puts "Specify the version in Semantic Versioning format:"
+  version_string = STDIN.gets.strip
 else
   exit(1)
 end
 
-version_string = version.join('.')
 package['version'] = version_string
 version_file = 'src/versioning/Versioning.ts'
 changelog_file = 'CHANGELOG.md'
@@ -68,9 +74,9 @@ verbose('git fetch origin')
 verbose('git reset --hard origin/master')
 verbose('git clean -ffxd .')
 
-File.write('package.json', JSON.pretty_generate(package) + "\n")
 File.write(version_file, File.read(version_file).gsub(/return '[.0-9]+';/, "return '#{version_string}';"))
 File.write(changelog_file, File.read(changelog_file).gsub(/\[Unreleased\]/, "[#{version_string}] - #{Date.today}"))
+verbose("npm version #{version_string} --no-git-tag-version")
 
 verbose('git add -A')
 verbose("git commit -m 'Publish #{tag}'")

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.0';
+    return '1.1.1';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
### Changed
- Automatically patch a version for each commit
- Allow to specify manual version in publish script
### Fixed
- Fix publish script to use npm version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
