### PR TITLE
Remove extra line endings when searching keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to specify manual version in publish script
 
 ### Fixed
+- Remove line endings in the keyword when searching for connection attributes in SDP
 - Fix pause and resume video functionality
 - Fix DefaultTransceiverController async function signature
 - Make DefaultBrowserBehavior implement BrowserBehavior interface

--- a/src/sdp/DefaultSDP.ts
+++ b/src/sdp/DefaultSDP.ts
@@ -76,7 +76,7 @@ export default class DefaultSDP implements SDP {
   }
 
   hasCandidatesForAllMLines(): boolean {
-    const isAnyCLineUsingLocalHost = this.sdp.indexOf('\r\nc=IN IP4 0.0.0.0\r\n') > -1;
+    const isAnyCLineUsingLocalHost = this.sdp.indexOf('c=IN IP4 0.0.0.0') > -1;
     const mLinesHaveCandidates = !isAnyCLineUsingLocalHost;
     return mLinesHaveCandidates;
   }


### PR DESCRIPTION
*Issue #:* 

*Description of changes*
Remove extra line endings when searching keyword (connection attribute) in SDP.
iOS occasionally used `\n` instead of `\r\n` for line ending

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
