### PR TITLE
Change the cloudwatch log message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Prevent prebuild from increase patch number when publishing to NPM
+- Change the cloudwatch log message format
 
 ### Removed
 

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -258,7 +258,8 @@ exports.logs = async (event, context) => {
     if (body.logs.length > 0) {
       for (let i = 0; i < body.logs.length; i++) {
         var log = body.logs[i];
-        var message = `${log.sequenceNumber} AttendeeID: ${body.attendeeId} [${log.logLevel}] ${log.message} ${log.timestampMs}`;
+        var timestampIso = new Date(log.timestampMs).toISOString();
+        var message = `${timestampIso} [${log.sequenceNumber}] [${log.logLevel}] [mid: ${body.meetingId.toString()}] [aid: ${body.attendeeId}]: ${log.message}`;
         logEvents.push({
           "message": message,
           "timestamp": log.timestampMs

--- a/docs/classes/log.html
+++ b/docs/classes/log.html
@@ -102,13 +102,13 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Log<span class="tsd-signature-symbol">(</span>sequenceNumber<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, message<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, timestampMs<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, logLevel<span class="tsd-signature-symbol">: </span><a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="log.html" class="tsd-signature-type">Log</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Log<span class="tsd-signature-symbol">(</span>sequenceNumber<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, message<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, timestampMs<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, logLevel<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="log.html" class="tsd-signature-type">Log</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L6">src/logger/Log.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L4">src/logger/Log.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -123,7 +123,7 @@
 									<h5>timestampMs: <span class="tsd-signature-type">number</span></h5>
 								</li>
 								<li>
-									<h5>logLevel: <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h5>
+									<h5>logLevel: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="log.html" class="tsd-signature-type">Log</a></h4>
@@ -136,10 +136,10 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="loglevel" class="tsd-anchor"></a>
 					<h3>log<wbr>Level</h3>
-					<div class="tsd-signature tsd-kind-icon">log<wbr>Level<span class="tsd-signature-symbol">:</span> <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></div>
+					<div class="tsd-signature tsd-kind-icon">log<wbr>Level<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L11">src/logger/Log.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L9">src/logger/Log.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L9">src/logger/Log.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L7">src/logger/Log.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">sequence<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L8">src/logger/Log.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L6">src/logger/Log.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L10">src/logger/Log.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L8">src/logger/Log.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/logger/Log.ts
+++ b/src/logger/Log.ts
@@ -1,13 +1,11 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import LogLevel from './LogLevel';
-
 export default class Log {
   constructor(
     public sequenceNumber: number,
     public message: string,
     public timestampMs: number,
-    public logLevel: LogLevel
+    public logLevel: string
   ) {}
 }

--- a/src/logger/MeetingSessionPOSTLogger.ts
+++ b/src/logger/MeetingSessionPOSTLogger.ts
@@ -105,7 +105,7 @@ export default class MeetingSessionPOSTLogger {
       return;
     }
     const date = new Date();
-    this.logCapture.push(new Log(this.sequenceNumber, msg, date.getTime(), type));
+    this.logCapture.push(new Log(this.sequenceNumber, msg, date.getTime(), LogLevel[type]));
     this.sequenceNumber += 1;
   }
 }

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.5';
+    return '1.2.6';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
Updated the cloudwatchlog format to
ISO_timestamp [SeqNo] [LogLevel] [mid: MeetingID] [aid: AttendeeId] LogString

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
