### PR TITLE
Add method to get the nearest media region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bandwidth policy to meeting session configuration to allow overriding default policies
 - Add more content sharing integration tests
 - Add gifs to read me file to show latest npm version and downloads
+- Add method to get the nearest media region
 
 ### Changed
 - Simplify meeting demos to leverage externalUserId in roster

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -144,6 +144,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       "amazon-chime-sdk-js@" + Versioning.sdkVersion;
     this.initEventListeners();
     this.initParameters();
+    this.getNearestMediaRegion();
   }
 
   initParameters(): void {
@@ -472,6 +473,30 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
         window.location = window.location.pathname;
       });
     });
+  }
+
+  getNearestMediaRegion(): void {
+    const supportedMediaRegions: Array<string> = ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-north-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'];
+    new AsyncScheduler().start(
+      async (): Promise<void> => {
+        try {
+          const nearestMediaRegionResponse = await fetch(
+            `https://nearest-media-region.l.chime.aws`,
+            {
+              method: 'GET',
+            }
+          );
+          const nearestMediaRegionJSON = await nearestMediaRegionResponse.json();
+          const nearestMediaRegion = nearestMediaRegionJSON.region;
+          if (supportedMediaRegions.indexOf(nearestMediaRegion) !== -1) {
+            (document.getElementById('inputRegion') as HTMLInputElement).value = nearestMediaRegion;
+          } else {
+            throw new Error(`${nearestMediaRegion} doesn't exist`);
+          }
+        } catch (error) {
+          this.log('Default media region selected: ' + error.message);
+        }
+      });
   }
 
   toggleButton(button: string, state?: 'on' | 'off'): boolean {

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -150,6 +150,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
       "amazon-chime-sdk-js@" + Versioning.sdkVersion;
     this.initEventListeners();
     this.initParameters();
+    this.getNearestMediaRegion();
     if (this.isRecorder()) {
       new AsyncScheduler().start(async () => {
         this.meeting = new URL(window.location.href).searchParams.get('m');
@@ -436,6 +437,30 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         window.location = window.location.pathname;
       });
     });
+  }
+
+  getNearestMediaRegion(): void {
+    const supportedMediaRegions: Array<string> = ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'eu-central-1', 'eu-north-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'sa-east-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2'];
+    new AsyncScheduler().start(
+      async (): Promise<void> => {
+        try {
+          const nearestMediaRegionResponse = await fetch(
+            `https://nearest-media-region.l.chime.aws`,
+            {
+              method: 'GET',
+            }
+          );
+          const nearestMediaRegionJSON = await nearestMediaRegionResponse.json();
+          const nearestMediaRegion = nearestMediaRegionJSON.region;
+          if (supportedMediaRegions.indexOf(nearestMediaRegion) !== -1) {
+            (document.getElementById('inputRegion') as HTMLInputElement).value = nearestMediaRegion;
+          } else {
+            throw new Error(`${nearestMediaRegion} doesn't exist`);
+          }
+        } catch (error) {
+          this.log('Default media region selected: ' + error.message);
+        }
+      });
   }
 
   toggleButton(button: string, state?: 'on' | 'off'): boolean {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.18';
+    return '1.4.19';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
https://nearest-media-region.l.chime.aws returns the nearest AWS region that can host a meeting. We use this publicly available API, to select the region returned as the default media region in the demo app.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Selects us-west-2 as the closest media region
https://ciavhkpz27.execute-api.us-east-1.amazonaws.com/Prod/v2/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
