### PR TITLE
Fix the default video resolution comment in DeviceController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Temporarily only run test in Chrome for Travis integration tests
 - Allow content share frame rate to be configurable
 - Move demo guides to demo folders
+- Fix the default video resolution comment in DeviceController
 
 ### Removed
 - Remove unimplemented callbacks remoteDidMuteAudio and remoteDidUnmuteAudio on AudioVideoObserver

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -466,7 +466,7 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Sets the video input quality parameters to request when enabling video. These settings
-										take effect the next time a video input device is chosen. The default is 1280x720 @ 15 fps
+										take effect the next time a video input device is chosen. The default is 960x540 @ 15 fps
 									with a max bandwidth of 1400 kbps.</p>
 								</div>
 							</div>

--- a/docs/interfaces/devicecontroller.html
+++ b/docs/interfaces/devicecontroller.html
@@ -277,7 +277,7 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Sets the video input quality parameters to request when enabling video. These settings
-										take effect the next time a video input device is chosen. The default is 1280x720 @ 15 fps
+										take effect the next time a video input device is chosen. The default is 960x540 @ 15 fps
 									with a max bandwidth of 1400 kbps.</p>
 								</div>
 							</div>

--- a/docs/interfaces/devicecontrollerbasedmediastreambroker.html
+++ b/docs/interfaces/devicecontrollerbasedmediastreambroker.html
@@ -369,7 +369,7 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Sets the video input quality parameters to request when enabling video. These settings
-										take effect the next time a video input device is chosen. The default is 1280x720 @ 15 fps
+										take effect the next time a video input device is chosen. The default is 960x540 @ 15 fps
 									with a max bandwidth of 1400 kbps.</p>
 								</div>
 							</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/devicecontroller/DeviceController.ts
+++ b/src/devicecontroller/DeviceController.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import DeviceChangeObserver from '../devicechangeobserver/DeviceChangeObserver';
@@ -121,7 +121,7 @@ export default interface DeviceController {
 
   /**
    * Sets the video input quality parameters to request when enabling video. These settings
-   * take effect the next time a video input device is chosen. The default is 1280x720 @ 15 fps
+   * take effect the next time a video input device is chosen. The default is 960x540 @ 15 fps
    * with a max bandwidth of 1400 kbps.
    */
   chooseVideoInputQuality(

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.2.33';
+    return '1.2.34';
   }
 
   /**


### PR DESCRIPTION
*Description of changes*
The comment in DeviceController mentioned the default video resolution is 1280*720 which is not correct. Update to 960*540.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
