### PR TITLE
Update README.md

### DIFF
--- a/demos/serverless/README.md
+++ b/demos/serverless/README.md
@@ -23,6 +23,7 @@ API Gateway deployment that runs the `meeting` demo.
 
 ```
 cd demos/serverless
+npm install
 npm run deploy -- -r us-east-1 -b <my-bucket> -s <my-stack-name> -a meeting
 ```
 


### PR DESCRIPTION
adding npm install command before deploy, which is missing when executing deploy

**Issue #:** 
Got the following error while trying to deploy following the readme:

```
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'fs-extra'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/home/ubuntu/environment/amazon-chime-sdk-js/demos/serverless/deploy.js:2:12)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! amazon-chime-sdk-js-serverless-demos@0.1.0 deploy: `node ./deploy.js "-r" "us-east-1" "-b" "aaavvvv-chime-new-jsssss" "-s" "new-chime-js" "-a" "meeting"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the amazon-chime-sdk-js-serverless-demos@0.1.0 deploy script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2020-05-10T10_16_27_696Z-debug.log
```

**Description of changes:**
missing npm install command

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
follow the read me guidelines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
