### PR TITLE
Add mechanism to capture browser logs on cloudwatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ integration/js/temp
 integration/kite-allure-reports
 integration/logs
 node_modules
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add BITRATES in SdkSignalFrame Type and regenerate corresponding JS and TS protocol files.
+- Add mechanism to capture browser logs on CloudWatch
 
 ### Changed
 - Show SDK version in the demo meeting app

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -22,6 +22,7 @@ import {
   MeetingSessionStatus,
   MeetingSessionStatusCode,
   MeetingSessionVideoAvailability,
+  POSTRequestLogger,
   ScreenMessageDetail,
   ScreenShareFacadeObserver,
   TimeoutScheduler,
@@ -128,7 +129,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
 
   // feature flags
   enableWebAudio = false;
-
+  logger: any = null;
   constructor() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).app = this;
@@ -442,22 +443,26 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       }
       new AsyncScheduler().start(async () => {
         (buttonMeetingEnd as HTMLButtonElement).disabled = true;
+        (buttonMeetingLeave as HTMLButtonElement).disabled = true;
         await this.endMeeting();
         this.leave();
-        (buttonMeetingEnd as HTMLButtonElement).disabled = false;
         // @ts-ignore
         window.location = window.location.pathname;
+        (buttonMeetingEnd as HTMLButtonElement).disabled = false;
+        (buttonMeetingLeave as HTMLButtonElement).disabled = false;
       });
     });
 
     const buttonMeetingLeave = document.getElementById('button-meeting-leave');
     buttonMeetingLeave.addEventListener('click', _e => {
       new AsyncScheduler().start(async () => {
+        (buttonMeetingEnd as HTMLButtonElement).disabled = true;
         (buttonMeetingLeave as HTMLButtonElement).disabled = true;
         this.leave();
-        (buttonMeetingLeave as HTMLButtonElement).disabled = false;
         // @ts-ignore
         window.location = window.location.pathname;
+        (buttonMeetingEnd as HTMLButtonElement).disabled = false;
+        (buttonMeetingLeave as HTMLButtonElement).disabled = false;
       });
     });
   }
@@ -548,11 +553,16 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     }
   }
 
+
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
-    const logger = new ConsoleLogger('SDK', LogLevel.DEBUG);
-    const deviceController = new DefaultDeviceController(logger);
+    if (!(DemoMeetingApp.BASE_URL.includes('localhost') || DemoMeetingApp.BASE_URL.includes("127.0.0.1"))) {
+      this.logger = new POSTRequestLogger('SDK', configuration, 75, 1750, `${DemoMeetingApp.BASE_URL}logs`, LogLevel.INFO);
+    } else {
+      this.logger = new ConsoleLogger('SDK', LogLevel.DEBUG);
+    }
+    const deviceController = new DefaultDeviceController(this.logger);
     configuration.enableWebAudio = this.enableWebAudio;
-    this.meetingSession = new DefaultMeetingSession(configuration, logger, deviceController);
+    this.meetingSession = new DefaultMeetingSession(configuration, this.logger, deviceController);
     this.audioVideo = this.meetingSession.audioVideo;
 
     this.audioVideo.addDeviceChangeObserver(this);

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -119,6 +119,9 @@ const server = require(protocol).createServer(options, async (request, response)
         .promise();
       response.statusCode = 200;
       response.end();
+    } else if (request.method === 'POST' && request.url.startsWith('/logs')) {
+      console.log('Writing logs to cloudwatch');
+      response.end('Writing logs to cloudwatch');
     } else {
       response.statusCode = 404;
       response.setHeader('Content-Type', 'text/plain');

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -210,8 +210,20 @@ exports.end = async(event, context, callback) => {
   callback(null, response);
 };
 
+async function ensureLogStream(cloudWatchClient, logStreamName) {
+  var describeLogStreamsParams = {
+    "logGroupName": logGroupName,
+    "logStreamNamePrefix": logStreamName
+  };
+  var response = await cloudWatchClient.describeLogStreams(describeLogStreamsParams).promise();
+  var foundStream = response.logStreams.find(s => s.logStreamName === logStreamName);
+  if (foundStream) {
+    return foundStream.uploadSequenceToken;
+  }
+  return null;
+}
+
 exports.logs = async (event, context) => {
-  var sequenceToken = "";
   var response = {
     "statusCode": 200,
     "headers": {},
@@ -222,27 +234,20 @@ exports.logs = async (event, context) => {
     var body = JSON.parse(event.body);
     if (!body.logs || !body.meetingId || !body.attendeeId || !body.appName) {
       response.body = "Empty Parameters Received";
+      response.statusCode = 400;
       return response;
     }
     const logStreamName = "ChimeSDKMeeting_" + body.meetingId.toString();
     var cloudWatchClient = new AWS.CloudWatchLogs({
       apiVersion: '2014-03-28'
     });
+    var uploadSequence = await ensureLogStream(cloudWatchClient, logStreamName);
     var putLogEventsInput = {
       "logGroupName": logGroupName,
       "logStreamName": logStreamName
     };
-    var describeLogStreamsParams = {
-      "logGroupName": logGroupName,
-      "logStreamNamePrefix": logStreamName
-    };
-    var describeLogStreamsResponse = await cloudWatchClient.describeLogStreams(describeLogStreamsParams).promise();
-    var logStreamsArr = describeLogStreamsResponse.logStreams;
-    var currentLogStream = logStreamsArr.find(logStreamJSON => logStreamJSON.logStreamName === logStreamName);
-    if (!currentLogStream) {
-      var res = await cloudWatchClient.createLogStream(putLogEventsInput).promise();
-    } else {
-      putLogEventsInput["sequenceToken"] = currentLogStream.uploadSequenceToken;
+    if (uploadSequence) {
+      putLogEventsInput["sequenceToken"] = uploadSequence;
     }
     var logEvents = [];
     for (let i = 0; i < body.logs.length; i++) {

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -19,6 +19,7 @@ Globals:
         MEETINGS_TABLE_NAME: !Ref Meetings
         ATTENDEES_TABLE_NAME: !Ref Attendees
         SQS_QUEUE_ARN: !GetAtt MeetingNotificationsQueue.Arn
+        BROWSER_LOG_GROUP_NAME: BrowserLogs
 Resources:
   ChimeMeetingsAccessPolicy:
     Type: AWS::IAM::Policy
@@ -44,8 +45,23 @@ Resources:
         - Ref: ChimeSdkAttendeeLambdaRole
         - Ref: ChimeSdkEndLambdaRole
         - Ref: ChimeSdkCreateMeetingLambdaRole
+  CloudWatchAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: CloudWatchAccess
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'logs:DescribeLogStreams'
+            Resource: '*'
+      Roles:
+        - Ref: ChimeSdkBrowserLogsLambdaRole
   Meetings:
-    Type: 'AWS::DynamoDB::Table'
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         - AttributeName: "Title"
@@ -72,7 +88,7 @@ Resources:
         AttributeName: "TTL"
         Enabled: true
   Attendees:
-    Type: 'AWS::DynamoDB::Table'
+    Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
         - AttributeName: "AttendeeId"
@@ -98,7 +114,7 @@ Resources:
             Path: /
             Method: GET
   ChimeSdkCreateMeetingLambda:
-    Type: 'AWS::Serverless::Function'
+    Type: AWS::Serverless::Function
     Properties:
       Handler: handlers.createMeeting
       CodeUri: src/
@@ -115,7 +131,7 @@ Resources:
             Path: /meeting
             Method: POST
   ChimeSdkJoinLambda:
-    Type: 'AWS::Serverless::Function'
+    Type: AWS::Serverless::Function
     Properties:
       Handler: handlers.join
       CodeUri: src/
@@ -134,7 +150,7 @@ Resources:
             Path: /join
             Method: POST
   ChimeSdkEndLambda:
-    Type: 'AWS::Serverless::Function'
+    Type: AWS::Serverless::Function
     Properties:
       Handler: handlers.end
       CodeUri: src/
@@ -148,7 +164,7 @@ Resources:
             Path: /end
             Method: POST
   ChimeSdkAttendeeLambda:
-    Type: 'AWS::Serverless::Function'
+    Type: AWS::Serverless::Function
     Properties:
       Handler: handlers.attendee
       CodeUri: src/
@@ -189,6 +205,17 @@ Resources:
                 - aws.chime
               detail-type:
                 - "Chime Meeting State Change"
+  ChimeSdkBrowserLogsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.logs
+      CodeUri: src/
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /logs
+            Method: POST
   ChimeNotificationsQueuePolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -19,7 +19,7 @@ Globals:
         MEETINGS_TABLE_NAME: !Ref Meetings
         ATTENDEES_TABLE_NAME: !Ref Attendees
         SQS_QUEUE_ARN: !GetAtt MeetingNotificationsQueue.Arn
-        BROWSER_LOG_GROUP_NAME: BrowserLogs
+        BROWSER_LOG_GROUP_NAME: !Ref ChimeBrowserLogs
 Resources:
   ChimeMeetingsAccessPolicy:
     Type: AWS::IAM::Policy
@@ -232,6 +232,8 @@ Resources:
             Resource: !GetAtt MeetingNotificationsQueue.Arn
       Queues:
         - Ref: MeetingNotificationsQueue
+  ChimeBrowserLogs:
+    Type: AWS::Logs::LogGroup
 Outputs:
   ApiURL:
     Description: "API endpoint URL for Prod environment"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,7 @@ import None from './maybe/None';
 import OpenScreenSignalingSessionTask from './task/OpenScreenSignalingSessionTask';
 import OpenScreenViewingConnectionTask from './task/OpenScreenViewingConnectionTask';
 import OpenSignalingConnectionTask from './task/OpenSignalingConnectionTask';
+import POSTRequestLogger from './logger/POSTRequestLogger';
 import ParallelGroupTask from './task/ParallelGroupTask';
 import PingPong from './pingpong/PingPong';
 import PingPongObserver from './pingpongobserver/PingPongObserver';
@@ -422,6 +423,7 @@ export {
   OpenScreenSignalingSessionTask,
   OpenScreenViewingConnectionTask,
   OpenSignalingConnectionTask,
+  POSTRequestLogger,
   ParallelGroupTask,
   PingPong,
   PingPongObserver,

--- a/src/logger/POSTRequestLogger.ts
+++ b/src/logger/POSTRequestLogger.ts
@@ -1,0 +1,124 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Logger from '../logger/Logger';
+import LogLevel from '../logger/LogLevel';
+import IntervalScheduler from '../scheduler/IntervalScheduler';
+import MeetingSessionConfiguration from '../meetingsession/MeetingSessionConfiguration';
+
+export default class POSTRequestLogger implements Logger {
+  private logCapture: string[] = [];
+  private logSequenceNumber: number = 0;
+  private lock = false;
+  private intervalScheduler: IntervalScheduler;
+
+  constructor(
+    private name: string,
+    private configuration: MeetingSessionConfiguration,
+    private batchSize: number,
+    private intervalMs: number,
+    private baseURL: string,
+    private level = LogLevel.INFO,
+  ) {
+    this.intervalScheduler = new IntervalScheduler(this.intervalMs);
+    this.startLogPublishScheduler(this.batchSize);
+    window.addEventListener('unload', () => {
+      this.intervalScheduler.stop();
+      const body = this.jsonStringify(this.logCapture);
+      navigator.sendBeacon(this.baseURL, body);
+   });
+  }
+
+  debug(debugFunction: () => string): void {
+    if (LogLevel.DEBUG < this.level) {
+      return;
+    }
+    this.log(LogLevel.DEBUG, debugFunction());
+  }
+
+  info(msg: string): void {
+    this.log(LogLevel.INFO, msg);
+  }
+
+  warn(msg: string): void {
+    this.log(LogLevel.WARN, msg);
+  }
+
+  error(msg: string): void {
+    this.log(LogLevel.ERROR, msg);
+  }
+
+  setLogLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  getLogLevel(): LogLevel {
+    return this.level;
+  }
+
+  startLogPublishScheduler(batchSize: number): void {
+    this.intervalScheduler.start(async () => {
+      if (this.lock === true || this.logCapture.length === 0) {
+        return;
+      }
+      this.lock = true;
+      const batch = this.logCapture.slice(0, batchSize);
+      const body = this.jsonStringify(batch);
+      try {
+        const response = await fetch(this.baseURL, {
+          method: 'POST',
+          body,
+        });
+        if (response.status === 200) {
+          this.logCapture = this.logCapture.slice(batch.length);
+        }
+      } catch (error) {
+        console.warn('[POSTRequestLogger] ' + error.message);
+      } finally {
+        this.lock = false;
+      }
+    });
+  }
+
+  private jsonStringify(batch: string[]) : string {
+    return JSON.stringify({
+      meetingId: this.configuration.meetingId,
+      attendeeId: this.configuration.credentials.attendeeId,
+      appName: this.name,
+      logs: batch,
+    });
+  }
+
+  private log(type: LogLevel, msg: string): void {
+    if (type < this.level) {
+      return;
+    }
+    const date = new Date();
+    const timestamp = date.toISOString();
+    const logMessage = `${this.logSequenceNumber} ${timestamp} [${LogLevel[type]}] ${this.name} - ${msg}`;
+
+    switch (type) {
+      case LogLevel.ERROR:
+        console.trace(logMessage);
+        break;
+      case LogLevel.WARN:
+        console.warn(logMessage);
+        break;
+      case LogLevel.DEBUG:
+        console.debug(logMessage.replace(/\\r\\n/g, '\n'));
+        break;
+      case LogLevel.INFO:
+        console.info(logMessage);
+        break;
+    }
+    this.logCapture.push(
+      JSON.stringify({
+        logSequenceNumber: this.logSequenceNumber,
+        logMessage: msg,
+        timestamp: date.getTime(),
+        logLevelType: LogLevel[type],
+      })
+    );
+    this.logSequenceNumber += 1;
+  }
+}

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.3';
+    return '1.1.4';
   }
 
   /**


### PR DESCRIPTION
*Issue #:* 

*Description of changes*
Added cloudwatch implementation to capture the logs generated in the browser. Every 5 seconds batch size of 50 logs are written to the CloudWatch
LogGroup Name: BrowserLogs [has to be created manually from the console]
LogStream is meeting ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
