### PR TITLE
Use getSettings if possile on MediaStream and remove some verbose logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Allow audio for screen capture in Chrome and Edge browsers
 - Decouple the get call request from the UI
+- Use getSettings if possile on MediaStream
 
 ### Removed
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.674.0",
+    "aws-sdk": "^2.675.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/docs/classes/createpeerconnectiontask.html
+++ b/docs/classes/createpeerconnectiontask.html
@@ -324,7 +324,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L170">src/task/CreatePeerConnectionTask.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L174">src/task/CreatePeerConnectionTask.ts:174</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -350,7 +350,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L145">src/task/CreatePeerConnectionTask.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L149">src/task/CreatePeerConnectionTask.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -486,7 +486,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L258">src/task/CreatePeerConnectionTask.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L263">src/task/CreatePeerConnectionTask.ts:263</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -819,7 +819,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L656">src/audiovideocontroller/DefaultAudioVideoController.ts:656</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L655">src/audiovideocontroller/DefaultAudioVideoController.ts:655</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -961,7 +961,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L662">src/audiovideocontroller/DefaultAudioVideoController.ts:662</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L661">src/audiovideocontroller/DefaultAudioVideoController.ts:661</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaulttransceivercontroller.html
+++ b/docs/classes/defaulttransceivercontroller.html
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L243">src/transceivercontroller/DefaultTransceiverController.ts:243</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L242">src/transceivercontroller/DefaultTransceiverController.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localaudiotransceiver">localAudioTransceiver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L50">src/transceivercontroller/DefaultTransceiverController.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L49">src/transceivercontroller/DefaultTransceiverController.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localvideotransceiver">localVideoTransceiver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L53">src/transceivercontroller/DefaultTransceiverController.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L52">src/transceivercontroller/DefaultTransceiverController.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#replaceaudiotrack">replaceAudioTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L124">src/transceivercontroller/DefaultTransceiverController.ts:124</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L123">src/transceivercontroller/DefaultTransceiverController.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L74">src/transceivercontroller/DefaultTransceiverController.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L73">src/transceivercontroller/DefaultTransceiverController.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -339,7 +339,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setaudioinput">setAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L133">src/transceivercontroller/DefaultTransceiverController.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L132">src/transceivercontroller/DefaultTransceiverController.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -363,7 +363,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setpeer">setPeer</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L70">src/transceivercontroller/DefaultTransceiverController.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L69">src/transceivercontroller/DefaultTransceiverController.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L257">src/transceivercontroller/DefaultTransceiverController.ts:257</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L256">src/transceivercontroller/DefaultTransceiverController.ts:256</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -413,7 +413,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideoinput">setVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L138">src/transceivercontroller/DefaultTransceiverController.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L137">src/transceivercontroller/DefaultTransceiverController.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -437,7 +437,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideosendingbitratekbps">setVideoSendingBitrateKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L57">src/transceivercontroller/DefaultTransceiverController.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L56">src/transceivercontroller/DefaultTransceiverController.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -461,7 +461,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setuplocaltransceivers">setupLocalTransceivers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L100">src/transceivercontroller/DefaultTransceiverController.ts:100</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L99">src/transceivercontroller/DefaultTransceiverController.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -478,7 +478,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L191">src/transceivercontroller/DefaultTransceiverController.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L190">src/transceivercontroller/DefaultTransceiverController.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -505,7 +505,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#trackisvideoinput">trackIsVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L90">src/transceivercontroller/DefaultTransceiverController.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L89">src/transceivercontroller/DefaultTransceiverController.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -528,7 +528,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L234">src/transceivercontroller/DefaultTransceiverController.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L233">src/transceivercontroller/DefaultTransceiverController.ts:233</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -551,7 +551,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L166">src/transceivercontroller/DefaultTransceiverController.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L165">src/transceivercontroller/DefaultTransceiverController.ts:165</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -581,7 +581,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#updatevideotransceivers">updateVideoTransceivers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L143">src/transceivercontroller/DefaultTransceiverController.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L142">src/transceivercontroller/DefaultTransceiverController.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -608,7 +608,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#usetransceivers">useTransceivers</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L82">src/transceivercontroller/DefaultTransceiverController.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L81">src/transceivercontroller/DefaultTransceiverController.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -625,7 +625,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L38">src/transceivercontroller/DefaultTransceiverController.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L37">src/transceivercontroller/DefaultTransceiverController.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -645,7 +645,7 @@
 					<a name="setvideosendingbitratekbpsforsender" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> set<wbr>Video<wbr>Sending<wbr>Bitrate<wbr>Kbps<wbr>For<wbr>Sender</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">set<wbr>Video<wbr>Sending<wbr>Bitrate<wbr>Kbps<wbr>For<wbr>Sender<span class="tsd-signature-symbol">(</span>sender<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RTCRtpSender</span>, bitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, logger<span class="tsd-signature-symbol">: </span><a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">set<wbr>Video<wbr>Sending<wbr>Bitrate<wbr>Kbps<wbr>For<wbr>Sender<span class="tsd-signature-symbol">(</span>sender<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RTCRtpSender</span>, bitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, _logger<span class="tsd-signature-symbol">: </span><a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -663,7 +663,7 @@
 									<h5>bitrateKbps: <span class="tsd-signature-type">number</span></h5>
 								</li>
 								<li>
-									<h5>logger: <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h5>
+									<h5>_logger: <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -460,7 +460,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L656">src/audiovideocontroller/DefaultAudioVideoController.ts:656</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L655">src/audiovideocontroller/DefaultAudioVideoController.ts:655</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -607,7 +607,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L662">src/audiovideocontroller/DefaultAudioVideoController.ts:662</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L661">src/audiovideocontroller/DefaultAudioVideoController.ts:661</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -638,7 +638,6 @@ export default class DefaultAudioVideoController implements AudioVideoController
 
   async handleHasBandwidthPriority(hasBandwidthPriority: boolean): Promise<void> {
     if (this.meetingSessionContext && this.meetingSessionContext.videoUplinkBandwidthPolicy) {
-      this.logger.info(`video send has bandwidth priority: ${hasBandwidthPriority}`);
       const oldMaxBandwidth = this.meetingSessionContext.videoUplinkBandwidthPolicy.maxBandwidthKbps();
       this.meetingSessionContext.videoUplinkBandwidthPolicy.setHasBandwidthPriority(
         hasBandwidthPriority
@@ -646,7 +645,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
       const newMaxBandwidth = this.meetingSessionContext.videoUplinkBandwidthPolicy.maxBandwidthKbps();
       if (oldMaxBandwidth !== newMaxBandwidth) {
         this.logger.info(
-          `video send bandwidth max has changed from ${oldMaxBandwidth} kbps to ${newMaxBandwidth} kbps`
+          `video send bandwidth priority ${hasBandwidthPriority} max has changed from ${oldMaxBandwidth} kbps to ${newMaxBandwidth} kbps`
         );
         await this.enforceBandwidthLimitationForSender(newMaxBandwidth);
       }

--- a/src/task/CreatePeerConnectionTask.ts
+++ b/src/task/CreatePeerConnectionTask.ts
@@ -129,10 +129,14 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
 
   private trackIsVideoInput(track: MediaStreamTrack): boolean {
     if (this.context.transceiverController.useTransceivers()) {
-      this.logger.info(`getting video track type (unified-plan)`);
+      this.logger.debug(() => {
+        return `getting video track type (unified-plan)`;
+      });
       return this.context.transceiverController.trackIsVideoInput(track);
     }
-    this.logger.info(`getting video track type (plan-b)`);
+    this.logger.debug(() => {
+      return `getting video track type (plan-b)`;
+    });
     if (this.context.activeVideoInput) {
       const tracks = this.context.activeVideoInput.getVideoTracks();
       if (tracks && tracks.length > 0 && tracks[0].id === track.id) {
@@ -170,7 +174,6 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
   private addRemoteVideoTrack(track: MediaStreamTrack, stream: MediaStream): void {
     let trackId = stream.id;
     if (!this.context.browserBehavior.requiresUnifiedPlan()) {
-      this.logger.info('redefining MediaStream as track array (plan-b)');
       stream = new MediaStream([track]);
       trackId = track.id;
     }
@@ -181,7 +184,7 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     // why this can happen, so adding a log statement to track this and learn more.
     const tilesRemoved = this.context.videoTileController.removeVideoTilesByAttendeeId(attendeeId);
     if (tilesRemoved.length > 0) {
-      this.logger.warn(
+      this.logger.info(
         `removing existing tiles ${tilesRemoved} with same attendee id ${attendeeId}`
       );
     }
@@ -217,12 +220,12 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
 
     let width: number;
     let height: number;
-    if (track.getCapabilities) {
-      const cap: MediaTrackCapabilities = track.getCapabilities();
+    if (track.getSettings) {
+      const cap: MediaTrackSettings = track.getSettings();
       width = cap.width as number;
       height = cap.height as number;
     } else {
-      const cap: MediaTrackSettings = track.getSettings();
+      const cap: MediaTrackCapabilities = track.getCapabilities();
       width = cap.width as number;
       height = cap.height as number;
     }
@@ -241,7 +244,9 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     let endEvent = 'removetrack';
     let target: MediaStream = stream;
     if (!this.context.browserBehavior.requiresUnifiedPlan()) {
-      this.logger.info('updating end event and target track (plan-b)');
+      this.logger.debug(() => {
+        return 'updating end event and target track (plan-b)';
+      });
       endEvent = 'ended';
       // @ts-ignore
       target = track;

--- a/src/task/SetLocalDescriptionTask.ts
+++ b/src/task/SetLocalDescriptionTask.ts
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
@@ -24,7 +24,9 @@ export default class SetLocalDescriptionTask extends BaseTask {
   async run(): Promise<void> {
     const peer = this.context.peer;
     const sdpOffer = this.context.sdpOfferInit;
-    this.logger.info(`local description is >>>${sdpOffer.sdp}<<<`);
+    this.logger.debug(() => {
+      return `local description is >>>${sdpOffer.sdp}<<<`;
+    });
 
     await new Promise<void>(async (resolve, reject) => {
       this.cancelPromise = (error: Error) => {

--- a/src/transceivercontroller/DefaultTransceiverController.ts
+++ b/src/transceivercontroller/DefaultTransceiverController.ts
@@ -19,7 +19,7 @@ export default class DefaultTransceiverController implements TransceiverControll
   static async setVideoSendingBitrateKbpsForSender(
     sender: RTCRtpSender,
     bitrateKbps: number,
-    logger: Logger
+    _logger: Logger
   ): Promise<void> {
     if (!sender || bitrateKbps <= 0) {
       return;
@@ -32,7 +32,6 @@ export default class DefaultTransceiverController implements TransceiverControll
       encodeParam.maxBitrate = bitrateKbps * 1000;
     }
     await sender.setParameters(param);
-    logger.info(`set video send bandwidth to ${bitrateKbps}kbps`);
   }
 
   static async replaceAudioTrackForSender(

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.5.3';
+    return '1.5.4';
   }
 
   /**

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -300,11 +300,14 @@ describe('CreatePeerConnectionTask', () => {
         expect(tile.state().streamId).to.equal(streamId);
       });
 
-      it('uses getCapabilities if available in the track', async () => {
+      it('uses getCapabilities if getSettings is not available in the track', async () => {
         domMockBehavior.mediaStreamTrackCapabilities = {
           width: 640,
           height: 480,
         };
+
+        // eslint-disable-next-line
+        delete MediaStreamTrack.prototype['getSettings'];
 
         let tile: VideoTile;
         const attendeeIdForTrack = 'attendee-id';
@@ -339,7 +342,7 @@ describe('CreatePeerConnectionTask', () => {
         );
       });
 
-      it('uses getSettings if getCapabilities is not available in the track', async () => {
+      it('uses getSettings if available', async () => {
         domMockBehavior.mediaStreamTrackCapabilities = {
           width: 400,
           height: 300,
@@ -351,9 +354,6 @@ describe('CreatePeerConnectionTask', () => {
         };
 
         let tile: VideoTile;
-
-        // eslint-disable-next-line
-        delete MediaStreamTrack.prototype['getCapabilities'];
 
         const attendeeIdForTrack = 'attendee-id';
         context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Use getSettings if possile on MediaStream and remove some verbose logs
**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes

2. How did you test these changes?

With demo client, smoke testing 3 video meetings


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
