### PR TITLE
Prevent prebuild from increase patch number when publishing to NPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Prevent prebuild from increase patch number when publishing to NPM
+
 ## [1.2.1] - 2020-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -17,6 +17,9 @@
     "prebuild:release": "script/prebuild",
     "build:release": "npm run build && npm run lint && npm run check && npm run doc && npm run test:retry",
     "postbuild:release": "script/postbuild",
+    "prebuild:publish": "script/prebuild --publish",
+    "build:publish": "npm run build && npm run lint && npm run check && npm run doc && npm run test:retry",
+    "postbuild:publish": "script/postbuild",
     "predoc": "rm -rf docs && node script/build-guides.js",
     "doc": "node node_modules/typedoc/bin/typedoc --options typedoc.json",
     "postdoc": "node script/update-typedoc-link.js",

--- a/script/prebuild
+++ b/script/prebuild
@@ -25,28 +25,31 @@ elsif commits.size == 1
     STDERR.puts "Error: Does not contain CHANGELOG.md in the commit #{commits[0]}"
     exit 1
   end
-  version_file = 'src/versioning/Versioning.ts'
 
-  #Reset to the base version
-  base_version = JSON.parse(`git show #{`cat .base-branch`.strip}:package.json`)['version']
-  package_json = JSON.parse(File.read('package.json'))
-  package_json['version'] = base_version
-  File.write('package.json', JSON.pretty_generate(package_json))
+  unless ARGV.include?('--publish')
+    version_file = 'src/versioning/Versioning.ts'
 
-  #Increase to new version
-  verbose("npm version patch --no-git-tag-version")
-  package_json = JSON.parse(File.read('package.json'))
-  new_version = package_json['version']
-  puts "Increasing patch version from #{base_version} to #{new_version}"
-  File.write(version_file, File.read(version_file).gsub(/return '[.0-9]+';/, "return '#{new_version}';"))
+    #Reset to the base version
+    base_version = JSON.parse(`git show #{`cat .base-branch`.strip}:package.json`)['version']
+    package_json = JSON.parse(File.read('package.json'))
+    package_json['version'] = base_version
+    File.write('package.json', JSON.pretty_generate(package_json))
 
-  #Pull in npm audit fixes automatically
-  verbose('npm audit fix --force')
+    #Increase to new version
+    verbose("npm version patch --no-git-tag-version")
+    package_json = JSON.parse(File.read('package.json'))
+    new_version = package_json['version']
+    puts "Increasing patch version from #{base_version} to #{new_version}"
+    File.write(version_file, File.read(version_file).gsub(/return '[.0-9]+';/, "return '#{new_version}';"))
 
-  verbose("git add #{version_file}")
-  verbose("git add package.json")
-  verbose("git add package-lock.json")
-  verbose("git commit --amend --no-edit")
+    #Pull in npm audit fixes automatically
+    verbose('npm audit fix --force')
+
+    verbose("git add #{version_file}")
+    verbose("git add package.json")
+    verbose("git add package-lock.json")
+    verbose("git commit --amend --no-edit")
+  end
 elsif commits.size == 2 && `git diff #{commits[0]} #{commits[1]}`.strip == ''
   puts "OK: branch contains empty merge commit followed by one commit on top of #{base}"
 else

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.1';
+    return '1.2.2';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
Prevent prebuild from increase patch number when publishing to NPM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
