### PR TITLE
Added sleep timeout condition to reconnect logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make DefaultBrowserBehavior implement BrowserBehavior interface
 - Fix publish script to use npm version
 - Add stage to saucelabs session name for integration tests
+- Added sleep timeout condition to reconnect logic
 
 ## [1.1.0] - 2020-02-04
 

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -67,6 +67,7 @@ import NScaleVideoUplinkBandwidthPolicy from '../videouplinkbandwidthpolicy/NSca
 import DefaultVolumeIndicatorAdapter from '../volumeindicatoradapter/DefaultVolumeIndicatorAdapter';
 import WebSocketAdapter from '../websocketadapter/WebSocketAdapter';
 import AudioVideoControllerState from './AudioVideoControllerState';
+import PingPong from '../pingpong/PingPong';
 
 export default class DefaultAudioVideoController implements AudioVideoController {
   private _facade: AudioVideoFacade;
@@ -79,7 +80,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
   private _deviceController: DeviceControllerBasedMediaStreamBroker;
   private _reconnectController: ReconnectController;
   private _audioMixController: AudioMixController;
-
+  private pingPong: PingPong;
   private connectionHealthData = new ConnectionHealthData();
   private observerQueue: Set<AudioVideoObserver> = new Set<AudioVideoObserver>();
   private meetingSessionContext = new AudioVideoControllerState();
@@ -201,8 +202,8 @@ export default class DefaultAudioVideoController implements AudioVideoController
       this._webSocketAdapter,
       this.logger
     );
+
     this.meetingSessionContext.mediaStreamBroker = this._deviceController;
-    this.meetingSessionContext.deviceController = this._deviceController;
     this.meetingSessionContext.realtimeController = this._realtimeController;
     this.meetingSessionContext.audioMixController = this._audioMixController;
     this.meetingSessionContext.audioVideoController = this;
@@ -234,16 +235,17 @@ export default class DefaultAudioVideoController implements AudioVideoController
     this.meetingSessionContext.videosToReceive = new DefaultVideoStreamIdSet();
     this.meetingSessionContext.videosPaused = new DefaultVideoStreamIdSet();
     this.meetingSessionContext.statsCollector = new DefaultStatsCollector(this, this.logger);
+    this.pingPong = new DefaultPingPong(
+          this.meetingSessionContext.signalingClient,
+          DefaultAudioVideoController.PING_PONG_INTERVAL_MS,
+          this.logger
+        );
     this.meetingSessionContext.connectionMonitor = new SignalingAndMetricsConnectionMonitor(
       this,
       this._realtimeController,
       this._videoTileController,
       this.connectionHealthData,
-      new DefaultPingPong(
-        this.meetingSessionContext.signalingClient,
-        DefaultAudioVideoController.PING_PONG_INTERVAL_MS,
-        this.logger
-      ),
+      this.pingPong,
       this.meetingSessionContext.statsCollector
     );
     this.meetingSessionContext.reconnectController = this._reconnectController;
@@ -259,9 +261,9 @@ export default class DefaultAudioVideoController implements AudioVideoController
 
     if (this._reconnectController.hasStartedConnectionAttempt()) {
       // This does not reset the reconnect deadline, but declare it's not the first connection.
-      this._reconnectController.startedConnectionAttempt(false);
+      this._reconnectController.startedConnectionAttempt(false, this.pingPong);
     } else {
-      this._reconnectController.startedConnectionAttempt(true);
+      this._reconnectController.startedConnectionAttempt(true, this.pingPong);
     }
 
     try {
@@ -513,7 +515,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
 
   private async actionReconnect(): Promise<void> {
     if (!this._reconnectController.hasStartedConnectionAttempt()) {
-      this._reconnectController.startedConnectionAttempt(false);
+      this._reconnectController.startedConnectionAttempt(false, this.pingPong);
       this.forEachObserver(observer => {
         Maybe.of(observer.audioVideoDidStartConnecting).map(f => f.bind(observer)(true));
       });

--- a/src/reconnectcontroller/ReconnectController.ts
+++ b/src/reconnectcontroller/ReconnectController.ts
@@ -1,6 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import PingPong from '../pingpong/PingPong';
 /**
  * [[ReconnectController]] describes the status about the meeting session connection and makes decisions
  * based on the controller implementation.
@@ -16,7 +17,7 @@ export default interface ReconnectController {
    * can be set.
    * @param{boolean} isFirstConnection whether this is the first attempt to connect for this session
    */
-  startedConnectionAttempt(isFirstConnection: boolean): void;
+  startedConnectionAttempt(isFirstConnection: boolean, pingPong: PingPong): void;
 
   /**
    * Indicates whether a connection attempt is already in progress.

--- a/test/reconnectcontroller/DefaultReconnectController.test.ts
+++ b/test/reconnectcontroller/DefaultReconnectController.test.ts
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 
 import FullJitterBackoff from '../../src/backoff/FullJitterBackoff';
 import DefaultReconnectController from '../../src/reconnectcontroller/DefaultReconnectController';
 import TimeoutScheduler from '../../src/scheduler/TimeoutScheduler';
+import PingPong from '../../src/pingpong/PingPong';
+import PingPongObserver from '../../src/pingpongobserver/PingPongObserver';
 
 describe('DefaultReconnectController', () => {
+  let pingPongStartCalled: boolean;
   let expect: Chai.ExpectStatic;
   let timeout: number;
   let defaultController = (): DefaultReconnectController => {
@@ -15,6 +19,9 @@ describe('DefaultReconnectController', () => {
   };
 
   beforeEach(() => {
+    pingPongStartCalled = false;
+    const controller = defaultController();
+    controller.startedConnectionAttempt(false, new TestPingPong());
     expect = chai.expect;
     timeout = 50;
   });
@@ -84,7 +91,7 @@ describe('DefaultReconnectController', () => {
 
     it('stops calling the retry func if it is past the deadline', done => {
       const controller = defaultController();
-      controller.startedConnectionAttempt(true);
+      controller.startedConnectionAttempt(true, new TestPingPong());
       expect(controller.hasStartedConnectionAttempt()).to.equal(true);
       expect(controller.isFirstConnection()).to.equal(true);
       const tryAgain = (): void => {
@@ -99,8 +106,66 @@ describe('DefaultReconnectController', () => {
       };
       tryAgain();
       new TimeoutScheduler(2 * timeout).start(() => {});
-      controller.startedConnectionAttempt(false);
+      controller.startedConnectionAttempt(false, new TestPingPong());
       expect(controller.isFirstConnection()).to.equal(false);
     });
+    it('stops calling the retry func if it is past the deadline', done => {
+          const controller = defaultController();
+          controller.startedConnectionAttempt(true, new TestPingPong());
+          expect(controller.hasStartedConnectionAttempt()).to.equal(true);
+          expect(controller.isFirstConnection()).to.equal(true);
+                  controller.didReceivePong(0, 0);
+          const tryAgain = (): void => {
+            controller.retryWithBackoff(
+              () => {},
+              () => {}
+            )
+              ? new TimeoutScheduler(10).start(() => {
+                  tryAgain();
+                })
+              : done();
+          };
+          tryAgain();
+          new TimeoutScheduler(2 * timeout).start(() => {});
+          controller.startedConnectionAttempt(false, new TestPingPong());
+          expect(controller.isFirstConnection()).to.equal(false);
+        });
   });
+
+  it('can start a PingPong', () => {
+    const controller = defaultController();
+    controller.startedConnectionAttempt(true, new TestPingPong());
+    expect(pingPongStartCalled).to.equal(true);
+  });
+
+  it('can receive a pong', () => {
+    const controller = defaultController();
+    const didReceivePongSpy = sinon.spy(controller, 'didReceivePong');
+    controller.didReceivePong(0, 0);
+    expect(didReceivePongSpy.called).to.equal(true);
+  });
+
+  it('can stop a PingPong', () => {
+    const controller = defaultController();
+    const pingPong = new TestPingPong();
+    const startSpy = sinon.spy(pingPong, 'start');
+    const stopSpy = sinon.spy(pingPong, 'stop');
+    controller.startedConnectionAttempt(true, pingPong);
+    expect(controller.hasStartedConnectionAttempt()).to.equal(true);
+    expect(controller.isFirstConnection()).to.equal(true);
+    controller.didReceivePong(0, 0);
+    expect(startSpy.called).to.equal(true);
+    controller.reset();
+    expect(stopSpy.called).to.equal(true);
+  });
+
+  class TestPingPong implements PingPong {
+      addObserver(_observer: PingPongObserver): void {}
+      removeObserver(_observer: PingPongObserver): void {}
+      forEachObserver(_observerFunc: (_observer: PingPongObserver) => void): void {}
+      start(): void {
+        pingPongStartCalled = true;
+      }
+      stop(): void {}
+    }
 });


### PR DESCRIPTION
*Issue #:* 
474 Reconnected to the meeting even after putting laptop for sleep/closing lid for a longtime #474

*Description of changes*
Fixed reconnect logic to stop trying to reconnect to a meeting after the laptop is put to sleep.
Changed the hasPastReconnectDeadline logic. Adds DefaultReconnectController as a pingPongObserver and updates the time it received the last Pong in response for a ping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
