### PR TITLE
Display meeting id in the demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add guide for content sharing
+- Display meeting id in the demo app
 
 ### Changed
 - Prevent prebuild from increase patch number when publishing to NPM

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -198,6 +198,7 @@
 
     <div id="flow-meeting" class="flow" style="position:absolute;left:15px;top:0;bottom:55px;right:15px">
       <div class="text-muted" style="position:fixed;left:3px;bottom:3px" id="video-uplink-bandwidth"></div>
+      <div class="text-muted" style="position:fixed;left:30%;width:40%;text-align:center;bottom:3px" id="chime-meeting-id"></div>
       <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="video-downlink-bandwidth"></div>
       <audio id="meeting-audio" style="display:none"></audio>
       <div class="container-fluid h-100">

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -167,8 +167,9 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       new AsyncScheduler().start(
         async (): Promise<void> => {
           this.showProgress('progress-authenticate');
+          let chimeMeetingId: string = '';
           try {
-            await this.authenticate();
+            chimeMeetingId = await this.authenticate();
           } catch (error) {
             (document.getElementById(
               'failed-meeting'
@@ -181,6 +182,9 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
           (document.getElementById(
             'meeting-id'
           ) as HTMLSpanElement).innerHTML = `${this.meeting} (${this.region})`;
+          (document.getElementById(
+            'chime-meeting-id'
+          ) as HTMLSpanElement).innerHTML = `${chimeMeetingId}`;
           (document.getElementById('info-meeting') as HTMLSpanElement).innerHTML = this.meeting;
           (document.getElementById('info-name') as HTMLSpanElement).innerHTML = this.name;
           this.switchToFlow('flow-devices');
@@ -1050,7 +1054,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     return value;
   }
 
-  async authenticate(): Promise<void> {
+  async authenticate(): Promise<string> {
     let joinInfo = (await this.joinMeeting()).JoinInfo;
     await this.initializeMeetingSession(
       new MeetingSessionConfiguration(joinInfo.Meeting, joinInfo.Attendee)
@@ -1058,6 +1062,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     const url = new URL(window.location.href);
     url.searchParams.set('m', this.meeting);
     history.replaceState({}, `${this.meeting}`, url.toString());
+    return joinInfo.Meeting.MeetingId;
   }
 
   log(str: string): void {

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -199,6 +199,7 @@
 <div id="flow-meeting" class="flow" style="position:absolute;left:15px;top:0;bottom:55px;right:15px">
   <video id="content-share-video" crossOrigin="anonymous" style="position:fixed;left:0px;bottom:0px;width:320px;height:240px;display:none"></video>
   <div class="text-muted" style="position:fixed;left:3px;bottom:3px" id="video-uplink-bandwidth"></div>
+  <div class="text-muted" style="position:fixed;left:30%;width:40%;text-align:center;bottom:3px" id="chime-meeting-id"></div>
   <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="video-downlink-bandwidth"></div>
   <audio id="meeting-audio" style="display:none"></audio>
   <div class="container-fluid h-100" style="display:flex; flex-flow:column">

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -173,9 +173,10 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
       this.region = (document.getElementById('inputRegion') as HTMLInputElement).value;
       new AsyncScheduler().start(
         async (): Promise<void> => {
+          let chimeMeetingId: string = '';
           this.showProgress('progress-authenticate');
           try {
-            await this.authenticate();
+            chimeMeetingId = await this.authenticate();
           } catch (error) {
             (document.getElementById(
               'failed-meeting'
@@ -188,6 +189,9 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           (document.getElementById(
             'meeting-id'
           ) as HTMLSpanElement).innerHTML = `${this.meeting} (${this.region})`;
+          (document.getElementById(
+            'chime-meeting-id'
+          ) as HTMLSpanElement).innerHTML = `${chimeMeetingId}`;
           (document.getElementById('info-meeting') as HTMLSpanElement).innerHTML = this.meeting;
           (document.getElementById('info-name') as HTMLSpanElement).innerHTML = this.name;
           this.switchToFlow('flow-devices');
@@ -1074,7 +1078,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     }
   }
 
-  async authenticate(): Promise<void> {
+  async authenticate(): Promise<string> {
     let joinInfo = (await this.joinMeeting()).JoinInfo;
     await this.initializeMeetingSession(
       new MeetingSessionConfiguration(joinInfo.Meeting, joinInfo.Attendee)
@@ -1082,6 +1086,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     const url = new URL(window.location.href);
     url.searchParams.set('m', this.meeting);
     history.replaceState({}, `${this.meeting}`, url.toString());
+    return joinInfo.Meeting.MeetingId;
   }
 
   log(str: string): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1298,9 +1298,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -1960,9 +1960,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3448,9 +3448,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pkg-dir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.4';
+    return '1.2.5';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
Populating the meeting id, so that it can be used to filter the log stream on Cloudwatch which has a format "ChimeSDKMeeting_<meeting_id>"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
