### PR TITLE
Fix an issue that a dev dependnecy @types/dom-mediacapture-record is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update typedocs to 0.16 and re-generate doc files
 - Fix issue in Travis script that prevents integration tests from running
 - Fix markdown formatting with backticks in API overview
+- Fix an issue that a dev dependnecy @types/dom-mediacapture-record is not getting installed
 
 ## [1.2.1] - 2020-03-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -427,10 +427,9 @@
       "dev": true
     },
     "@types/dom-mediacapture-record": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.2.tgz",
-      "integrity": "sha512-kvpfcIq+YnOPnXxzTx6hbStJin0jtcFgCQxn4XgumF11HrOICxddPJ0/oGBLOd0mauxpPvxBuVvBi1qf7NC7Fg==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.4.tgz",
+      "integrity": "sha512-3u6HCFY83HQ0Aqs5wq+bTSGRfSb4QAYERz+7nvm4sJf2h48NkJlGlLi082j3+xwC6ce3en9mRl3QUCH8mlLWmg=="
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -39,7 +39,6 @@
     "@fluffy-spoon/substitute": "^1.89.0",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
-    "@types/dom-mediacapture-record": "^1.0.1",
     "@types/mocha": "^5.2.6",
     "@types/sinon": "^7.0.12",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
@@ -63,6 +62,7 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
+    "@types/dom-mediacapture-record": "^1.0.4",
     "detect-browser": "^4.7.0",
     "protobufjs": "~6.8.8",
     "resize-observer": "^1.0.0"

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.22';
+    return '1.2.23';
   }
 
   /**


### PR DESCRIPTION
…not getting installed

*Issue #:* https://github.com/aws/amazon-chime-sdk-js/issues/244

*Description of changes*
- Chime SDK had `@types/dom-mediacapture-record` under `devDependencies`. If a builder runs `npm i amazon-chime-sdk-js` without the `--dev` option, this package will not be installed in a builder app's `node_modules` folder. In a strict TS setup, Chime SDK will fail to import types for MediaStream Recording.
- Tested this change by publishing it to a local NPM registry `verdaccio`. In the future, we need to add integration tests, installing and importing SDK in popular frameworks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
