### PR TITLE
Use getByteTimeDomainData to support iOS Safari in meeting demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add BrowserBehavior test for supported video codecs
 
 ### Changed
+- Use getByteTimeDomainData to support iOS Safari in meeting demo
 
 ### Removed
 

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -986,19 +986,19 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     if (!analyserNode) {
       return;
     }
-    if (!analyserNode.getFloatTimeDomainData) {
+    if (!analyserNode.getByteTimeDomainData) {
       document.getElementById('audio-preview').parentElement.style.visibility = 'hidden';
       return;
     }
-    const data = new Float32Array(analyserNode.fftSize);
+    const data = new Uint8Array(analyserNode.fftSize);
     let frameIndex = 0;
     this.analyserNodeCallback = () => {
       if (frameIndex === 0) {
-        analyserNode.getFloatTimeDomainData(data);
+        analyserNode.getByteTimeDomainData(data);
         const lowest = 0.01;
         let max = lowest;
         for (const f of data) {
-          max = Math.max(max, Math.abs(f));
+          max = Math.max(max, (f - 128) / 128);
         }
         let normalized = (Math.log(lowest) - Math.log(max)) / Math.log(lowest);
         let percent = Math.min(Math.max(normalized * 100, 0), 100);

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -958,19 +958,19 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (!analyserNode) {
       return;
     }
-    if (!analyserNode.getFloatTimeDomainData) {
+    if (!analyserNode.getByteTimeDomainData) {
       document.getElementById('audio-preview').parentElement.style.visibility = 'hidden';
       return;
     }
-    const data = new Float32Array(analyserNode.fftSize);
+    const data = new Uint8Array(analyserNode.fftSize);
     let frameIndex = 0;
     this.analyserNodeCallback = () => {
       if (frameIndex === 0) {
-        analyserNode.getFloatTimeDomainData(data);
+        analyserNode.getByteTimeDomainData(data);
         const lowest = 0.01;
         let max = lowest;
         for (const f of data) {
-          max = Math.max(max, Math.abs(f));
+          max = Math.max(max, (f - 128) / 128);
         }
         let normalized = (Math.log(lowest) - Math.log(max)) / Math.log(lowest);
         let percent = Math.min(Math.max(normalized * 100, 0), 100);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.3.3';
+    return '1.3.4';
   }
 
   /**


### PR DESCRIPTION
*Issue #:* #287 

*Description of changes*

Use getByteTimeDomainData to support iOS Safari in meeting demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
