### PR TITLE
Fix broken link in GitHub main page README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Fixed
+- Fix broken link in GitHub main page README
+
 ## [1.3.0] - 2020-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ And review the following guides:
 
 ## Examples
 
-- [Meeting Demo](demos/browser) - A browser meeting application with a local server
-- [Serverless Meeting Demo](demos/serverless) - A self-contained serverless meeting application
-- [Video Help Desk](demos/videohelpdesk) - A tutorial that shows how to build a website widget that allows a customer to make a video call to a help desk
-- [Single JS](demos/singlejs) - A script to bundle the SDK into a single `.js` file
+- [Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser) - A browser
+ meeting application with a local server
+- [Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) - A self-contained serverless meeting application
+- [Video Help Desk](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/videohelpdesk) - A tutorial that shows how to build a website widget that allows a customer to make a video call to a help desk
+- [Single JS](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs) - A script to bundle the SDK into a single `.js` file
 - [Recording Demo](https://github.com/aws-samples/amazon-chime-sdk-recording-demo) - Recording the meeting's audio, video and screen share in high definition
 - [Virtual Classroom](https://github.com/aws-samples/amazon-chime-sdk-classroom-demo) - An online classroom built with Electron and React
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,10 +100,11 @@
 					<h2>Examples</h2>
 				</a>
 				<ul>
-					<li><a href="demos/browser">Meeting Demo</a> - A browser meeting application with a local server</li>
-					<li><a href="demos/serverless">Serverless Meeting Demo</a> - A self-contained serverless meeting application</li>
-					<li><a href="demos/videohelpdesk">Video Help Desk</a> - A tutorial that shows how to build a website widget that allows a customer to make a video call to a help desk</li>
-					<li><a href="demos/singlejs">Single JS</a> - A script to bundle the SDK into a single <code>.js</code> file</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser">Meeting Demo</a> - A browser
+					meeting application with a local server</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless">Serverless Meeting Demo</a> - A self-contained serverless meeting application</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/videohelpdesk">Video Help Desk</a> - A tutorial that shows how to build a website widget that allows a customer to make a video call to a help desk</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs">Single JS</a> - A script to bundle the SDK into a single <code>.js</code> file</li>
 					<li><a href="https://github.com/aws-samples/amazon-chime-sdk-recording-demo">Recording Demo</a> - Recording the meeting&#39;s audio, video and screen share in high definition</li>
 					<li><a href="https://github.com/aws-samples/amazon-chime-sdk-classroom-demo">Virtual Classroom</a> - An online classroom built with Electron and React</li>
 				</ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.3.2';
+    return '1.3.3';
   }
 
   /**


### PR DESCRIPTION
*Issue #274 :* 

*Description of changes*
Demo links in README is in relative path so they are broken in GitHub main page. Change to absolute path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
