### PR TITLE
Fix integration test completion time writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add stage to saucelabs session name for integration tests
 - Fix audio-video session stop to return Left status code
 - Fix crash in demo app when click on screen share view
+- Fix integration test completion time writer
 
 ## [1.1.0] - 2020-02-04
 

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -97,7 +97,7 @@ class SdkBaseTest extends KiteBaseTest {
   writeCompletionTimeTo(filePath) {
     try {
       const epochTimeInSeconds = Math.round(new Date().getTime() / 1000);
-      fs.writeFileSync(`${filePath}/last_run_timestamp`, epochTimeInSeconds);
+      fs.appendFileSync(`${filePath}/last_run_timestamp`, `${epochTimeInSeconds}\n`, {flag: 'a+'});
       console.log(`Wrote canary completion timestamp : ${epochTimeInSeconds}`);
     } catch (e) {
       console.log(`Failed to write last completed canary timestamp to a file : ${e}`)


### PR DESCRIPTION
Appending the test completion time to a file instead of overwriting it.