### PR TITLE
Disable audio capture for Electron Screen Capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+ 
+### Added 
+
+### Changed
+
+### Removed
+
+### Fixed
+- Disable audio capture for Electron Screen Capture
+
 ## [1.6.0] - 2020-05-15
 
 ### Added

--- a/docs/classes/contentsharemediastreambroker.html
+++ b/docs/classes/contentsharemediastreambroker.html
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L106">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L109">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L93">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:93</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L96">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/contentsharecontroller/ContentShareMediaStreamBroker.ts
+++ b/src/contentsharecontroller/ContentShareMediaStreamBroker.ts
@@ -72,7 +72,10 @@ export default class ContentShareMediaStreamBroker implements MediaStreamBroker 
     frameRate?: number
   ): MediaStreamConstraints {
     return {
-      audio: new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport() ? true : false,
+      audio:
+        !sourceId && new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()
+          ? true
+          : false,
       video: {
         ...(!sourceId && {
           frameRate: {

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.0';
+    return '1.6.1';
   }
 
   /**

--- a/test/contentsharecontroller/ContentShareMediaStreamBroker.test.ts
+++ b/test/contentsharecontroller/ContentShareMediaStreamBroker.test.ts
@@ -205,6 +205,25 @@ describe('ContentShareMediaStreamBroker', () => {
       await contentShareMediaStreamBroker.acquireScreenCaptureDisplayInputStream();
       expect(spy.calledWith(sinon.match(streamConstraints))).to.be.true;
     });
+
+    it('disable audio in Electron', async () => {
+      dommMockBehavior.browserName = 'chrome';
+      domMockBuilder = new DOMMockBuilder(dommMockBehavior);
+      const streamConstraints: MediaStreamConstraints = {
+        audio: false,
+        video: {
+          // @ts-ignore
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: 'sourceId',
+            maxFrameRate: 15,
+          },
+        },
+      };
+      const spy = sinon.spy(contentShareMediaStreamBroker, 'acquireDisplayInputStream');
+      await contentShareMediaStreamBroker.acquireScreenCaptureDisplayInputStream('sourceId');
+      expect(spy.calledWith(sinon.match(streamConstraints))).to.be.true;
+    });
   });
 
   describe('toggleMediaStream', () => {


### PR DESCRIPTION
**Description of changes:**
Disable audio capture for Electron Screen Capture
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually tested with https://github.com/aws-samples/amazon-chime-sdk-classroom-demo and verified that the app does not crash when picking screen to share.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
