### PR TITLE
Use "navigate" instead of "change" for cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ demo locally:
 role with a policy allowing `chime:CreateMeeting`, `chime:DeleteMeeting`, and
 `chime:CreateAttendee`.
 
-2. Change to the `demos/browser` folder: `cd demos/browser`
+2. Navigate to the `demos/browser` folder: `cd demos/browser`
 
 3. Start the demo application: `npm run start`
 


### PR DESCRIPTION
Both "browse" and "navigate" are clearer instructions. My initial reading of "change" was "edit"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
