### PR TITLE
Add more content sharing integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,22 +32,14 @@ jobs:
         - source script/travis-awscli-installation
         - integration/js/script/install-kite
       script: npm run test:integration-video
-    #Integ test meeting leave & end
+    #Integ test meeting end
     - stage: integ_meeting_quit
       if: (type = pull_request) OR (type = push AND branch != master)
       before_install: script/needs-integration-test || travis_terminate 0
       install:
         - source script/travis-awscli-installation
         - integration/js/script/install-kite
-      script: npm run test:integration-meeting-quit
-    #Integ test app quit
-    - stage: integ_app_quit
-      if: (type = pull_request) OR (type = push AND branch != master)
-      before_install: script/needs-integration-test || travis_terminate 0
-      install:
-        - source script/travis-awscli-installation
-        - integration/js/script/install-kite
-      script: npm run test:integration-app-quit
+      script: npm run test:integration-meeting-end
     #Integ test screen share
     - stage: integ_screen_share
       if: (type = pull_request) OR (type = push AND branch != master)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add bandwidth policy to meeting session configuration to allow overriding default policies
+- Add more content sharing integration tests
 
 ### Changed
 - Simplify meeting demos to leverage externalUserId in roster
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix local video freeze in Safari after toggling off and on
 - Fix meeting demo content share turning off on attendee join
 - Disable audio sample constraints when not using WebAudio
+- Reset Sauce Lab session to make sure clean state
 
 ## [1.4.0] - 2020-04-24
 

--- a/integration/configs/app_quit_content_share_test.config.json
+++ b/integration/configs/app_quit_content_share_test.config.json
@@ -1,0 +1,26 @@
+{
+  "`": 1,
+  "name": "app_quit_content_share_test.config.json %ts",
+  "grids": [
+  ],
+  "tests": [
+    {
+      "name": "App Quit Content Share Test %ts",
+      "description": "App Quit Content Share Test",
+      "tupleSize": 1,
+      "noOfThreads": 1,
+      "testImpl": "AppQuitContentShareTest.js",
+      "payload": {
+        "url": "http://localhost:8080/",
+        "retry": 2
+      }
+    }
+  ],
+  "clients": [
+    {
+      "browserName": "chrome",
+      "version": "78",
+      "platform": "MAC"
+    }
+  ]
+}

--- a/integration/configs/content_share_join_later_test.config.json
+++ b/integration/configs/content_share_join_later_test.config.json
@@ -1,0 +1,26 @@
+{
+  "`": 1,
+  "name": "content_share_join_later_test.config.json %ts",
+  "grids": [
+  ],
+  "tests": [
+    {
+      "name": "Content Share Join Later Test %ts",
+      "description": "Test that content share can be viewed when an attendee joins after",
+      "tupleSize": 1,
+      "noOfThreads": 1,
+      "testImpl": "ContentShareJoinLaterTest.js",
+      "payload": {
+        "url": "http://localhost:8080/",
+        "retry": 2
+      }
+    }
+  ],
+  "clients": [
+    {
+      "browserName": "chrome",
+      "version": "78",
+      "platform": "MAC"
+    }
+  ]
+}

--- a/integration/configs/meeting_leave_content_share_test.config.json
+++ b/integration/configs/meeting_leave_content_share_test.config.json
@@ -1,0 +1,26 @@
+{
+  "`": 1,
+  "name": "meeting_leave_content_share_test.config.json %ts",
+  "grids": [
+  ],
+  "tests": [
+    {
+      "name": "Meeting Leave Content Share Test %ts",
+      "description": "Meeting leave Content Share Test",
+      "tupleSize": 1,
+      "noOfThreads": 1,
+      "testImpl": "MeetingLeaveContentShareTest.js",
+      "payload": {
+        "url": "http://localhost:8080/",
+        "retry": 2
+      }
+    }
+  ],
+  "clients": [
+    {
+      "browserName": "chrome",
+      "version": "78",
+      "platform": "MAC"
+    }
+  ]
+}

--- a/integration/js/AppQuitAudioTest.js
+++ b/integration/js/AppQuitAudioTest.js
@@ -78,6 +78,6 @@ module.exports = AppQuitAudioTest;
 
 (async () => {
   const kiteConfig = await TestUtils.getKiteConfig(__dirname);
-  let test = new AppQuitAudioTest('Meeting end audio test', kiteConfig);
+  let test = new AppQuitAudioTest('App quit audio test', kiteConfig);
   await test.run();
 })();

--- a/integration/js/AppQuitContentShareTest.js
+++ b/integration/js/AppQuitContentShareTest.js
@@ -1,0 +1,46 @@
+const {ClickContentShareButton} = require('./steps');
+const {ContentShareVideoCheck, RosterCheck} = require('./checks');
+const {TestUtils} = require('./node_modules/kite-common');
+const SdkBaseTest = require('./utils/SdkBaseTest');
+const {SdkTestUtils} = require('./utils/SdkTestUtils');
+const {Window} = require('./utils/Window');
+const uuidv4 = require('uuid/v4');
+
+class AppQuitContentShareTest extends SdkBaseTest {
+  constructor(name, kiteConfig) {
+    super(name, kiteConfig, "AppQuitAudioCheck");
+  }
+
+  async runIntegrationTest() {
+    const session = this.seleniumSessions[0];
+    const test_attendee_id = uuidv4();
+    const monitor_attendee_id = uuidv4();
+
+    const test_window = await Window.existing(session.driver, "TEST");
+    const monitor_window = await Window.openNew(session.driver, "MONITOR");
+
+    await test_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, test_attendee_id, session));
+    await monitor_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, monitor_attendee_id, session));
+
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+
+    await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
+    await TestUtils.waitAround(5000);
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+
+    await test_window.close();
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+  }
+}
+
+module.exports = AppQuitContentShareTest;
+
+(async () => {
+  const kiteConfig = await TestUtils.getKiteConfig(__dirname);
+  let test = new AppQuitContentShareTest('App quit content share test', kiteConfig);
+  await test.run();
+})();

--- a/integration/js/AppQuitVideoTest.js
+++ b/integration/js/AppQuitVideoTest.js
@@ -78,6 +78,6 @@ module.exports = AppQuitVideoTest;
 
 (async () => {
   const kiteConfig = await TestUtils.getKiteConfig(__dirname);
-  let test = new AppQuitVideoTest('Meeting end video test', kiteConfig);
+  let test = new AppQuitVideoTest('App quit video test', kiteConfig);
   await test.run();
 })();

--- a/integration/js/ContentShareJoinLaterTest.js
+++ b/integration/js/ContentShareJoinLaterTest.js
@@ -1,0 +1,45 @@
+const {ClickContentShareButton} = require('./steps');
+const {ContentShareVideoCheck, RosterCheck} = require('./checks');
+const {TestUtils} = require('./node_modules/kite-common');
+const SdkBaseTest = require('./utils/SdkBaseTest');
+const {SdkTestUtils} = require('./utils/SdkTestUtils');
+const {Window} = require('./utils/Window');
+const uuidv4 = require('uuid/v4');
+
+class ContentShareJoinLaterTest extends SdkBaseTest {
+  constructor(name, kiteConfig) {
+    super(name, kiteConfig, "AppQuitAudioCheck");
+  }
+
+  async runIntegrationTest() {
+    const session = this.seleniumSessions[0];
+    const test_attendee_id = uuidv4();
+    const monitor_attendee_id = uuidv4();
+
+    const test_window = await Window.existing(session.driver, "TEST");
+    const monitor_window = await Window.openNew(session.driver, "MONITOR");
+
+    await test_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, test_attendee_id, session));
+    await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
+    await TestUtils.waitAround(5000);
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+
+    await monitor_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, monitor_attendee_id, session));
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+
+    await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
+    await TestUtils.waitAround(5000);
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+  }
+}
+
+module.exports = ContentShareJoinLaterTest;
+
+(async () => {
+  const kiteConfig = await TestUtils.getKiteConfig(__dirname);
+  let test = new ContentShareJoinLaterTest('Meeting leave content share test', kiteConfig);
+  await test.run();
+})();

--- a/integration/js/MeetingLeaveContentShareTest.js
+++ b/integration/js/MeetingLeaveContentShareTest.js
@@ -1,0 +1,47 @@
+const {ClickContentShareButton, LeaveMeetingStep} = require('./steps');
+const {ContentShareVideoCheck, RosterCheck} = require('./checks');
+const {TestUtils} = require('./node_modules/kite-common');
+const SdkBaseTest = require('./utils/SdkBaseTest');
+const {SdkTestUtils} = require('./utils/SdkTestUtils');
+const {Window} = require('./utils/Window');
+const uuidv4 = require('uuid/v4');
+
+class MeetingLeaveContentShareTest extends SdkBaseTest {
+  constructor(name, kiteConfig) {
+    super(name, kiteConfig, "AppQuitAudioCheck");
+  }
+
+  async runIntegrationTest() {
+    const session = this.seleniumSessions[0];
+    const test_attendee_id = uuidv4();
+    const monitor_attendee_id = uuidv4();
+
+    const test_window = await Window.existing(session.driver, "TEST");
+    const monitor_window = await Window.openNew(session.driver, "MONITOR");
+
+    await test_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, test_attendee_id, session));
+    await monitor_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, monitor_attendee_id, session));
+
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+
+    await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
+    await TestUtils.waitAround(5000);
+    await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+
+    await test_window.runCommands(async () => await LeaveMeetingStep.executeStep(this, session));
+    await TestUtils.waitAround(5000);
+    await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+  }
+}
+
+module.exports = MeetingLeaveContentShareTest;
+
+(async () => {
+  const kiteConfig = await TestUtils.getKiteConfig(__dirname);
+  let test = new MeetingLeaveContentShareTest('Meeting leave content share test', kiteConfig);
+  await test.run();
+})();

--- a/integration/js/script/run-test
+++ b/integration/js/script/run-test
@@ -59,18 +59,16 @@ cd ../
 case $1 in
    audio)
       r audio_test.config.json
+      r app_quit_audio_test.config.json
+      r meeting_leave_audio_test.config.json
       ;;
    video)
       r video_test.config.json
-      ;;
-   meeting_quit)
-      r meeting_leave_audio_test.config.json
-      r meeting_leave_video_test.config.json
-      r meeting_end_test.config.json
-      ;;
-   app_quit)
-      r app_quit_audio_test.config.json
       r app_quit_video_test.config.json
+      r meeting_leave_video_test.config.json
+      ;;
+   meeting_end)
+      r meeting_end_test.config.json
       ;;
    screen_share)
       r screen_sharing_test.config.json
@@ -81,6 +79,9 @@ case $1 in
    content_share)
       r content_share_screen_capture_test.config.json
       r content_share_only_allow_two_test.config.json
+      r content_share_join_later_test.config.json
+      r app_quit_content_share_test.config.json
+      r meeting_leave_content_share_test.config.json
       ;;
    *)
       r audio_test.config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -31,8 +31,7 @@
     "test:integration": "cd ./integration/js && npm run test && npm run upload-logs-to-s3",
     "test:integration-audio": "cd ./integration/js && npm run test -- audio && npm run upload-logs-to-s3",
     "test:integration-video": "cd ./integration/js && npm run test -- video && npm run upload-logs-to-s3",
-    "test:integration-meeting-quit": "cd ./integration/js && npm run test -- meeting_quit && npm run upload-logs-to-s3",
-    "test:integration-app-quit": "cd ./integration/js && npm run test -- app_quit && npm run upload-logs-to-s3",
+    "test:integration-meeting-end": "cd ./integration/js && npm run test -- meeting_end && npm run upload-logs-to-s3",
     "test:integration-screen-share": "cd ./integration/js && npm run test -- screen_share && npm run upload-logs-to-s3",
     "test:integration-content-share": "cd ./integration/js && npm run test -- content_share && npm run upload-logs-to-s3"
   },

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.10';
+    return '1.4.11';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
- When retrying integration tests, end the current Sauce Labs session and start a new one. This ensures we have a clean state every time.
- Adding 3 new test cases for Content Share:
  - If an attendee joins later, verify that they can see content share.
  - If the sharer leaves the meeting, verify that the content share also ends.
  - If the sharer closes the app, verify that the content share also ends.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
- Manually run the integration tests and verify that tests pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
