### PR TITLE
Fix video freeze in Safari after toggling off and on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix broken link in GitHub main page README
+- Fix video freeze in Safari after toggling off and on
 
 ## [1.3.0] - 2020-04-17
 

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L87">src/videotile/DefaultVideoTile.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L92">src/videotile/DefaultVideoTile.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<wbr>Monitor<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicepixelratiomonitor.html" class="tsd-signature-type">DevicePixelRatioMonitor</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L93">src/videotile/DefaultVideoTile.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L98">src/videotile/DefaultVideoTile.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L92">src/videotile/DefaultVideoTile.ts:92</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L97">src/videotile/DefaultVideoTile.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>State<span class="tsd-signature-symbol">:</span> <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a><span class="tsd-signature-symbol"> = new VideoTileState()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L13">src/videotile/DefaultVideoTile.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L12">src/videotile/DefaultVideoTile.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L177">src/videotile/DefaultVideoTile.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L182">src/videotile/DefaultVideoTile.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -231,7 +231,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L131">src/videotile/DefaultVideoTile.ts:131</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L136">src/videotile/DefaultVideoTile.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L233">src/videotile/DefaultVideoTile.ts:233</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L238">src/videotile/DefaultVideoTile.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ImageData</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L100">src/videotile/DefaultVideoTile.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L105">src/videotile/DefaultVideoTile.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratioobserver.html">DevicePixelRatioObserver</a>.<a href="../interfaces/devicepixelratioobserver.html#devicepixelratiochanged">devicePixelRatioChanged</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L114">src/videotile/DefaultVideoTile.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L119">src/videotile/DefaultVideoTile.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#id">id</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L119">src/videotile/DefaultVideoTile.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L124">src/videotile/DefaultVideoTile.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L215">src/videotile/DefaultVideoTile.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L220">src/videotile/DefaultVideoTile.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L201">src/videotile/DefaultVideoTile.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L206">src/videotile/DefaultVideoTile.ts:206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L246">src/videotile/DefaultVideoTile.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L251">src/videotile/DefaultVideoTile.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#state">state</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L123">src/videotile/DefaultVideoTile.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L128">src/videotile/DefaultVideoTile.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#stateref">stateRef</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L127">src/videotile/DefaultVideoTile.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L132">src/videotile/DefaultVideoTile.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L224">src/videotile/DefaultVideoTile.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L229">src/videotile/DefaultVideoTile.ts:229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L208">src/videotile/DefaultVideoTile.ts:208</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L213">src/videotile/DefaultVideoTile.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L253">src/videotile/DefaultVideoTile.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L258">src/videotile/DefaultVideoTile.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -492,7 +492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L263">src/videotile/DefaultVideoTile.ts:263</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L268">src/videotile/DefaultVideoTile.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -509,7 +509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L278">src/videotile/DefaultVideoTile.ts:278</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L283">src/videotile/DefaultVideoTile.ts:283</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L15">src/videotile/DefaultVideoTile.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L14">src/videotile/DefaultVideoTile.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L51">src/videotile/DefaultVideoTile.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L50">src/videotile/DefaultVideoTile.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L293">src/videotile/DefaultVideoTile.ts:293</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L298">src/videotile/DefaultVideoTile.ts:298</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.7';
+    return '1.4.8';
   }
 
   /**


### PR DESCRIPTION
**Issue #319 and #157 :** 

**Description of changes:**
- Switch back to use requestAnimationFrame instead of AsyncScheduler to fix the local video freeze in Safari.
- Check the video element's srcObject before clearing it out to make sure the video element's srcObject has not been overriden.

**Testing**

1. Have you successfully run `npm run build:release` locally? 
Yes
2. How did you test these changes?
- Add unit tests
- Manually testing in Safari and verified that the local video is not frozen after toggling off then on again.
- Retest the issue #3 and verify there is no crash when remote video is added or toggled.
- Retest the fix in #63 and verify the following case is working:
  
    - In browser window 1, join A and enable video
    - In browser window 2, join B and enable video
    - Confirm both windows show local/remote videos
    - In browser window 1, open a new tab (e.g. example.com) and leave focused
    - In browser window 2, toggle B video off and on
    - Switch back to tab in browser window 1 with participant A
    - Video appears (and not empty)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
