### PR TITLE
Inject an environment variable to check if the demo app is running on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add POSTLogger for meeting sessions
 - Integrate POSTLogger into the demo app
 - Add content share integration test
+- Enable POSTLogger for the serverless demo app
 
 ### Changed
 - Add observer event for content sharing

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -17,8 +17,10 @@ import {
   Device,
   DeviceChangeObserver,
   LogLevel,
+  Logger,
   MeetingSession,
   MeetingSessionConfiguration,
+  MeetingSessionPOSTLogger,
   MeetingSessionStatus,
   MeetingSessionStatusCode,
   MeetingSessionVideoAvailability,
@@ -96,6 +98,11 @@ class TestSound {
 }
 
 export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver {
+  static readonly DID: string = '+17035550122';
+  static readonly BASE_URL: string = [location.protocol, '//', location.host, location.pathname.replace(/\/*$/, '/')].join('');
+  static readonly LOGGER_BATCH_SIZE: number = 85;
+  static readonly LOGGER_INTERVAL_MS: number = 1150;
+
   showActiveSpeakerScores = false;
   activeSpeakerLayout = true;
   meeting: string | null = null;
@@ -103,9 +110,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
   voiceConnectorId: string | null = null;
   sipURI: string | null = null;
   region: string | null = null;
-  static readonly DID: string = '+17035550122';
-  static readonly BASE_URL: string = [location.protocol, '//', location.host, location.pathname.replace(/\/*$/, '/')].join('');
-
   meetingSession: MeetingSession | null = null;
   audioVideo: AudioVideoFacade | null = null;
   tileOrganizer: DemoTileOrganizer = new DemoTileOrganizer();
@@ -550,7 +554,19 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
   }
 
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
-    const logger = new ConsoleLogger('SDK', LogLevel.INFO);
+    let logger: Logger;
+    if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
+      logger = new ConsoleLogger('SDK', LogLevel.INFO);
+    } else {
+      logger = new MeetingSessionPOSTLogger(
+        'SDK', 
+        configuration, 
+        DemoMeetingApp.LOGGER_BATCH_SIZE, 
+        DemoMeetingApp.LOGGER_INTERVAL_MS,
+        `${DemoMeetingApp.BASE_URL}logs`,
+        LogLevel.INFO
+      );
+    }
     const deviceController = new DefaultDeviceController(logger);
     configuration.enableWebAudio = this.enableWebAudio;
     this.meetingSession = new DefaultMeetingSession(configuration, logger, deviceController);

--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable */
-var HtmlWebpackInlineSourcePlugin = require ('html-webpack-inline-source-plugin');
+var webpack = require('webpack');
+var HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 /* eslint-enable */
 
@@ -18,6 +19,9 @@ module.exports = env => {
         inject: 'head',
       }),
       new HtmlWebpackInlineSourcePlugin(),
+      new webpack.EnvironmentPlugin({
+        IS_LOCAL: process.env.npm_config_is_local === 'true' ? 'true' : 'false'
+      })
     ],
     entry: [`./app/${app}/${app}.ts`],
     resolve: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.28';
+    return '1.1.29';
   }
 
   /**


### PR DESCRIPTION
… localhost

*Issue #:* 

*Description of changes*
- Take `process.env.npm_config_is_local` from the NPM script in which you can pass using the `--is_local` option.
- Inject `process.env.npm_config_is_local` into the demo app using the Webpack EnvironmentPlugin.
- In the serverless script, always build a demo app even if there exists assets in the `/dist` folder. I think building a demo app per script execution is better than grabbing possibly old assets anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
