### PR TITLE
Fix meeting demo content share takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not mirror local video for rear-facing camera
 - Fix sip url for meeting demo
 - Fix local video freeze in Safari after toggling off and on
+- Fix meeting demo content share turning off on attendee join
 
 ## [1.4.0] - 2020-04-24
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -661,7 +661,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         return;
       }
       //If someone else share content, stop the current content share
-      if (!this.allowMaxContentShare() && !isSelfAttendee && this.isButtonOn('button-content-share')) {
+      if (!this.allowMaxContentShare() && !isSelfAttendee && isContentAttendee && this.isButtonOn('button-content-share')) {
         this.contentShareStop();
       }
       if (!this.roster[attendeeId]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.8';
+    return '1.4.9';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**

Fix meeting demo content share takeover. Regression due to: https://github.com/aws/amazon-chime-sdk-js/commit/48e1d3842f7bd72a2110659155e4c8df0bce7628

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

Tested that content share takes over in meeting demo when other participant starts content, but not if other participant just joins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
