### PR TITLE
Fix markdown formatting in API Overview guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix retry logic for integration test
 - Update typedocs to 0.16 and re-generate doc files
 - Fix issue in Travis script that prevents integration tests from running
+- Fix markdown formatting with backticks in API overview
 
 ## [1.2.1] - 2020-03-20
 

--- a/docs/modules/apioverview.html
+++ b/docs/modules/apioverview.html
@@ -82,7 +82,7 @@
 						<h3>1a. Create a logger</h3>
 					</a>
 					<p>Create a <a href="https://aws.github.io/amazon-chime-sdk-js/classes/consolelogger.html">ConsoleLogger</a> to log everything to the browser console. You can also implement the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html">Logger</a> interface to customize logging behavior.</p>
-					<pre><code><span class="hljs-keyword">const</span> logger = <span class="hljs-keyword">new</span> ConsoleLogger(`<span class="hljs-string">'MeetingLogs'</span>, LogLevel.INFO);`</code></pre>
+					<pre><code><span class="hljs-keyword">const</span> logger = <span class="hljs-keyword">new</span> ConsoleLogger(<span class="hljs-string">'MeetingLogs'</span>, LogLevel.INFO);</code></pre>
 					<a href="#1b-create-a-device-controller" id="1b-create-a-device-controller" style="color: inherit; text-decoration: none;">
 						<h3>1b. Create a device controller</h3>
 					</a>
@@ -106,13 +106,13 @@
 						<h3>2a. Configure the device label trigger (optional)</h3>
 					</a>
 					<p>When obtaining devices to configure, the browser may initially decline to provide device labels due to privacy restrictions. However, without device labels the application user will not be able to select devices by name. When no labels are present, the device-label trigger is run. The default implementation of the device-label trigger requests permission to the mic and camera. If the user grants permission, the device labels will become available.</p>
-					<p>You can override the behavior of the device-label trigger by calling <code>meetingSession.audioVideo.[setDeviceLabelTrigger(trigger)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger)</code>.</p>
+					<p>You can override the behavior of the device-label trigger by calling meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger">setDeviceLabelTrigger(trigger)</a>.</p>
 					<a href="#2b-register-a-device-change-observer-optional" id="2b-register-a-device-change-observer-optional" style="color: inherit; text-decoration: none;">
 						<h3>2b. Register a device-change observer (optional)</h3>
 					</a>
 					<p>You can receive events about changes to available devices by implementing a <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/devicechangeobserver.html">DeviceChangeObserver</a> and registering the observer with the device controller.</p>
-					<p>To add a DeviceChangeObserver, call <code>deviceController.[addDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#adddevicechangeobserver)</code>.</p>
-					<p>To remove a DeviceChangeObserver, call <code>deviceController.[removeDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removedevicechangeobserver)</code>.</p>
+					<p>To add a DeviceChangeObserver, call deviceController.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#adddevicechangeobserver">addDeviceChangeObserver(observer)</a>.</p>
+					<p>To remove a DeviceChangeObserver, call deviceController.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removedevicechangeobserver">removeDeviceChangeObserver(observer)</a>.</p>
 					<p>You can implement the following callbacks:</p>
 					<ul>
 						<li><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/devicechangeobserver.html#audioinputschanged">audioInputsChanged</a>: occurs when audio inputs are changed</li>
@@ -123,44 +123,44 @@
 						<h3>2c. Configure the audio input device</h3>
 					</a>
 					<p>To send audio to the remote attendees, list the available audio input devices and choose an input to use.</p>
-					<p>To retrieve a list of available audio input devices, call <code>meetingSession.audioVideo.[listAudioInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudioinputdevices)</code>.</p>
-					<p>To use the chosen audio input device, call <code>meetingSession.audioVideo.[chooseAudioInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudioinputdevice)</code>.</p>
+					<p>To retrieve a list of available audio input devices, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudioinputdevices">listAudioInputDevices()</a>.</p>
+					<p>To use the chosen audio input device, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudioinputdevice">chooseAudioInputDevice(device)</a>.</p>
 					<a href="#2d-preview-microphone-volume-levels-optional" id="2d-preview-microphone-volume-levels-optional" style="color: inherit; text-decoration: none;">
 						<h3>2d. Preview microphone volume levels (optional)</h3>
 					</a>
 					<p>You can create a WebAudio <a href="https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode">AnalyserNode</a> from the current audio input to generate a display such as a mic indicator. This is useful for allowing attendees to preview their microphone volume level prior to joining the meeting.</p>
-					<p>To create the AnalyserNode, call <code>meetingSession.audioVideo.[createAnalyserNodeForAudioInput()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#createanalysernodeforaudioinput)</code>.</p>
+					<p>To create the AnalyserNode, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput()</a>.</p>
 					<a href="#2e-configure-the-audio-output-device-optional" id="2e-configure-the-audio-output-device-optional" style="color: inherit; text-decoration: none;">
 						<h3>2e. Configure the audio output device (optional)</h3>
 					</a>
 					<p>On browsers that <a href="https://caniuse.com/#search=setSinkId">support setSinkId</a>, you can optionally list the available audio output devices and choose one to use.</p>
-					<p>To retrieve a list of available audio output devices, call <code>meetingSession.audioVideo.[listAudioOutputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudiooutputdevices)</code>.</p>
-					<p>To use the chosen audio output device, call <code>meetingSession.audioVideo.[chooseAudioOutputDevice(deviceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudiooutputdevice)</code>.</p>
-					<a href="#2f-bind-the-audio-output-to-an--element" id="2f-bind-the-audio-output-to-an--element" style="color: inherit; text-decoration: none;">
-						<h3>2f. Bind the audio output to an <audio> element</h3>
+					<p>To retrieve a list of available audio output devices, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudiooutputdevices">listAudioOutputDevices()</a>.</p>
+					<p>To use the chosen audio output device, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudiooutputdevice">chooseAudioOutputDevice(deviceId)</a>.</p>
+					<a href="#2f-bind-the-audio-output-to-an-audio-element" id="2f-bind-the-audio-output-to-an-audio-element" style="color: inherit; text-decoration: none;">
+						<h3>2f. Bind the audio output to an audio element</h3>
 					</a>
 					<p>To hear audio from the remote attendees, bind the audio output device to an HTMLAudioElement in the DOM. The element does not need to be visible; you can hide it with CSS style <code>display: none</code>.</p>
-					<p>To bind the chosen audio output device to a HTMLAudioElement, call <code>meetingSession.audioVideo.[bindAudioElement(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindaudioelement)</code>.</p>
-					<p>To unbind the chosen audio output device, call <code>meetingSession.audioVideo.[unbindAudioElement()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindaudioelement)</code>.</p>
+					<p>To bind the chosen audio output device to a HTMLAudioElement, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindaudioelement">bindAudioElement(element)</a>.</p>
+					<p>To unbind the chosen audio output device, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindaudioelement">unbindAudioElement()</a>.</p>
 					<a href="#2g-configure-the-video-input-device" id="2g-configure-the-video-input-device" style="color: inherit; text-decoration: none;">
 						<h3>2g. Configure the video input device</h3>
 					</a>
 					<p>To send video to remote attendees, list the available video input devices, optionally select video quality settings, and choose a device to use.</p>
-					<p>To get a list of available video input devices, call <code>meetingSession.audioVideo.[listVideoInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listvideoinputdevices)</code>.</p>
-					<p>You can configure the quality of the video that is sent to the remote attendees by calling <code>meetingSession.audioVideo.[chooseVideoInputQuality(width, height, frameRate, maxBandwidthKbps)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputquality)</code>. The changes take effect the next time a video input device is chosen. The default quality is 960x540 @ 15 fps with a maximum uplink bandwidth of 1400 kbps. The maximum supported quality settings are 1280x720 @ 30 fps with a maximum uplink bandwidth of 2400 Kbps. Actual quality achieved may vary throughout the call depending on what the device, system, and network can provide.</p>
-					<p>To use the chosen video input device, call <code>meetingSession.audioVideo.[chooseVideoInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice)</code>.</p>
-					<a href="#2h-preview-local-camera-in-a--element-optional" id="2h-preview-local-camera-in-a--element-optional" style="color: inherit; text-decoration: none;">
-						<h3>2h. Preview local camera in a <video> element (optional)</h3>
+					<p>To get a list of available video input devices, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listvideoinputdevices">listVideoInputDevices()</a>.</p>
+					<p>You can configure the quality of the video that is sent to the remote attendees by calling meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputquality">chooseVideoInputQuality(width, height, frameRate, maxBandwidthKbps)</a>. The changes take effect the next time a video input device is chosen. The default quality is 960x540 @ 15 fps with a maximum uplink bandwidth of 1400 kbps. The maximum supported quality settings are 1280x720 @ 30 fps with a maximum uplink bandwidth of 2400 Kbps. Actual quality achieved may vary throughout the call depending on what the device, system, and network can provide.</p>
+					<p>To use the chosen video input device, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice">chooseVideoInputDevice(device)</a>.</p>
+					<a href="#2h-preview-local-camera-in-a-video-element-optional" id="2h-preview-local-camera-in-a-video-element-optional" style="color: inherit; text-decoration: none;">
+						<h3>2h. Preview local camera in a video element (optional)</h3>
 					</a>
 					<p>Before the session is started, you can start a preview of the video in an HTMLVideoElement in the DOM.</p>
-					<p>To start video preview, call <code>meetingSession.audioVideo.[startVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice)</code>.</p>
-					<p>To stop video preview, call <code>meetingSession.audioVideo.[stopVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopvideopreviewforvideoinput)</code>.</p>
+					<p>To start video preview, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice">startVideoPreviewForVideoInput(element)</a>.</p>
+					<p>To stop video preview, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput(element)</a>.</p>
 					<a href="#3-register-an-audio-video-observer" id="3-register-an-audio-video-observer" style="color: inherit; text-decoration: none;">
 						<h2>3. Register an audio-video observer</h2>
 					</a>
 					<p>You can receive audio and video events by implementing the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html">AudioVideoObserver</a> interface and registering the observer with the meeting session.</p>
-					<p>To add an AudioVideoObserver, call <code>meetingSession.audioVideo.[addObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addobserver)</code>.</p>
-					<p>To remove an AudioVideoObserver, call <code>meetingSession.audioVideo.[removeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removeobserver)</code>.</p>
+					<p>To add an AudioVideoObserver, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addobserver">addObserver(observer)</a>.</p>
+					<p>To remove an AudioVideoObserver, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removeobserver">removeObserver(observer)</a>.</p>
 					<p>You should implement the following key observer callbacks:</p>
 					<ul>
 						<li><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#audiovideodidstart">audioVideoDidStart</a>: occurs when the audio-video session finishes connecting</li>
@@ -187,8 +187,8 @@
 						<h2>4. Start and stop the session</h2>
 					</a>
 					<p>Call this API after doing pre-requisite configuration (See previous sections). Otherwise, there will not be working audio and video.</p>
-					<p>To start the meeting session, call <code>meetingSession.audioVideo.</code><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#start"><code>start()</code></a>. This method will initialize all underlying components, set up connections, and immediately start sending and receiving audio.</p>
-					<p>To stop the meeting session, call <code>meetingSession.audioVideo.[stop()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stop)</code>.</p>
+					<p>To start the meeting session, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#start">start()</a>. This method will initialize all underlying components, set up connections, and immediately start sending and receiving audio.</p>
+					<p>To stop the meeting session, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stop">stop()</a>.</p>
 					<a href="#5-build-a-roster-of-participants-using-the-real-time-api" id="5-build-a-roster-of-participants-using-the-real-time-api" style="color: inherit; text-decoration: none;">
 						<h2>5. Build a roster of participants using the real-time API</h2>
 					</a>
@@ -200,26 +200,26 @@
 						<h3>5a. Subscribe to attendee presence changes</h3>
 					</a>
 					<p>To learn when attendees join or leave, subscribe to the attendee ID presence changes. The callback provides both the attendee ID and external user ID from <a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">chime:CreateAttendee</a> so that you may map between the two IDs.</p>
-					<p>To subscribe to attendee presence changes, call <code>meetingSession.audioVideo.[realtimeSubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoattendeeidpresence)</code>.</p>
-					<p>To unsubscribe to attendee presence changes, call <code>meetingSession.audioVideo.[realtimeUnsubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetoattendeeidpresence)</code>.</p>
+					<p>To subscribe to attendee presence changes, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoattendeeidpresence">realtimeSubscribeToAttendeeIdPresence(callback)</a>.</p>
+					<p>To unsubscribe to attendee presence changes, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetoattendeeidpresence">realtimeUnsubscribeToAttendeeIdPresence(callback)</a>.</p>
 					<a href="#5b-subscribe-to-volume-indicators" id="5b-subscribe-to-volume-indicators" style="color: inherit; text-decoration: none;">
 						<h3>5b. Subscribe to volume indicators</h3>
 					</a>
 					<p>To show speaker volume, mute state, and signal strength for each attendee, subscribe to volume indicators for each attendee ID. You should subscribe and unsubscribe to attendee volume indicators as part of the attendee ID presence callback.</p>
 					<p>Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on a scale of 0 to 1 (full packet loss to no packet loss). You can use the signal strength of remote attendees to show an indication of whether an attendee is experiencing packet loss and thus may be unable to communicate at the moment.</p>
-					<p>To subscribe to an attendee’s volume indicator, call <code>meetingSession.audioVideo.[realtimeSubscribeToVolumeIndicator(attendeeId, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator)</code>.</p>
-					<p>To unsubscribe from an attendee’s volume indicator, call <code>meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator)</code>.</p>
+					<p>To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator(attendeeId, callback)</a>.</p>
+					<p>To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator(attendeeId)</a>.</p>
 					<a href="#5c-signal-strength-change-optional" id="5c-signal-strength-change-optional" style="color: inherit; text-decoration: none;">
 						<h3>5c. Signal strength change (optional)</h3>
 					</a>
-					<p>To subscribe to the local attendee’s signal strength changes, call <code>meetingSession.audioVideo.[realtimeSubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetolocalsignalstrengthchange)</code>.</p>
-					<p>To unsubscribe from the local attendee’s signal strength changes, call <code>meetingSession.audioVideo.[realtimeUnsubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetolocalsignalstrengthchange)</code>.</p>
+					<p>To subscribe to the local attendee’s signal strength changes, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetolocalsignalstrengthchange">realtimeSubscribeToLocalSignalStrengthChange(callback)</a>.</p>
+					<p>To unsubscribe from the local attendee’s signal strength changes, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetolocalsignalstrengthchange">realtimeUnsubscribeToLocalSignalStrengthChange(callback)</a>.</p>
 					<a href="#5d-subscribe-to-an-active-speaker-detector-optional" id="5d-subscribe-to-an-active-speaker-detector-optional" style="color: inherit; text-decoration: none;">
 						<h3>5d. Subscribe to an active-speaker detector (optional)</h3>
 					</a>
 					<p>If you are interested in detecting the active speaker (e.g. to display the active speaker’s video as a large, central tile), subscribe to the active-speaker detector with an active speaker policy such as the <a href="https://aws.github.io/amazon-chime-sdk-js/classes/defaultactivespeakerpolicy.html">DefaultActiveSpeakerPolicy</a>. You can receive updates when the list of active speakers changes. The list is ordered most active to least active. Active speaker policies use volume indicator changes to determine the prominence of each speaker over time.</p>
-					<p>To subscribe to active speaker updates, call <code>meetingSession.audioVideo.[subscribeToActiveSpeakerDetector(policy, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#subscribetoactivespeakerdetector)</code>.</p>
-					<p>To unsubscribe from active speaker updates, call <code>meetingSession.audioVideo.[unsubscribeFromActiveSpeakerDetector(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unsubscribefromactivespeakerdetector)</code>.</p>
+					<p>To subscribe to active speaker updates, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#subscribetoactivespeakerdetector">subscribeToActiveSpeakerDetector(policy, callback)</a>.</p>
+					<p>To unsubscribe from active speaker updates, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unsubscribefromactivespeakerdetector">unsubscribeFromActiveSpeakerDetector(callback)</a>.</p>
 					<a href="#6-mute-and-unmute-microphone-audio-with-the-real-time-api" id="6-mute-and-unmute-microphone-audio-with-the-real-time-api" style="color: inherit; text-decoration: none;">
 						<h2>6. Mute and unmute microphone audio with the real-time API</h2>
 					</a>
@@ -229,19 +229,19 @@
 					<a href="#6a-mute-and-unmute-audio" id="6a-mute-and-unmute-audio" style="color: inherit; text-decoration: none;">
 						<h3>6a. Mute and unmute audio</h3>
 					</a>
-					<p>To mute the local attendee’s audio, call <code>meetingSession.audioVideo.[realtimeMuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimemutelocalaudio)</code>.</p>
-					<p>To unmute the local attendee’s audio, call <code>meetingSession.audioVideo.[realtimeUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunmutelocalaudio)</code>.</p>
-					<p>To determine if the local attendee’s audio is muted, call <code>meetingSession.audioVideo.[realtimeIsLocalAudioMuted()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeislocalaudiomuted)</code>.</p>
-					<p>To subscribe to changes in the local attendee’s audio mute state, call <code>meetingSession.audioVideo.[realtimeSubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetomuteandunmutelocalaudio)</code>.</p>
-					<p>To unsubscribe from changes in the local attendee’s audio mute state, call <code>meetingSession.audioVideo.[realtimeUnsubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetomuteandunmutelocalaudio)</code>.</p>
+					<p>To mute the local attendee’s audio, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio()</a>.</p>
+					<p>To unmute the local attendee’s audio, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio()</a>.</p>
+					<p>To determine if the local attendee’s audio is muted, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted()</a>.</p>
+					<p>To subscribe to changes in the local attendee’s audio mute state, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetomuteandunmutelocalaudio">realtimeSubscribeToMuteAndUnmuteLocalAudio(callback)</a>.</p>
+					<p>To unsubscribe from changes in the local attendee’s audio mute state, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetomuteandunmutelocalaudio">realtimeUnsubscribeToMuteAndUnmuteLocalAudio(callback)</a>.</p>
 					<a href="#6b-prevent-a-local-attendee-from-unmuting-audio-optional" id="6b-prevent-a-local-attendee-from-unmuting-audio-optional" style="color: inherit; text-decoration: none;">
 						<h3>6b. Prevent a local attendee from unmuting audio (optional)</h3>
 					</a>
 					<p>Depending on the type of meeting application you are building, you may want to temporarily prevent the local attendee from unmuting (e.g. to avoid disruption if someone is presenting). If so, use the methods below rather than keeping track of your own can-unmute state.</p>
-					<p>To set whether or not the local attendee can unmute, call <code>meetingSession.audioVideo.[realtimeSetCanUnmuteLocalAudio(canUnmute)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio)</code>.</p>
-					<p>To determine whether or not the local attendee can unmute, call <code>meetingSession.audioVideo.[realtimeCanUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimecanunmutelocalaudio)</code>.</p>
-					<p>To subscribe to changes in whether or not the local attendee can unmute, call <code>meetingSession.audioVideo.[realtimeSubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetosetcanunmutelocalaudio)</code>.</p>
-					<p>To unsubscribe from changes in whether or not the local attendee can unmute, call <code>meetingSession.audioVideo.[realtimeUnsubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetosetcanunmutelocalaudio)</code>.</p>
+					<p>To set whether or not the local attendee can unmute, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio(canUnmute)</a>.</p>
+					<p>To determine whether or not the local attendee can unmute, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio()</a>.</p>
+					<p>To subscribe to changes in whether or not the local attendee can unmute, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetosetcanunmutelocalaudio">realtimeSubscribeToSetCanUnmuteLocalAudio(callback)</a>.</p>
+					<p>To unsubscribe from changes in whether or not the local attendee can unmute, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetosetcanunmutelocalaudio">realtimeUnsubscribeToSetCanUnmuteLocalAudio(callback)</a>.</p>
 					<a href="#7-share-and-display-video" id="7-share-and-display-video" style="color: inherit; text-decoration: none;">
 						<h2>7. Share and display video</h2>
 					</a>
@@ -251,27 +251,27 @@
 						<h3>7a. Share local video</h3>
 					</a>
 					<p>After choosing the video input and starting the meeting session, you can share the local attendee’s video with remote attendees.</p>
-					<p>To start sharing video with others, call <code>meetingSession.audioVideo.[startLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startlocalvideotile)</code>.</p>
-					<p>To stop sharing video with others, call <code>meetingSession.audioVideo.[stopLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stoplocalvideotile)</code>.</p>
+					<p>To start sharing video with others, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startlocalvideotile">startLocalVideoTile()</a>.</p>
+					<p>To stop sharing video with others, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stoplocalvideotile">stopLocalVideoTile()</a>.</p>
 					<a href="#7b-display-local-and-remote-video" id="7b-display-local-and-remote-video" style="color: inherit; text-decoration: none;">
 						<h3>7b. Display local and remote video</h3>
 					</a>
-					<p>You are responsible for maintaining HTMLVideoElement objects in the DOM and arranging their layout within the web page. To display a video, you must handle the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved">videoTileWasRemoved</a> callbacks in an <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html">AudioVideoObserver</a>. In the implementation of <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a>, bind the tile ID from the provided VideoTileState with the HTMLVideoElement in your DOM by calling <code>meetingSession.audioVideo.[bindVideoElement(tileId, videoElement)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindvideoelement)</code>.</p>
-					<p>To unbind a tile, call <code>meetingSession.audioVideo.[unbindVideoElement(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindvideoelement)</code>.</p>
+					<p>You are responsible for maintaining HTMLVideoElement objects in the DOM and arranging their layout within the web page. To display a video, you must handle the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved">videoTileWasRemoved</a> callbacks in an <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html">AudioVideoObserver</a>. In the implementation of <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a>, bind the tile ID from the provided VideoTileState with the HTMLVideoElement in your DOM by calling meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindvideoelement">bindVideoElement(tileId, videoElement)</a>.</p>
+					<p>To unbind a tile, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindvideoelement">unbindVideoElement(tileId)</a>.</p>
 					<a href="#7c-pause-and-unpause-video-optional" id="7c-pause-and-unpause-video-optional" style="color: inherit; text-decoration: none;">
 						<h3>7c. Pause and unpause video (optional)</h3>
 					</a>
 					<p>Video tiles may be paused individually. The server will not send paused video streams to the attendee requesting the pause. Pausing video does not affect remote attendees.</p>
-					<p>To pause video, call <code>meetingSession.audioVideo.</code><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausevideotile"><code>pauseVideoTile(tileId)</code></a>.</p>
-					<p>To resume a paused video, call <code>meetingSession.audioVideo.[unpauseVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausevideotile)</code>.</p>
+					<p>To pause video, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausevideotile">pauseVideoTile(tileId)</a>.</p>
+					<p>To resume a paused video, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausevideotile">unpauseVideoTile(tileId)</a>.</p>
 					<a href="#7d-find-video-tiles-optional" id="7d-find-video-tiles-optional" style="color: inherit; text-decoration: none;">
 						<h3>7d. Find video tiles (optional)</h3>
 					</a>
 					<p>Aside from the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved">videoTileWasRemoved</a> callbacks in an <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html">AudioVideoObserver</a>, video tile information can be gathered from the following methods.</p>
-					<p>To get all video tiles, call <code>meetingSession.audioVideo.[getAllVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallvideotiles)</code>.</p>
-					<p>To get all remote attendees’ video tiles, call <code>meetingSession.audioVideo.[getAllRemoteVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallremotevideotiles)</code>.</p>
-					<p>To get the local attendee’s video tile, call <code>meetingSession.audioVideo.[getLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getlocalvideotile)</code>.</p>
-					<p>To get a video tile, call <code>meetingSession.audioVideo.[getVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getvideotile)</code>.</p>
+					<p>To get all video tiles, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallvideotiles">getAllVideoTiles()</a>.</p>
+					<p>To get all remote attendees’ video tiles, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallremotevideotiles">getAllRemoteVideoTiles()</a>.</p>
+					<p>To get the local attendee’s video tile, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getlocalvideotile">getLocalVideoTile()</a>.</p>
+					<p>To get a video tile, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getvideotile">getVideoTile(tileId)</a>.</p>
 					<a href="#8-share-screen-and-other-content-optional" id="8-share-screen-and-other-content-optional" style="color: inherit; text-decoration: none;">
 						<h2>8. Share screen and other content (optional)</h2>
 					</a>
@@ -280,17 +280,17 @@
 					<a href="#8a-start-and-stop-the-content-share" id="8a-start-and-stop-the-content-share" style="color: inherit; text-decoration: none;">
 						<h3>8a. Start and stop the content share</h3>
 					</a>
-					<p>To start the content share, call <code>meetingSession.audioVideo.[startContentShare(stream)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare)</code>.</p>
-					<p>To start sharing screen as a content share, call <code>meetingSession.audioVideo.[startContentShareFromScreenCapture(sourceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentsharefromscreencapture)</code>.</p>
-					<p>To stop the content share, call <code>meetingSession.audioVideo.[stopContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopcontentshare)</code>.</p>
-					<p>To pause content share, call <code>meetingSession.audioVideo.[pauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausecontentshare)</code>.</p>
-					<p>To resume content share, call <code>meetingSession.audioVideo.[unpauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausecontentshare)</code>.</p>
+					<p>To start the content share, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare">startContentShare(stream)</a>.</p>
+					<p>To start sharing screen as a content share, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture(sourceId)</a>.</p>
+					<p>To stop the content share, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopcontentshare">stopContentShare()</a>.</p>
+					<p>To pause content share, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausecontentshare">pauseContentShare()</a>.</p>
+					<p>To resume content share, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausecontentshare">unpauseContentShare()</a>.</p>
 					<a href="#8b-register-a-content-share-observer" id="8b-register-a-content-share-observer" style="color: inherit; text-decoration: none;">
 						<h3>8b. Register a content share observer</h3>
 					</a>
 					<p>You can receive events about the content share by implementing a <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/contentshareobserver.html">ContentShareObserver</a> and adding the observer to the meeting session.</p>
-					<p>To add a ContentShareObserver, call <code>meetingSession.audioVideo.</code><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addcontentshareobserver"><code>addContentShareObserver(observer)</code></a>.</p>
-					<p>To remove a ContentShareObserver, call <code>meetingSession.audioVideo.[removeContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removecontentshareobserver)</code>.</p>
+					<p>To add a ContentShareObserver, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addcontentshareobserver">addContentShareObserver(observer)</a>.</p>
+					<p>To remove a ContentShareObserver, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removecontentshareobserver">removeContentShareObserver(observer)</a>.</p>
 					<p>You can implement the following callbacks:</p>
 					<ul>
 						<li><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/contentshareobserver.html#contentsharedidstart">contentShareDidStart</a>: occurs when a content share session is started</li>

--- a/guides/03_API_Overview.md
+++ b/guides/03_API_Overview.md
@@ -11,7 +11,7 @@ The [MeetingSession](https://aws.github.io/amazon-chime-sdk-js/interfaces/meetin
 Create a [ConsoleLogger](https://aws.github.io/amazon-chime-sdk-js/classes/consolelogger.html) to log everything to the browser console. You can also implement the [Logger](https://aws.github.io/amazon-chime-sdk-js/interfaces/logger.html) interface to customize logging behavior.
 
 ```
-const logger = new ConsoleLogger(`'MeetingLogs', LogLevel.INFO);`
+const logger = new ConsoleLogger('MeetingLogs', LogLevel.INFO);
 ```
 
 ### 1b. Create a device controller
@@ -46,15 +46,15 @@ Before starting the meeting session, you should configure audio and video device
 
 When obtaining devices to configure, the browser may initially decline to provide device labels due to privacy restrictions. However, without device labels the application user will not be able to select devices by name. When no labels are present, the device-label trigger is run. The default implementation of the device-label trigger requests permission to the mic and camera. If the user grants permission, the device labels will become available.
 
-You can override the behavior of the device-label trigger by calling `meetingSession.audioVideo.[setDeviceLabelTrigger(trigger)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger)`.
+You can override the behavior of the device-label trigger by calling meetingSession.audioVideo.[setDeviceLabelTrigger(trigger)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger).
 
 ### 2b. Register a device-change observer (optional)
 
 You can receive events about changes to available devices by implementing a [DeviceChangeObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/devicechangeobserver.html) and registering the observer with the device controller.
 
-To add a DeviceChangeObserver, call `deviceController.[addDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#adddevicechangeobserver)`.
+To add a DeviceChangeObserver, call deviceController.[addDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#adddevicechangeobserver).
 
-To remove a DeviceChangeObserver, call `deviceController.[removeDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removedevicechangeobserver)`.
+To remove a DeviceChangeObserver, call deviceController.[removeDeviceChangeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removedevicechangeobserver).
 
 You can implement the following callbacks:
 
@@ -66,57 +66,57 @@ You can implement the following callbacks:
 
 To send audio to the remote attendees, list the available audio input devices and choose an input to use.
 
-To retrieve a list of available audio input devices, call `meetingSession.audioVideo.[listAudioInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudioinputdevices)`.
+To retrieve a list of available audio input devices, call meetingSession.audioVideo.[listAudioInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudioinputdevices).
 
-To use the chosen audio input device, call `meetingSession.audioVideo.[chooseAudioInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudioinputdevice)`.
+To use the chosen audio input device, call meetingSession.audioVideo.[chooseAudioInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudioinputdevice).
 
 ### 2d. Preview microphone volume levels (optional)
 
 You can create a WebAudio [AnalyserNode](https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode) from the current audio input to generate a display such as a mic indicator. This is useful for allowing attendees to preview their microphone volume level prior to joining the meeting.
 
-To create the AnalyserNode, call `meetingSession.audioVideo.[createAnalyserNodeForAudioInput()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#createanalysernodeforaudioinput)`.
+To create the AnalyserNode, call meetingSession.audioVideo.[createAnalyserNodeForAudioInput()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#createanalysernodeforaudioinput).
 
 ### 2e. Configure the audio output device (optional)
 
 On browsers that [support setSinkId](https://caniuse.com/#search=setSinkId), you can optionally list the available audio output devices and choose one to use.
 
-To retrieve a list of available audio output devices, call `meetingSession.audioVideo.[listAudioOutputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudiooutputdevices)`.
+To retrieve a list of available audio output devices, call meetingSession.audioVideo.[listAudioOutputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listaudiooutputdevices).
 
-To use the chosen audio output device, call `meetingSession.audioVideo.[chooseAudioOutputDevice(deviceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudiooutputdevice)`.
+To use the chosen audio output device, call meetingSession.audioVideo.[chooseAudioOutputDevice(deviceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#chooseaudiooutputdevice).
 
-### 2f. Bind the audio output to an <audio> element
+### 2f. Bind the audio output to an audio element
 
 To hear audio from the remote attendees, bind the audio output device to an HTMLAudioElement in the DOM. The element does not need to be visible; you can hide it with CSS style `display: none`.
 
-To bind the chosen audio output device to a HTMLAudioElement, call `meetingSession.audioVideo.[bindAudioElement(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindaudioelement)`.
+To bind the chosen audio output device to a HTMLAudioElement, call meetingSession.audioVideo.[bindAudioElement(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindaudioelement).
 
-To unbind the chosen audio output device, call `meetingSession.audioVideo.[unbindAudioElement()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindaudioelement)`.
+To unbind the chosen audio output device, call meetingSession.audioVideo.[unbindAudioElement()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindaudioelement).
 
 ### 2g. Configure the video input device
 
 To send video to remote attendees, list the available video input devices, optionally select video quality settings, and choose a device to use.
 
-To get a list of available video input devices, call `meetingSession.audioVideo.[listVideoInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listvideoinputdevices)`.
+To get a list of available video input devices, call meetingSession.audioVideo.[listVideoInputDevices()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#listvideoinputdevices).
 
-You can configure the quality of the video that is sent to the remote attendees by calling `meetingSession.audioVideo.[chooseVideoInputQuality(width, height, frameRate, maxBandwidthKbps)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputquality)`. The changes take effect the next time a video input device is chosen. The default quality is 960x540 @ 15 fps with a maximum uplink bandwidth of 1400 kbps. The maximum supported quality settings are 1280x720 @ 30 fps with a maximum uplink bandwidth of 2400 Kbps. Actual quality achieved may vary throughout the call depending on what the device, system, and network can provide.
+You can configure the quality of the video that is sent to the remote attendees by calling meetingSession.audioVideo.[chooseVideoInputQuality(width, height, frameRate, maxBandwidthKbps)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputquality). The changes take effect the next time a video input device is chosen. The default quality is 960x540 @ 15 fps with a maximum uplink bandwidth of 1400 kbps. The maximum supported quality settings are 1280x720 @ 30 fps with a maximum uplink bandwidth of 2400 Kbps. Actual quality achieved may vary throughout the call depending on what the device, system, and network can provide.
 
-To use the chosen video input device, call `meetingSession.audioVideo.[chooseVideoInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice)`.
+To use the chosen video input device, call meetingSession.audioVideo.[chooseVideoInputDevice(device)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice).
 
-### 2h. Preview local camera in a <video> element (optional)
+### 2h. Preview local camera in a video element (optional)
 
 Before the session is started, you can start a preview of the video in an HTMLVideoElement in the DOM.
 
-To start video preview, call `meetingSession.audioVideo.[startVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice)`.
+To start video preview, call meetingSession.audioVideo.[startVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#choosevideoinputdevice).
 
-To stop video preview, call `meetingSession.audioVideo.[stopVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopvideopreviewforvideoinput)`.
+To stop video preview, call meetingSession.audioVideo.[stopVideoPreviewForVideoInput(element)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopvideopreviewforvideoinput).
 
 ## 3. Register an audio-video observer
 
 You can receive audio and video events by implementing the [AudioVideoObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html) interface and registering the observer with the meeting session.
 
-To add an AudioVideoObserver, call `meetingSession.audioVideo.[addObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addobserver)`.
+To add an AudioVideoObserver, call meetingSession.audioVideo.[addObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addobserver).
 
-To remove an AudioVideoObserver, call `meetingSession.audioVideo.[removeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removeobserver)`.
+To remove an AudioVideoObserver, call meetingSession.audioVideo.[removeObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removeobserver).
 
 You should implement the following key observer callbacks:
 
@@ -144,9 +144,9 @@ You may optionally listen to the following callbacks to monitor aspects of conne
 
 Call this API after doing pre-requisite configuration (See previous sections). Otherwise, there will not be working audio and video.
 
-To start the meeting session, call `meetingSession.audioVideo.`[`start()`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#start). This method will initialize all underlying components, set up connections, and immediately start sending and receiving audio.
+To start the meeting session, call meetingSession.audioVideo.[start()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#start). This method will initialize all underlying components, set up connections, and immediately start sending and receiving audio.
 
-To stop the meeting session, call `meetingSession.audioVideo.[stop()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stop)`.
+To stop the meeting session, call meetingSession.audioVideo.[stop()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stop).
 
 ## 5. Build a roster of participants using the real-time API
 
@@ -162,9 +162,9 @@ Real-time volume indicator callbacks are called at a rate of 5 updates per secon
 
 To learn when attendees join or leave, subscribe to the attendee ID presence changes. The callback provides both the attendee ID and external user ID from [chime:CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html) so that you may map between the two IDs.
 
-To subscribe to attendee presence changes, call `meetingSession.audioVideo.[realtimeSubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoattendeeidpresence)`.
+To subscribe to attendee presence changes, call meetingSession.audioVideo.[realtimeSubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetoattendeeidpresence).
 
-To unsubscribe to attendee presence changes, call `meetingSession.audioVideo.[realtimeUnsubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetoattendeeidpresence)`.
+To unsubscribe to attendee presence changes, call meetingSession.audioVideo.[realtimeUnsubscribeToAttendeeIdPresence(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetoattendeeidpresence).
 
 ### 5b. Subscribe to volume indicators
 
@@ -172,23 +172,23 @@ To show speaker volume, mute state, and signal strength for each attendee, subsc
 
 Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on a scale of 0 to 1 (full packet loss to no packet loss). You can use the signal strength of remote attendees to show an indication of whether an attendee is experiencing packet loss and thus may be unable to communicate at the moment.
 
-To subscribe to an attendee’s volume indicator, call `meetingSession.audioVideo.[realtimeSubscribeToVolumeIndicator(attendeeId, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator)`.
+To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeSubscribeToVolumeIndicator(attendeeId, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator).
 
-To unsubscribe from an attendee’s volume indicator, call `meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator)`.
+To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator).
 
 ### 5c. Signal strength change (optional)
 
-To subscribe to the local attendee’s signal strength changes, call `meetingSession.audioVideo.[realtimeSubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetolocalsignalstrengthchange)`.
+To subscribe to the local attendee’s signal strength changes, call meetingSession.audioVideo.[realtimeSubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetolocalsignalstrengthchange).
 
-To unsubscribe from the local attendee’s signal strength changes, call `meetingSession.audioVideo.[realtimeUnsubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetolocalsignalstrengthchange)`.
+To unsubscribe from the local attendee’s signal strength changes, call meetingSession.audioVideo.[realtimeUnsubscribeToLocalSignalStrengthChange(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetolocalsignalstrengthchange).
 
 ### 5d. Subscribe to an active-speaker detector (optional)
 
 If you are interested in detecting the active speaker (e.g. to display the active speaker’s video as a large, central tile), subscribe to the active-speaker detector with an active speaker policy such as the [DefaultActiveSpeakerPolicy](https://aws.github.io/amazon-chime-sdk-js/classes/defaultactivespeakerpolicy.html). You can receive updates when the list of active speakers changes. The list is ordered most active to least active. Active speaker policies use volume indicator changes to determine the prominence of each speaker over time.
 
-To subscribe to active speaker updates, call `meetingSession.audioVideo.[subscribeToActiveSpeakerDetector(policy, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#subscribetoactivespeakerdetector)`.
+To subscribe to active speaker updates, call meetingSession.audioVideo.[subscribeToActiveSpeakerDetector(policy, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#subscribetoactivespeakerdetector).
 
-To unsubscribe from active speaker updates, call `meetingSession.audioVideo.[unsubscribeFromActiveSpeakerDetector(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unsubscribefromactivespeakerdetector)`.
+To unsubscribe from active speaker updates, call meetingSession.audioVideo.[unsubscribeFromActiveSpeakerDetector(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unsubscribefromactivespeakerdetector).
 
 ## 6. Mute and unmute microphone audio with the real-time API
 
@@ -200,27 +200,27 @@ To ensure that attendee privacy is respected, pay close attention that the UI co
 
 ### 6a. Mute and unmute audio
 
-To mute the local attendee’s audio, call `meetingSession.audioVideo.[realtimeMuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimemutelocalaudio)`.
+To mute the local attendee’s audio, call meetingSession.audioVideo.[realtimeMuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimemutelocalaudio).
 
-To unmute the local attendee’s audio, call `meetingSession.audioVideo.[realtimeUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunmutelocalaudio)`.
+To unmute the local attendee’s audio, call meetingSession.audioVideo.[realtimeUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunmutelocalaudio).
 
-To determine if the local attendee’s audio is muted, call `meetingSession.audioVideo.[realtimeIsLocalAudioMuted()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeislocalaudiomuted)`.
+To determine if the local attendee’s audio is muted, call meetingSession.audioVideo.[realtimeIsLocalAudioMuted()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeislocalaudiomuted).
 
-To subscribe to changes in the local attendee’s audio mute state, call `meetingSession.audioVideo.[realtimeSubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetomuteandunmutelocalaudio)`.
+To subscribe to changes in the local attendee’s audio mute state, call meetingSession.audioVideo.[realtimeSubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetomuteandunmutelocalaudio).
 
-To unsubscribe from changes in the local attendee’s audio mute state, call `meetingSession.audioVideo.[realtimeUnsubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetomuteandunmutelocalaudio)`.
+To unsubscribe from changes in the local attendee’s audio mute state, call meetingSession.audioVideo.[realtimeUnsubscribeToMuteAndUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetomuteandunmutelocalaudio).
 
 ### 6b. Prevent a local attendee from unmuting audio (optional)
 
 Depending on the type of meeting application you are building, you may want to temporarily prevent the local attendee from unmuting (e.g. to avoid disruption if someone is presenting). If so, use the methods below rather than keeping track of your own can-unmute state.
 
-To set whether or not the local attendee can unmute, call `meetingSession.audioVideo.[realtimeSetCanUnmuteLocalAudio(canUnmute)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio)`.
+To set whether or not the local attendee can unmute, call meetingSession.audioVideo.[realtimeSetCanUnmuteLocalAudio(canUnmute)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio).
 
-To determine whether or not the local attendee can unmute, call `meetingSession.audioVideo.[realtimeCanUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimecanunmutelocalaudio)`.
+To determine whether or not the local attendee can unmute, call meetingSession.audioVideo.[realtimeCanUnmuteLocalAudio()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimecanunmutelocalaudio).
 
-To subscribe to changes in whether or not the local attendee can unmute, call `meetingSession.audioVideo.[realtimeSubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetosetcanunmutelocalaudio)`.
+To subscribe to changes in whether or not the local attendee can unmute, call meetingSession.audioVideo.[realtimeSubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetosetcanunmutelocalaudio).
 
-To unsubscribe from changes in whether or not the local attendee can unmute, call `meetingSession.audioVideo.[realtimeUnsubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetosetcanunmutelocalaudio)`.
+To unsubscribe from changes in whether or not the local attendee can unmute, call meetingSession.audioVideo.[realtimeUnsubscribeToSetCanUnmuteLocalAudio(callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribetosetcanunmutelocalaudio).
 
 ## 7. Share and display video
 
@@ -232,35 +232,35 @@ Local video is automatically displayed horizontally-mirrored by convention.
 
 After choosing the video input and starting the meeting session, you can share the local attendee’s video with remote attendees.
 
-To start sharing video with others, call `meetingSession.audioVideo.[startLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startlocalvideotile)`.
+To start sharing video with others, call meetingSession.audioVideo.[startLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startlocalvideotile).
 
-To stop sharing video with others, call `meetingSession.audioVideo.[stopLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stoplocalvideotile)`.
+To stop sharing video with others, call meetingSession.audioVideo.[stopLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stoplocalvideotile).
 
 ### 7b. Display local and remote video
 
-You are responsible for maintaining HTMLVideoElement objects in the DOM and arranging their layout within the web page. To display a video, you must handle the [videoTileDidUpdate](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate) and [videoTileWasRemoved](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved) callbacks in an [AudioVideoObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html). In the implementation of [videoTileDidUpdate](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate), bind the tile ID from the provided VideoTileState with the HTMLVideoElement in your DOM by calling `meetingSession.audioVideo.[bindVideoElement(tileId, videoElement)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindvideoelement)`.
+You are responsible for maintaining HTMLVideoElement objects in the DOM and arranging their layout within the web page. To display a video, you must handle the [videoTileDidUpdate](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate) and [videoTileWasRemoved](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved) callbacks in an [AudioVideoObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html). In the implementation of [videoTileDidUpdate](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate), bind the tile ID from the provided VideoTileState with the HTMLVideoElement in your DOM by calling meetingSession.audioVideo.[bindVideoElement(tileId, videoElement)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#bindvideoelement).
 
-To unbind a tile, call `meetingSession.audioVideo.[unbindVideoElement(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindvideoelement)`.
+To unbind a tile, call meetingSession.audioVideo.[unbindVideoElement(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unbindvideoelement).
 
 ### 7c. Pause and unpause video (optional)
 
 Video tiles may be paused individually. The server will not send paused video streams to the attendee requesting the pause. Pausing video does not affect remote attendees.
 
-To pause video, call `meetingSession.audioVideo.`[`pauseVideoTile(tileId)`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausevideotile).
+To pause video, call meetingSession.audioVideo.[pauseVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausevideotile).
 
-To resume a paused video, call `meetingSession.audioVideo.[unpauseVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausevideotile)`.
+To resume a paused video, call meetingSession.audioVideo.[unpauseVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausevideotile).
 
 ### 7d. Find video tiles (optional)
 
 Aside from the [videoTileDidUpdate](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotiledidupdate) and [videoTileWasRemoved](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videotilewasremoved) callbacks in an [AudioVideoObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html), video tile information can be gathered from the following methods.
 
-To get all video tiles, call `meetingSession.audioVideo.[getAllVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallvideotiles)`.
+To get all video tiles, call meetingSession.audioVideo.[getAllVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallvideotiles).
 
-To get all remote attendees’ video tiles, call `meetingSession.audioVideo.[getAllRemoteVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallremotevideotiles)`.
+To get all remote attendees’ video tiles, call meetingSession.audioVideo.[getAllRemoteVideoTiles()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getallremotevideotiles).
 
-To get the local attendee’s video tile, call `meetingSession.audioVideo.[getLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getlocalvideotile)`.
+To get the local attendee’s video tile, call meetingSession.audioVideo.[getLocalVideoTile()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getlocalvideotile).
 
-To get a video tile, call `meetingSession.audioVideo.[getVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getvideotile)`.
+To get a video tile, call meetingSession.audioVideo.[getVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#getvideotile).
 
 ## 8. Share screen and other content (optional)
 
@@ -270,23 +270,23 @@ Each attendee can share one content share in addition to their main mic and came
 
 ### 8a. Start and stop the content share
 
-To start the content share, call `meetingSession.audioVideo.[startContentShare(stream)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare)`.
+To start the content share, call meetingSession.audioVideo.[startContentShare(stream)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare).
 
-To start sharing screen as a content share, call `meetingSession.audioVideo.[startContentShareFromScreenCapture(sourceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentsharefromscreencapture)`.
+To start sharing screen as a content share, call meetingSession.audioVideo.[startContentShareFromScreenCapture(sourceId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentsharefromscreencapture).
 
-To stop the content share, call `meetingSession.audioVideo.[stopContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopcontentshare)`.
+To stop the content share, call meetingSession.audioVideo.[stopContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#stopcontentshare).
 
-To pause content share, call `meetingSession.audioVideo.[pauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausecontentshare)`.
+To pause content share, call meetingSession.audioVideo.[pauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#pausecontentshare).
 
-To resume content share, call `meetingSession.audioVideo.[unpauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausecontentshare)`.
+To resume content share, call meetingSession.audioVideo.[unpauseContentShare()](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#unpausecontentshare).
 
 ### 8b. Register a content share observer
 
 You can receive events about the content share by implementing a [ContentShareObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/contentshareobserver.html) and adding the observer to the meeting session.
 
-To add a ContentShareObserver, call `meetingSession.audioVideo.`[`addContentShareObserver(observer)`](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addcontentshareobserver).
+To add a ContentShareObserver, call meetingSession.audioVideo.[addContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#addcontentshareobserver).
 
-To remove a ContentShareObserver, call `meetingSession.audioVideo.[removeContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removecontentshareobserver)`.
+To remove a ContentShareObserver, call meetingSession.audioVideo.[removeContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#removecontentshareobserver).
 
 You can implement the following callbacks:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.16';
+    return '1.2.17';
   }
 
   /**


### PR DESCRIPTION
*Issue #:* 
* https://github.com/aws/amazon-chime-sdk-js/issues/209 - Summarize the main API surface

*Description of changes*
* This is a followup of https://github.com/aws/amazon-chime-sdk-js/pull/242
* Remove backticks as GitHub Markdown didn't render inline code with embedded URLs
* Also removed `<` and `>` from audio and video, as they vanished in the generated HTML.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
