### PR TITLE
Show meeting and attendee IDs in the meeting v2 demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add more content sharing integration tests
 - Add gifs to read me file to show latest npm version and downloads
 - Add method to get the nearest media region
+- Display meeting and attendee IDs in the demo
 
 ### Changed
 - Simplify meeting demos to leverage externalUserId in roster
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable audio sample constraints when not using WebAudio
 - Reset Sauce Lab session to make sure clean state
 - Fix integration test emit metrics
+- Fix the CloudWatch log handler
 
 ### Security
 - Bump package-lock.json jquery to 3.5.0 and yargs-parser to 18.1.3

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -201,10 +201,15 @@
     <div class="row w-100">
       <video id="content-share-video" crossOrigin="anonymous" style="left:0px;bottom:0px;width:320px;height:240px;display:none"></video>
     </div>
-    <div class="row w-100">
-      <div id="video-uplink-bandwidth" class="text-muted col"></div>
-      <div id="chime-meeting-id" class="text-muted col" style="align:center;"></div>
-      <div id="video-downlink-bandwidth" class="text-muted col" style="text-align:right;"></div>
+    <div class="row align-items-end">
+      <div class="col">
+        <div id="chime-meeting-id" class="text-muted"></div>
+        <div id="desktop-attendee-id" class="text-muted"></div>
+      </div>
+      <div class="col d-none d-lg-block">
+        <div id="video-uplink-bandwidth" class="text-muted text-right"></div>
+        <div id="video-downlink-bandwidth" class="text-muted text-right"></div>
+      </div>
     </div>
   </div>
   <audio id="meeting-audio" style="display:none"></audio>
@@ -212,6 +217,8 @@
     <div class="row mb-3 mb-lg-0">
       <div class="col-12 col-lg-3 order-1 order-lg-1 text-center text-lg-left">
         <div id="meeting-id" class="navbar-brand text-muted m-0 m-lg-2"></div>
+        <div id="mobile-chime-meeting-id" class="text-muted d-block d-sm-none" style="font-size:0.65rem;"></div>
+        <div id="mobile-attendee-id" class="text-muted d-block d-sm-none mb-2" style="font-size:0.65rem;"></div>
       </div>
       <div class="col-8 col-lg-6 order-2 order-lg-2 text-left text-lg-center">
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle microphone">

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -206,6 +206,15 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           (document.getElementById(
             'chime-meeting-id'
           ) as HTMLSpanElement).innerText = `Meeting ID: ${chimeMeetingId}`;
+          (document.getElementById(
+            'mobile-chime-meeting-id'
+          ) as HTMLSpanElement).innerText = `Meeting ID: ${chimeMeetingId}`;
+          (document.getElementById(
+            'mobile-attendee-id'
+          ) as HTMLSpanElement).innerText = `Attendee ID: ${this.meetingSession.configuration.credentials.attendeeId}`;
+          (document.getElementById(
+            'desktop-attendee-id'
+          ) as HTMLSpanElement).innerText = `Attendee ID: ${this.meetingSession.configuration.credentials.attendeeId}`;
           (document.getElementById('info-meeting') as HTMLSpanElement).innerText = this.meeting;
           (document.getElementById('info-name') as HTMLSpanElement).innerText = this.name;
           this.switchToFlow('flow-devices');

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -102,7 +102,10 @@ exports.logs = async (event, context) => {
   const body = JSON.parse(event.body);
   if (!body.logs || !body.meetingId || !body.attendeeId || !body.appName) {
     return response(400, 'application/json', JSON.stringify({error: 'Need properties: logs, meetingId, attendeeId, appName'}));
+  } else if (!body.logs.length) {
+    return response(200, 'application/json', JSON.stringify({}));
   }
+
   const logStreamName = `ChimeSDKMeeting_${body.meetingId.toString()}`;
   const cloudWatchClient = new AWS.CloudWatchLogs({ apiVersion: '2014-03-28' });
   const putLogEventsInput = {
@@ -114,9 +117,6 @@ exports.logs = async (event, context) => {
     putLogEventsInput.sequenceToken = uploadSequence;
   }
   const logEvents = [];
-  if (body.logs.length !== 0) {
-    return response(200, 'application/json', JSON.stringify({}));
-  }
   for (let i = 0; i < body.logs.length; i++) {
     const log = body.logs[i];
     const timestamp = new Date(log.timestampMs).toISOString();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.4.19';
+    return '1.4.20';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
N/A

**Description of changes:**
- Display meeting and attendee IDs in mobile and desktop screen
- Fix the serverless demo's CloudWatch handler

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Use the simulator to ensure meeting and attendee IDs show up at the top. They are required to debug logs uploaded by CloudWatch logger

<img width="320" alt="Screen Shot 2020-05-06 at 5 18 26 PM" src="https://user-images.githubusercontent.com/36240708/81240900-9e8f3e00-8fbd-11ea-9905-e08efb065f4e.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
