### PR TITLE
Fix browser versions for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix integration test completion time writer
 - Fix the ping pong reconnection issue
 - Fix example code in the getting started guide
+- Fix browser versions for integration tests
 
 ## [1.1.0] - 2020-02-04
 

--- a/integration/configs/app_quit_audio_test.config.json
+++ b/integration/configs/app_quit_audio_test.config.json
@@ -27,7 +27,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/app_quit_screen_share_test.config.json
+++ b/integration/configs/app_quit_screen_share_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/app_quit_video_test.config.json
+++ b/integration/configs/app_quit_video_test.config.json
@@ -27,7 +27,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/audio_test.config.json
+++ b/integration/configs/audio_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_end_test.config.json
+++ b/integration/configs/meeting_end_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_audio_test.config.json
+++ b/integration/configs/meeting_leave_audio_test.config.json
@@ -27,7 +27,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_screen_share_test.config.json
+++ b/integration/configs/meeting_leave_screen_share_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_video_test.config.json
+++ b/integration/configs/meeting_leave_video_test.config.json
@@ -27,7 +27,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/screen_sharing_test.config.json
+++ b/integration/configs/screen_sharing_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/screen_viewing_test.config.json
+++ b/integration/configs/screen_viewing_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/video_test.config.json
+++ b/integration/configs/video_test.config.json
@@ -24,7 +24,7 @@
     },
     {
       "browserName": "chrome",
-      "version": "77",
+      "version": "78",
       "platform": "MAC"
     }
   ]

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -24,7 +24,7 @@ const getFirefoxCapabilities = (capabilities) => {
   return {
     platformName: getPlatformName(capabilities),
     browserName: 'Firefox',
-    browser_version: capabilities.version,
+    browserVersion: capabilities.version,
     resolution: '1920x1080',
     'moz:firefoxOptions': {
       args: [
@@ -88,7 +88,7 @@ const getSauceLabsConfig = (capabilities) => {
     name: capabilities.name,
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
-    extendedDebugging: false,
+    extendedDebugging: true,
     capturePerformance: true,
     crmuxdriverVersion: 'beta',
     tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.21';
+    return '1.1.22';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
- Fix the typo that specify the Firefox browser version
- Increase Chrome version to 78 which is the lowest version that SDK supports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
