### PR TITLE
Adds build script to package.json

### DIFF
--- a/demos/components/package.json
+++ b/demos/components/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/src/index.d.ts",
   "scripts": {
+    "build": "webpack",
     "start": "start-storybook"
   },
   "keywords": [],


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**

Adds `build` script that's referenced in `/demos/components/README.md` to `/demos/components/package.json`. In its absence, a `npm ERR! missing script: build` error is thrown. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
