### PR TITLE
Enable send-side bandiwdth estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Enabled the use of send-side bandwidth estimation
 - Add guide for content sharing
 - Display meeting id in the demo app
 - Add additional callback in AudioVideoObserver to indicate video downlink pressure

--- a/docs/classes/defaultsignalingclient.html
+++ b/docs/classes/defaultsignalingclient.html
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L38">src/signalingclient/DefaultSignalingClient.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L39">src/signalingclient/DefaultSignalingClient.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Request<wbr>Queue<span class="tsd-signature-symbol">:</span> <a href="signalingclientconnectionrequest.html" class="tsd-signature-type">SignalingClientConnectionRequest</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L37">src/signalingclient/DefaultSignalingClient.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L38">src/signalingclient/DefaultSignalingClient.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Closing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L36">src/signalingclient/DefaultSignalingClient.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L37">src/signalingclient/DefaultSignalingClient.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L40">src/signalingclient/DefaultSignalingClient.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L41">src/signalingclient/DefaultSignalingClient.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/signalingclientobserver.html" class="tsd-signature-type">SignalingClientObserver</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L34">src/signalingclient/DefaultSignalingClient.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L35">src/signalingclient/DefaultSignalingClient.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">unload<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L38">src/signalingclient/DefaultSignalingClient.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L39">src/signalingclient/DefaultSignalingClient.ts:39</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">was<wbr>Opened<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L35">src/signalingclient/DefaultSignalingClient.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L36">src/signalingclient/DefaultSignalingClient.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/websocketadapter.html" class="tsd-signature-type">WebSocketAdapter</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L40">src/signalingclient/DefaultSignalingClient.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L41">src/signalingclient/DefaultSignalingClient.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">FRAME_<wbr>TYPE_<wbr>RTC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L33">src/signalingclient/DefaultSignalingClient.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L34">src/signalingclient/DefaultSignalingClient.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L335">src/signalingclient/DefaultSignalingClient.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L341">src/signalingclient/DefaultSignalingClient.ts:341</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -298,7 +298,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#closeconnection">closeConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L143">src/signalingclient/DefaultSignalingClient.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L149">src/signalingclient/DefaultSignalingClient.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -315,7 +315,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L346">src/signalingclient/DefaultSignalingClient.ts:346</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L352">src/signalingclient/DefaultSignalingClient.ts:352</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#join">join</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L72">src/signalingclient/DefaultSignalingClient.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L73">src/signalingclient/DefaultSignalingClient.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -357,7 +357,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#leave">leave</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L126">src/signalingclient/DefaultSignalingClient.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L132">src/signalingclient/DefaultSignalingClient.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#mute">mute</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L166">src/signalingclient/DefaultSignalingClient.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L172">src/signalingclient/DefaultSignalingClient.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -399,7 +399,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#openconnection">openConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L57">src/signalingclient/DefaultSignalingClient.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L58">src/signalingclient/DefaultSignalingClient.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -423,7 +423,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L175">src/signalingclient/DefaultSignalingClient.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L181">src/signalingclient/DefaultSignalingClient.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -447,7 +447,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pingpong">pingPong</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L63">src/signalingclient/DefaultSignalingClient.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L64">src/signalingclient/DefaultSignalingClient.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L249">src/signalingclient/DefaultSignalingClient.ts:249</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L255">src/signalingclient/DefaultSignalingClient.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -494,7 +494,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#ready">ready</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L160">src/signalingclient/DefaultSignalingClient.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L166">src/signalingclient/DefaultSignalingClient.ts:166</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -511,7 +511,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L217">src/signalingclient/DefaultSignalingClient.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L223">src/signalingclient/DefaultSignalingClient.ts:223</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -535,7 +535,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L47">src/signalingclient/DefaultSignalingClient.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L48">src/signalingclient/DefaultSignalingClient.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -559,7 +559,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L52">src/signalingclient/DefaultSignalingClient.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L53">src/signalingclient/DefaultSignalingClient.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -582,7 +582,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L191">src/signalingclient/DefaultSignalingClient.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L197">src/signalingclient/DefaultSignalingClient.ts:197</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -600,7 +600,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#resume">resume</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L183">src/signalingclient/DefaultSignalingClient.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L189">src/signalingclient/DefaultSignalingClient.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -624,7 +624,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#sendclientmetrics">sendClientMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L136">src/signalingclient/DefaultSignalingClient.ts:136</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L142">src/signalingclient/DefaultSignalingClient.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -647,7 +647,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L271">src/signalingclient/DefaultSignalingClient.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L277">src/signalingclient/DefaultSignalingClient.ts:277</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -670,7 +670,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L196">src/signalingclient/DefaultSignalingClient.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L202">src/signalingclient/DefaultSignalingClient.ts:202</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -693,7 +693,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L256">src/signalingclient/DefaultSignalingClient.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L262">src/signalingclient/DefaultSignalingClient.ts:262</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -710,7 +710,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L296">src/signalingclient/DefaultSignalingClient.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L302">src/signalingclient/DefaultSignalingClient.ts:302</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -727,7 +727,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L240">src/signalingclient/DefaultSignalingClient.ts:240</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L246">src/signalingclient/DefaultSignalingClient.ts:246</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -751,7 +751,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#subscribe">subscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L85">src/signalingclient/DefaultSignalingClient.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L91">src/signalingclient/DefaultSignalingClient.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -50,6 +50,7 @@ message SdkErrorFrame {
 enum SdkJoinFlags {
     SEND_BITRATES = 1;
     HAS_STREAM_UPDATE = 2;
+    USE_SEND_SIDE_BWE = 8;
 }
 
 message SdkClientDetails {

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -1,6 +1,7 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
 import Logger from '../logger/Logger';
 import SignalingClientObserver from '../signalingclientobserver/SignalingClientObserver';
 import {
@@ -75,6 +76,11 @@ export default class DefaultSignalingClient implements SignalingClient {
     joinFrame.protocolVersion = 2;
     joinFrame.maxNumOfVideos = settings.maxVideos;
     joinFrame.flags = SdkJoinFlags.HAS_STREAM_UPDATE;
+    // Only Chrome currently supports the new send side bandwidth estimation
+    const browserBehavior = new DefaultBrowserBehavior();
+    if (browserBehavior.hasChromiumWebRTC()) {
+      joinFrame.flags |= SdkJoinFlags.USE_SEND_SIDE_BWE;
+    }
     joinFrame.flags |= settings.sendBitrates ? SdkJoinFlags.SEND_BITRATES : 0;
     const message = SdkSignalFrame.create();
     message.type = SdkSignalFrame.Type.JOIN;

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -314,7 +314,8 @@ export class SdkErrorFrame implements ISdkErrorFrame {
 /** SdkJoinFlags enum. */
 export enum SdkJoinFlags {
     SEND_BITRATES = 1,
-    HAS_STREAM_UPDATE = 2
+    HAS_STREAM_UPDATE = 2,
+    USE_SEND_SIDE_BWE = 8
 }
 
 /** Properties of a SdkClientDetails. */

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -1006,11 +1006,13 @@ $root.SdkErrorFrame = (function() {
  * @enum {string}
  * @property {number} SEND_BITRATES=1 SEND_BITRATES value
  * @property {number} HAS_STREAM_UPDATE=2 HAS_STREAM_UPDATE value
+ * @property {number} USE_SEND_SIDE_BWE=8 USE_SEND_SIDE_BWE value
  */
 $root.SdkJoinFlags = (function() {
     var valuesById = {}, values = Object.create(valuesById);
     values[valuesById[1] = "SEND_BITRATES"] = 1;
     values[valuesById[2] = "HAS_STREAM_UPDATE"] = 2;
+    values[valuesById[3] = "USE_SEND_SIDE_BWE"] = 8;
     return values;
 })();
 


### PR DESCRIPTION
**Description of changes**

This changeset enables the use of send-side bandwidth estimation for faster reaction to changing network conditions for media publishers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
