### PR TITLE
Bump package-lock.json jquery to 3.5.0 and yargs-parser to 18.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset Sauce Lab session to make sure clean state
 - Fix integration test emit metrics
 
+### Security
+- Bump package-lock.json jquery to 3.5.0 and yargs-parser to 18.1.3
+
 ## [1.4.0] - 2020-04-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2577,9 +2577,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
       "dev": true
     },
     "js-tokens": {
@@ -3238,9 +3238,9 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/prebuild
+++ b/script/prebuild
@@ -43,7 +43,7 @@ elsif commits.size == 1
     File.write(version_file, File.read(version_file).gsub(/return '[.0-9]+';/, "return '#{new_version}';"))
 
     #Pull in npm audit fixes automatically
-    verbose('npm audit fix --only=prod')
+    verbose('npm audit fix')
 
     verbose("git add #{version_file}")
     verbose("git add package.json")

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.13';
+    return '1.4.14';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**

Bump package-lock.json jquery to 3.5.0 and yargs-parser to 18.1.3. Also turning on automatic audit fixes of all dependencies including dev dependencies.

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

These were version changes to dependencies of dev dependencies only, so `npm run build:release` was used to test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
