### PR TITLE
Make meeting V2 the default demo meeting app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
       script: npm run test:integration-screen-share
     #Integ test content share
     - stage: integ_content_share
+      if: (type = pull_request) OR (type = push AND branch != master)
       script: npm run test:integration-content-share
     #Deploy
     - stage: deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure both participants in audio and video tests reach finish state before retrying
 - Trigger videoSendBandwidthDidChange and videoReceiveBandwidthDidChange for Safari
 - Do not disconnect video element with different srcObj when destroying video tile
+- Make meeting V2 the default demo meeting app
 
 ### Removed
 - Remove SDP class withPlanBSimulcast method

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -32,7 +32,7 @@ const log = message => {
   console.log(`${new Date().toISOString()} ${message}`);
 };
 
-const app = process.env.npm_config_app || 'meeting';
+const app = process.env.npm_config_app || 'meetingV2';
 
 const server = require(protocol).createServer(options, async (request, response) => {
   log(`${request.method} ${request.url} BEGIN`);

--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -6,7 +6,7 @@ var HtmlWebpackInlineSourcePlugin = require ('html-webpack-inline-source-plugin'
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 /* eslint-enable */
 
-const app = process.env.npm_config_app || 'meeting';
+const app = process.env.npm_config_app || 'meetingV2';
 
 module.exports = env => {
   return {

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -85,12 +85,14 @@ function spawnOrFail(command, args, options) {
     console.log(`Command ${command} failed with ${cmd.error.code}`);
     process.exit(255);
   }
-  console.log(cmd.output.toString());
+  const output=cmd.output.toString();
+  console.log(output);
   if (cmd.status !== 0) {
     console.log(`Command ${command} failed with exit code ${cmd.status} signal ${cmd.signal}`);
     console.log(cmd.stderr.toString());
     process.exit(cmd.status)
   }
+  return output;
 }
 
 function appHtml(appName) {
@@ -148,5 +150,8 @@ spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--sta
                     '--parameter-overrides', `UseEventBridge=${useEventBridge}`,
                     '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`]);
 console.log("Amazon Chime SDK Meeting Demo URL: ");
-spawnOrFail('aws', ['cloudformation', 'describe-stacks', '--stack-name', `${stack}`,
+const output=spawnOrFail('aws', ['cloudformation', 'describe-stacks', '--stack-name', `${stack}`,
                     '--query', 'Stacks[0].Outputs[0].OutputValue', '--output', 'text', '--region', `${region}`]);
+if (app === 'meeting') {
+  console.log(output.replace(/Prod/, 'Prod/v2'));
+}

--- a/integration/js/script/run-test
+++ b/integration/js/script/run-test
@@ -4,12 +4,12 @@ function start_demo_meeting {
     cd ~/build/aws/amazon-chime-sdk-js/demos/browser
     uuid=$(uuidgen)
     mkdir -p logs
-    if [[ $1 -eq 'v2' ]]
+    if [[ $1 == 'v1' ]]
     then
-      extra_args='--app=meetingV2'
-      echo "Starting the demo v2"
-    else
+      extra_args='--app=meeting'
       echo "Starting the demo v1"
+    else
+      echo "Starting the demo v2"
     fi
     npm run start $extra_args &> logs/$uuid.log &
 }
@@ -44,9 +44,9 @@ function wait_for_demo_to_start {
 
 curr=`pwd`
 
-if [[ $1 -eq content_share ]]
+if [[ $1 == screen_share ]]
 then
-  start_demo_meeting 'v2'
+  start_demo_meeting 'v1'
 else
   start_demo_meeting
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.1.26';
+    return '1.1.27';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
Make meeting V2 the default demo meeting app for local demo and Travis integration tests. Also print out the link to meetingV2 in demo serverless deploy script output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
