### PR TITLE
Style the chat area and add Markdown support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an integration test for Data Message
 
 ### Changed
+- Styling and Markdown support for meeting demo chat
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -286,11 +286,11 @@
           <ul id="roster" class="list-group"></ul>
         </div>
         <div class="message d-flex flex-column pt-3" style="flex: 1 1 auto; overflow: hidden; height: 50%;">
-          <div class="receive-message" id="receive-message" style="flex: 1 1 auto; overflow-y: scroll;
+          <div class="list-group receive-message" id="receive-message" style="flex: 1 1 auto; overflow-y: scroll;
             border: 1px solid rgba(0, 0, 0, 0.125); background-color: #fff"></div>
-          <div class="send-message" style="display:flex;flex:0 0 auto;">
-            <textarea id="send-message" rows="1" placeholder="Enter message" style="display:inline-block; width:100%;
-              resize:none; border-color: rgba(0, 0, 0, 0.125); outline: none"></textarea>
+          <div class="input-group send-message" style="display:flex;flex:0 0 auto;margin-top:0.2rem">
+            <textarea class="form-control shadow-none" id="send-message" rows="1" placeholder="Type a message (markdown supported)" style="display:inline-block; width:100%;
+              resize:none; border-color: rgba(0, 0, 0, 0.125); outline: none; padding-left: 1.4rem"></textarea>
           </div>
         </div>
       </div>

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -424,3 +424,56 @@ svg {
     height: 210px !important;
   }
 }
+
+.markdown {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+a.markdown:link {
+  color: rgb(39, 137, 144);
+}
+
+a.markdown:visited {
+  color: rgb(39, 137, 144);
+}
+
+a.markdown:hover {
+  color: rgb(39, 137, 144);
+}
+
+a.markdown:active {
+  color: rgb(39, 137, 144);
+}
+
+.message-bubble-self {
+  border-radius: 5px;
+  background-color: rgb(238, 248, 248);
+  border-width: 1px;
+  border-style: solid;
+  border-color: rgb(134, 209, 215);
+  padding: 0.3rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 0rem;
+  margin-bottom: 0.5rem;
+}
+
+.message-bubble-other {
+  border-radius: 5px;
+  background-color: rgb(241, 241, 241);
+  border-style: none;
+  padding: 0.3rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 0rem;
+  margin-bottom: 0.5rem;
+}
+
+.message-bubble-sender {
+  font-weight: bold;
+  margin-left: 1.3rem;
+  margin-right: 1rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -17,6 +17,7 @@
     "file-loader": "^4.2.0",
     "html-webpack-inline-source-plugin": "^0.0.10",
     "html-webpack-plugin": "^3.2.0",
+    "markdown-it": "^10.0.0",
     "node-sass": "^4.12.0",
     "open-iconic": "^1.1.1",
     "postcss-loader": "^3.0.0",
@@ -31,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.678.0",
+    "aws-sdk": "^2.680.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.5';
+    return '1.6.6';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**

Style the chat area and add Markdown support in the meeting demo.

![chatstyling](https://user-images.githubusercontent.com/18272283/82376099-7b5d8900-99d6-11ea-82d3-fda0f498ae07.png)

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

Using the meeting demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
