### PR TITLE
Support a mobile-friendly meeting v2 demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simplify meeting demos to leverage externalUserId in roster
 - Update PR template to add testing information
+- Support a mobile-friendly demo
 
 ### Removed
 - Remove unused VideoAdaptiveSubscribePolicy

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -10,7 +10,7 @@
 
 <!-- Initial meeting authentication screen with meeting and name inputs -->
 
-<div id="flow-authenticate" class="flow text-center">
+<div id="flow-authenticate" class="flow text-center p-2">
   <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="sdk-version"></div>
   <div class="container">
     <form id="form-authenticate">
@@ -139,11 +139,11 @@
     <form id="form-devices">
       <h1 class="h3 mb-3 font-weight-normal text-center">Select devices</h1>
       <div class="row mt-3">
-        <div class="col-8">
-          <label for="audio-input">Microphone</label>
-          <select id="audio-input" class="custom-select" style="width:308px"></select>
+        <div class="col-12 col-sm-8">
+          <label for="audio-input block">Microphone</label>
+          <select id="audio-input" class="custom-select" style="width:100%"></select>
         </div>
-        <div class="text-center col-4">
+        <div class="text-center col-sm-4 d-none d-sm-block">
           <label>Preview</label>
           <div class="w-100 progress" style="margin-top:0.75rem">
             <div id="audio-preview" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
@@ -151,17 +151,17 @@
         </div>
       </div>
       <div class="row mt-3">
-        <div class="col-8">
-          <label for="video-input">Camera</label>
-          <select id="video-input" class="custom-select" style="width:308px"></select>
+        <div class="col-12 col-sm-8">
+          <label for="video-input block">Camera</label>
+          <select id="video-input" class="custom-select" style="width:100%"></select>
         </div>
-        <div class="col-4 text-center" style="width:137px;height:82px">
+        <div class="col-sm-4 text-center d-none d-sm-block" style="width:137px;height:82px">
           <video id="video-preview" class="w-100 h-100" style="max-width:137px;max-height:82px;border-radius:8px"></video>
         </div>
       </div>
       <div class="row mt-3">
-        <div class="col-8">
-          <select id="video-input-quality" class="custom-select" style="width:308px">
+        <div class="col-12 col-sm-8">
+          <select id="video-input-quality" class="custom-select" style="width:100%">
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
             <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
             <option value="720p">720p (HD) @ 15 fps (1.4 Mbps max)</option>
@@ -169,12 +169,12 @@
         </div>
       </div>
       <div class="row mt-3">
-        <div class="col-8">
-          <label for="audio-output">Speaker</label>
-          <select id="audio-output" class="custom-select" style="width:308px"></select>
+        <div class="col-12 col-sm-8">
+          <label for="audio-output block">Speaker</label>
+          <select id="audio-output" class="custom-select" style="width:100%"></select>
         </div>
-        <div class="col-4">
-          <button id="button-test-sound" class="btn btn-outline-secondary btn-block h-50" style="margin-top:2rem">Test</button>
+        <div class="col-sm-4">
+          <button id="button-test-sound" class="btn btn-outline-secondary btn-block h-50 d-none d-sm-block" style="margin-top:2rem">Test</button>
         </div>
       </div>
       <div class="row mt-3">
@@ -196,86 +196,90 @@
 
 <!-- In-meeting screen -->
 
-<div id="flow-meeting" class="flow" style="position:absolute;left:15px;top:0;bottom:55px;right:15px">
-  <video id="content-share-video" crossOrigin="anonymous" style="position:fixed;left:0px;bottom:0px;width:320px;height:240px;display:none"></video>
-  <div class="text-muted" style="position:fixed;left:3px;bottom:3px" id="video-uplink-bandwidth"></div>
-  <div class="text-muted" style="position:fixed;left:30%;width:40%;text-align:center;bottom:3px" id="chime-meeting-id"></div>
-  <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="video-downlink-bandwidth"></div>
+<div id="flow-meeting" class="flow" style="position:absolute;left:0;top:0;bottom:55px;right:0">
+  <div class="p-2 d-none d-sm-block align-items-end" style="position:fixed;right:0;bottom:0;left:0;">
+    <div class="row w-100">
+      <video id="content-share-video" crossOrigin="anonymous" style="left:0px;bottom:0px;width:320px;height:240px;display:none"></video>
+    </div>
+    <div class="row w-100">
+      <div id="video-uplink-bandwidth" class="text-muted col"></div>
+      <div id="chime-meeting-id" class="text-muted col" style="align:center;"></div>
+      <div id="video-downlink-bandwidth" class="text-muted col" style="text-align:right;"></div>
+    </div>
+  </div>
   <audio id="meeting-audio" style="display:none"></audio>
   <div class="container-fluid h-100" style="display:flex; flex-flow:column">
-    <div class="row" style="height:60px">
-      <div class="col-1 text-left">
-        <div id="meeting-id" class="navbar-brand text-muted m-2"></div>
+    <div class="row mb-3 mb-lg-0">
+      <div class="col-12 col-lg-3 order-1 order-lg-1 text-center text-lg-left">
+        <div id="meeting-id" class="navbar-brand text-muted m-0 m-lg-2"></div>
       </div>
-      <div class="col-5 text-right">
-        <div class="btn-group m-2" role="group" aria-label="Toggle microphone">
+      <div class="col-8 col-lg-6 order-2 order-lg-2 text-left text-lg-center">
+        <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle microphone">
           <button id="button-microphone" type="button" class="btn btn-success" title="Toggle microphone">
             ${require('../../node_modules/open-iconic/svg/microphone.svg').default}
           </button>
           <div class="btn-group" role="group">
             <button id="button-microphone-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select microphone"></button>
-            <div id="dropdown-menu-microphone" class="dropdown-menu" aria-labelledby="button-microphone-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <div id="dropdown-menu-microphone" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-microphone-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a class="dropdown-item" href="#">Default microphone</a>
             </div>
           </div>
         </div>
-        <div class="btn-group m-2" role="group" aria-label="Toggle camera">
+        <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle camera">
           <button id="button-camera" type="button" class="btn btn-success" title="Toggle camera">
             ${require('../../node_modules/open-iconic/svg/video.svg').default}
           </button>
           <div class="btn-group" role="group">
             <button id="button-camera-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select camera"></button>
-            <div id="dropdown-menu-camera" class="dropdown-menu" aria-labelledby="button-camera-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <div id="dropdown-menu-camera" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-camera-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a class="dropdown-item" href="#">Default camera</a>
             </div>
           </div>
         </div>
-        <div class="btn-group m-2" role="group" aria-label="Toggle content share">
+        <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle content share">
           <button id="button-content-share" type="button" class="btn btn-success" title="Toggle content share">
             ${require('../../node_modules/open-iconic/svg/camera-slr.svg').default}
           </button>
           <div class="btn-group" role="group">
             <button id="button-content-share-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select content to share"></button>
-            <div id="dropdown-menu-content-share" class="dropdown-menu" aria-labelledby="button-content-share-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <div id="dropdown-menu-content-share" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-content-share-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a id="dropdown-item-content-share-screen-capture" class="dropdown-item" href="#">Screen Capture...</a>
               <a id="dropdown-item-content-share-screen-test-video" class="dropdown-item" href="#">Test Video</a>
               <a id="dropdown-item-content-share-file-item" class="dropdown-item" href="#"><input id="content-share-item" type="file"></a>
             </div>
           </div>
         </div>
-        <button id="button-pause-content-share" type="button" class="btn btn-success" title="Pause and unpause content share">
+        <button id="button-pause-content-share" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Pause and unpause content share">
           ${require('../../node_modules/open-iconic/svg/media-pause.svg').default}
         </button>
-      </div>
-      <div class="col-2 text-left">
-        <div class="btn-group m-2" role="group" aria-label="Toggle speaker">
+        <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle speaker">
           <button id="button-speaker" type="button" class="btn btn-success" title="Toggle speaker">
             ${require('../../node_modules/open-iconic/svg/volume-low.svg').default}
           </button>
           <div class="btn-group" role="group">
             <button id="button-speaker-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select speaker"></button>
-            <div id="dropdown-menu-speaker" class="dropdown-menu" aria-labelledby="button-speaker-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <div id="dropdown-menu-speaker" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-speaker-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a class="dropdown-item" href="#">Default speaker</a>
             </div>
           </div>
         </div>
       </div>
-      <div class="col-4 text-right">
-        <button id="button-meeting-leave" type="button" class="btn btn-outline-success m-2 px-4" title="Leave meeting">
+      <div class="col-4 col-lg-3 order-3 order-lg-3 text-right text-lg-right">
+        <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4" title="Leave meeting">
           ${require('../../node_modules/open-iconic/svg/account-logout.svg').default}
         </button>
-        <button id="button-meeting-end" type="button" class="btn btn-outline-danger m-2 px-4" title="End meeting">
+        <button id="button-meeting-end" type="button" class="btn btn-outline-danger mx-1 mx-xl-2 my-2 px-4" title="End meeting">
           ${require('../../node_modules/open-iconic/svg/power-standby.svg').default}
         </button>
       </div>
     </div>
-    <div class="row" style="flex-grow: 1">
-      <div class="col-sm-4">
+    <div class="row flex-sm-grow-1">
+      <div class="col-12 col-sm-6 col-md-5 col-lg-4">
         <div class="bs-component">
           <ul id="roster" class="list-group"></ul>
         </div>
       </div>
-      <div class="col p-0">
+      <div class="col-12 col-sm-6 col-md-7 col-lg-8 my-4 my-sm-0">
         <div id="tile-area" class="w-100 h-100">
           <div id="tile-0" style="display:none">
             <video id="video-0" class="w-100 h-100"></video>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import '../../style.scss';
+import './styleV2.scss';
 import 'bootstrap';
 
 import {

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1,0 +1,390 @@
+$white: #fff;
+$gray-100: #f8f9fa;
+$gray-200: #ecf0f1;
+$gray-300: #dee2e6;
+$gray-400: #ced4da;
+$gray-500: #b4bcc2;
+$gray-600: #95a5a6;
+$gray-700: #7b8a8b;
+$gray-800: #343a40;
+$gray-900: #212529;
+$black: #000;
+$blue: #2C3E50;
+$indigo: #6610f2;
+$purple: #6f42c1;
+$pink: #e83e8c;
+$red: #E74C3C;
+$orange: #fd7e14;
+$yellow: #F39C12;
+$green: #18BC9C;
+$teal: #20c997;
+$cyan: #3498DB;
+$primary: $blue;
+$secondary: $gray-600;
+$success: $green;
+$info: $cyan;
+$warning: $yellow;
+$danger: $red;
+$light: $gray-200;
+$dark: $gray-700;
+$yiq-contrasted-threshold: 175;
+$link-color: $success;
+$font-family-sans-serif: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-size-base: 0.9375rem;
+$h1-font-size: 3rem;
+$h2-font-size: 2.5rem;
+$h3-font-size: 2rem;
+$table-accent-bg: $gray-200;
+$dropdown-link-color: $gray-700;
+$dropdown-link-hover-color: $white;
+$dropdown-link-hover-bg: $primary;
+$nav-link-padding-y: .5rem  !default;
+$nav-link-padding-x: 2rem;
+$nav-link-disabled-color: $gray-600  !default;
+$nav-tabs-border-color: $gray-200;
+$navbar-padding-y: 1rem;
+$navbar-dark-color: $white;
+$navbar-dark-hover-color: $success;
+$pagination-color: $white;
+$pagination-bg: $success;
+$pagination-border-width: 0;
+$pagination-border-color: transparent;
+$pagination-hover-color: $white;
+$pagination-hover-bg: darken($success, 15%);
+$pagination-hover-border-color: transparent;
+$pagination-active-bg: $pagination-hover-bg;
+$pagination-active-border-color: transparent;
+$pagination-disabled-color: $gray-200;
+$pagination-disabled-bg: lighten($success, 15%);
+$pagination-disabled-border-color: transparent;
+$progress-height: 0.625rem;
+$progress-font-size: 0.625rem;
+$list-group-hover-bg: $gray-200;
+$list-group-disabled-bg: $gray-200;
+$close-color: $white;
+$close-text-shadow: none;
+
+@import "node_modules/bootstrap/scss/bootstrap";
+
+// Flatly 4.3.1
+// Bootswatch
+
+
+// Variables ===================================================================
+
+// Navbar =======================================================================
+
+.bg-primary {
+  .navbar-nav .active > .nav-link {
+    color: $success !important;
+  }
+}
+
+.bg-dark {
+  background-color: $success !important;
+  &.navbar-dark .navbar-nav {
+    .nav-link:focus,
+    .nav-link:hover,
+    .active > .nav-link {
+      color: $primary !important;
+    }
+  }
+}
+
+// Buttons =====================================================================
+
+.btn {
+  &-secondary,
+  &-secondary:hover,
+  &-warning,
+  &-warning:hover {
+    color: #fff;
+  }
+}
+
+// Typography ==================================================================
+
+// Tables ======================================================================
+
+.table {
+
+  &-primary,
+  &-secondary,
+  &-success,
+  &-info,
+  &-warning,
+  &-danger {
+    color: #fff;
+  }
+
+  &-primary {
+    &, > th, > td {
+      background-color: $primary;
+    }
+  }
+
+  &-secondary {
+    &, > th, > td {
+      background-color: $secondary;
+    }
+  }
+
+  &-light {
+    &, > th, > td {
+      background-color: $light;
+    }
+  }
+
+  &-dark {
+    &, > th, > td {
+      background-color: $dark;
+    }
+  }
+
+  &-success {
+    &, > th, > td {
+      background-color: $success;
+    }
+  }
+
+  &-info {
+    &, > th, > td {
+      background-color: $info;
+    }
+  }
+
+  &-danger {
+    &, > th, > td {
+      background-color: $danger;
+    }
+  }
+
+  &-warning {
+    &, > th, > td {
+      background-color: $warning;
+    }
+  }
+
+  &-active {
+    &, > th, > td {
+      background-color: $table-active-bg;
+    }
+  }
+
+  &-hover {
+
+    .table-primary:hover {
+      &, > th, > td {
+        background-color: darken($primary, 5%);
+      }
+    }
+
+    .table-secondary:hover {
+      &, > th, > td {
+        background-color: darken($secondary, 5%);
+      }
+    }
+
+    .table-light:hover {
+      &, > th, > td {
+        background-color: darken($light, 5%);
+      }
+    }
+
+    .table-dark:hover {
+      &, > th, > td {
+        background-color: darken($dark, 5%);
+      }
+    }
+
+    .table-success:hover {
+      &, > th, > td {
+        background-color: darken($success, 5%);
+      }
+    }
+
+    .table-info:hover {
+      &, > th, > td {
+        background-color: darken($info, 5%);
+      }
+    }
+
+    .table-danger:hover {
+      &, > th, > td {
+        background-color: darken($danger, 5%);
+      }
+    }
+
+    .table-warning:hover {
+      &, > th, > td {
+        background-color: darken($warning, 5%);
+      }
+    }
+
+    .table-active:hover {
+      &, > th, > td {
+        background-color: $table-active-bg;
+      }
+    }
+
+  }
+}
+
+// Forms =======================================================================
+
+// Navs ========================================================================
+
+.nav-tabs {
+  .nav-link.active,
+  .nav-link.active:focus,
+  .nav-link.active:hover,
+  .nav-item.open .nav-link,
+  .nav-item.open .nav-link:focus,
+  .nav-item.open .nav-link:hover {
+    color: $primary;
+  }
+}
+
+.pagination {
+  a:hover {
+    text-decoration: none;
+  }
+}
+
+// Indicators ==================================================================
+
+.close {
+  text-decoration: none;
+  opacity: 0.4;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+}
+
+.badge {
+  &-secondary,
+  &-warning {
+    color: #fff;
+  }
+}
+
+.alert {
+  border: none;
+  color: $white;
+
+  a,
+  .alert-link {
+    color: #fff;
+    text-decoration: underline;
+  }
+
+  @each $color, $value in $theme-colors {
+    &-#{$color} {
+      @if $enable-gradients {
+        background: $value linear-gradient(180deg, mix($body-bg, $value, 15%), $value) repeat-x;
+      } @else {
+        background-color: $value;
+      }
+    }
+  }
+
+  &-light {
+    &,
+    & a,
+    & .alert-link {
+      color: $body-color;
+    }
+  }
+}
+
+// Progress bars ===============================================================
+
+// Containers ==================================================================
+.modal .close{
+  color: $black;
+
+  &:not(:disabled):not(.disabled):hover,
+  &:not(:disabled):not(.disabled):focus {
+    color: $black;
+  }
+}
+
+// Custom
+
+html {
+  height: 100%;
+}
+
+body {
+  min-width: 320px;
+  height: 100%;
+  display: -ms-flexbox;
+  display: -webkit-box;
+  display: flex;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  justify-content: center;
+  background-color: #f5f5f5;
+}
+
+svg {
+  width: 20px;
+  height: 20px;
+  fill: lighten($secondary, 15%);
+}
+
+.svg-active {
+  fill: $white;
+}
+
+.svg-inactive {
+  fill: lighten($secondary, 15%);
+}
+
+.flow {
+  display: none;
+}
+
+.progress-hidden {
+  visibility: hidden;
+}
+
+#flow-meeting {
+  min-width: 320px;
+}
+
+@media (max-width: 575px) {
+  #tile-area {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  #tile-area > div {
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
+    width: 50% !important;
+    height: auto !important;
+    padding-bottom: 33% !important;
+  }
+
+  #tile-area > div > video {
+    object-fit: cover;
+  }
+
+  #tile-area > div > div,
+  #tile-area > div > button {
+    display: none !important;
+  }
+
+  #content-share-video {
+    display: none !important;
+  }
+}

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.668.0",
+    "aws-sdk": "^2.669.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.14';
+    return '1.4.15';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
- Make the meeting v2 responsive using Bootstrap classes
- I cloned `demos/browser/style.scss` to `styleV2.scss` and added a few styles for the Bootstrap XS size

<img width="200" alt="Screen Shot 2020-05-05 at 9 59 18 AM" src="https://user-images.githubusercontent.com/36240708/81093609-36eecb00-8eb7-11ea-81cb-ff4c30065b94.png">


**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
I deployed the serverless demo app and tested it on my iPhone.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
