### PR TITLE
Ensure attendee presence leave/join is ordered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix markdown formatting with backticks in API overview
 - Fix an issue that a dev dependnecy @types/dom-mediacapture-record is not getting installed
 - Fix typo in README.md file
+- Ensure that attendee presence leave and join are ordered correctly
 
 ## [1.2.1] - 2020-03-20
 

--- a/docs/classes/defaultvolumeindicatoradapter.html
+++ b/docs/classes/defaultvolumeindicatoradapter.html
@@ -293,7 +293,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L107">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L111">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L142">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L146">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:146</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L100">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L104">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L92">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L96">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L65">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L69">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.28';
+    return '1.2.29';
   }
 
   /**

--- a/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
+++ b/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
@@ -26,6 +26,10 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
   ) {}
 
   sendRealtimeUpdatesForAudioStreamIdInfo(info: SdkAudioStreamIdInfoFrame): void {
+    // @ts-ignore
+    info.streams.sort((a, b) => {
+      a.audioStreamId - b.audioStreamId;
+    });
     for (const stream of info.streams) {
       const hasAttendeeId = !!stream.attendeeId;
       const hasExternalUserId = !!stream.externalUserId;


### PR DESCRIPTION
*Issue #:* 

*Description of changes*

Ensure attendee presence leave/join is ordered correctly. The server may send old stream ids that are leaving after new stream ids that joining. When mapped to attendee presence this can appear as though the same attendee is joining and then leaving, when really they were rejoining.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
