### PR TITLE
Allow option to skip device selection page in demo app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Allow option to skip device selection page in demo app.
 ### Changed
 - Allow audio for screen capture in Chrome and Edge browsers
 ### Removed

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -217,7 +217,16 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           ) as HTMLSpanElement).innerText = `Attendee ID: ${this.meetingSession.configuration.credentials.attendeeId}`;
           (document.getElementById('info-meeting') as HTMLSpanElement).innerText = this.meeting;
           (document.getElementById('info-name') as HTMLSpanElement).innerText = this.name;
-          this.switchToFlow('flow-devices');
+
+          if(this.skipDeviceSelection()) {
+            await this.authenticate();
+            await this.join();
+            this.displayButtonStates();
+            this.switchToFlow('flow-meeting');
+          } else {
+            this.switchToFlow('flow-devices');
+          }
+
           await this.openAudioInputFromSelection();
           try {
             await this.openVideoInputFromSelection(
@@ -1143,6 +1152,10 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
 
   isRecorder(): boolean {
     return (new URL(window.location.href).searchParams.get('record')) === 'true';
+  }
+
+  skipDeviceSelection(): boolean {
+    return (new URL(window.location.href).searchParams.get('device')) === 'default';
   }
 
   async authenticate(): Promise<string> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.5.1';
+    return '1.5.2';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Added an option to skip the device selection page in the demo app.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
By running `npm run start` and visiting the URL `http://127.0.0.1:8080/?device=default` and ensured after hitting `Continue` button, it directly goes to the meeting page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
