### PR TITLE
Add externalUserId to the VideoTile properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to run integration tests locally
 - Add the use case guide
 - Upgrade dependency aws-iot-device-sdk version
+- Add externalUserId to the tile properties
 
 ### Changed
 - Prevent prebuild from increase patch number when publishing to NPM

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -229,7 +229,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L123">src/videotile/DefaultVideoTile.ts:123</a></li>
 								</ul>

--- a/docs/classes/defaultvideotilecontroller.html
+++ b/docs/classes/defaultvideotilecontroller.html
@@ -259,7 +259,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L135">src/videotilecontroller/DefaultVideoTileController.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L136">src/videotilecontroller/DefaultVideoTileController.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L192">src/videotilecontroller/DefaultVideoTileController.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L193">src/videotilecontroller/DefaultVideoTileController.ts:193</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L200">src/videotilecontroller/DefaultVideoTileController.ts:200</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L201">src/videotilecontroller/DefaultVideoTileController.ts:201</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -350,7 +350,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L121">src/videotilecontroller/DefaultVideoTileController.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L122">src/videotilecontroller/DefaultVideoTileController.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -368,7 +368,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L131">src/videotilecontroller/DefaultVideoTileController.ts:131</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L132">src/videotilecontroller/DefaultVideoTileController.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -386,7 +386,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L80">src/videotilecontroller/DefaultVideoTileController.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L81">src/videotilecontroller/DefaultVideoTileController.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L106">src/videotilecontroller/DefaultVideoTileController.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L107">src/videotilecontroller/DefaultVideoTileController.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -428,7 +428,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotilearea">getVideoTileArea</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L110">src/videotilecontroller/DefaultVideoTileController.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L111">src/videotilecontroller/DefaultVideoTileController.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -452,7 +452,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#hasstartedlocalvideotile">hasStartedLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L70">src/videotilecontroller/DefaultVideoTileController.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L71">src/videotilecontroller/DefaultVideoTileController.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -470,7 +470,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#havevideotileswithstreams">haveVideoTilesWithStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L183">src/videotilecontroller/DefaultVideoTileController.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L184">src/videotilecontroller/DefaultVideoTileController.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -488,7 +488,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L84">src/videotilecontroller/DefaultVideoTileController.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L85">src/videotilecontroller/DefaultVideoTileController.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -512,7 +512,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L170">src/videotilecontroller/DefaultVideoTileController.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L171">src/videotilecontroller/DefaultVideoTileController.ts:171</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -530,7 +530,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removelocalvideotile">removeLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L74">src/videotilecontroller/DefaultVideoTileController.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L75">src/videotilecontroller/DefaultVideoTileController.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -548,7 +548,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L143">src/videotilecontroller/DefaultVideoTileController.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L144">src/videotilecontroller/DefaultVideoTileController.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -572,7 +572,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L158">src/videotilecontroller/DefaultVideoTileController.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L159">src/videotilecontroller/DefaultVideoTileController.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -596,7 +596,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#sendtilestateupdate">sendTileStateUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L177">src/videotilecontroller/DefaultVideoTileController.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L178">src/videotilecontroller/DefaultVideoTileController.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -680,7 +680,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L95">src/videotilecontroller/DefaultVideoTileController.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L96">src/videotilecontroller/DefaultVideoTileController.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/videotile.html
+++ b/docs/interfaces/videotile.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L44">src/videotile/VideoTile.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L45">src/videotile/VideoTile.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 					<a name="bindvideostream" class="tsd-anchor"></a>
 					<h3>bind<wbr>Video<wbr>Stream</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">bind<wbr>Video<wbr>Stream<span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, localTile<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, mediaStream<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, contentWidth<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, contentHeight<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, streamId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">bind<wbr>Video<wbr>Stream<span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, localTile<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, mediaStream<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, contentWidth<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, contentHeight<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, streamId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -182,6 +182,9 @@
 								<li>
 									<h5>streamId: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 						</li>
@@ -197,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L77">src/videotile/VideoTile.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L78">src/videotile/VideoTile.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -220,7 +223,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L71">src/videotile/VideoTile.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L72">src/videotile/VideoTile.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L60">src/videotile/VideoTile.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L61">src/videotile/VideoTile.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -287,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L49">src/videotile/VideoTile.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L50">src/videotile/VideoTile.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -353,7 +356,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L65">src/videotile/VideoTile.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L66">src/videotile/VideoTile.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L55">src/videotile/VideoTile.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L56">src/videotile/VideoTile.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.26",
+  "version": "1.2.27",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.26';
+    return '1.2.27';
   }
 
   /**

--- a/src/videotile/VideoTile.ts
+++ b/src/videotile/VideoTile.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import VideoTileState from './VideoTileState';
@@ -32,7 +32,8 @@ export default interface VideoTile {
     mediaStream: MediaStream | null,
     contentWidth: number | null,
     contentHeight: number | null,
-    streamId: number | null
+    streamId: number | null,
+    externalUserId?: string | null
   ): void;
 
   /**

--- a/src/videotilecontroller/DefaultVideoTileController.ts
+++ b/src/videotilecontroller/DefaultVideoTileController.ts
@@ -62,7 +62,8 @@ export default class DefaultVideoTileController implements VideoTileController {
       null,
       null,
       null,
-      null
+      null,
+      this.audioVideoController.configuration.credentials.externalUserId
     );
     this.audioVideoController.update();
   }
@@ -208,7 +209,8 @@ export default class DefaultVideoTileController implements VideoTileController {
       null,
       null,
       null,
-      null
+      null,
+      this.audioVideoController.configuration.credentials.externalUserId
     );
     return this.currentLocalTile;
   }


### PR DESCRIPTION
*Issue #:* 

*Description of changes*
ExternalUserId is used while creating an attendee. We will store this id as a property to the VideoTile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
