### PR TITLE
Use max-bundle RTCRtpPolicy for firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not reconnect if the session has not received monitoring data for a while
 - Skip tests when merging to master
 - Bump acorn dependency in package-lock.json to 6.4.1 to address CVE-2020-7598
+- Use max-bundle RTCRtpPolicy for Firefox
 
 ### Fixed
 - Remove line endings in the keyword when searching for connection attributes in SDP

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -550,7 +550,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
   }
 
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
-    const logger = new ConsoleLogger('SDK', LogLevel.DEBUG);
+    const logger = new ConsoleLogger('SDK', LogLevel.INFO);
     const deviceController = new DefaultDeviceController(logger);
     configuration.enableWebAudio = this.enableWebAudio;
     this.meetingSession = new DefaultMeetingSession(configuration, logger, deviceController);

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -506,7 +506,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   }
 
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
-    const logger = new ConsoleLogger('SDK', LogLevel.DEBUG);
+    const logger = new ConsoleLogger('SDK', LogLevel.INFO);
     const deviceController = new DefaultDeviceController(logger);
     configuration.enableWebAudio = this.enableWebAudio;
     this.meetingSession = new DefaultMeetingSession(configuration, logger, deviceController);

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.639.0",
+    "aws-sdk": "^2.642.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -76,7 +76,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior {
   }
 
   requiresBundlePolicy(): RTCBundlePolicy {
-    if (this.isSafari()) {
+    if (this.isSafari() || this.isFirefox()) {
       return 'max-bundle';
     } else {
       return 'balanced';

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.27';
+    return '1.1.28';
   }
 
   /**

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -45,7 +45,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().isSupported()).to.eq(true);
       expect(new DefaultBrowserBehavior().screenShareUnsupported()).to.eq(false);
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(68);
-      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('balanced');
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
     });
 
     it('can detect Chrome', () => {


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

`max-bundle` is the policy that is best compatible with our server. 
Safari is using this policy right now. 
Chrome still uses Plan B so it's left untouched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
