### PR TITLE
Fix data message integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix Firefox version 76 missing/grey tiles
+- Fix data message integration tests
 
 ## [1.6.2] - 2020-05-18
 

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -502,7 +502,7 @@ class AppPage {
   }
 
   async checkDataMessageExist(message) {
-    const dataMessageSpan = await this.driver.findElement(By.xpath(`//div[@id='receive-message']//*[text() = ':${message}']`));
+    const dataMessageSpan = await this.driver.findElement(By.xpath(`//div[@id='receive-message']//*[text() = '${message}']`));
     return dataMessageSpan? true: false;
   }
 }

--- a/integration/js/script/failure-check
+++ b/integration/js/script/failure-check
@@ -4,7 +4,7 @@ require "json"
 failure_reasons = {}
 
 def failure_reason(failed_step)
-  if failed_step["attachments"] != nil
+  if failed_step["attachments"].nil? and failed_step["attachments"].empty?
     puts "\s\sFailure reason: "
     failed_step["attachments"].each do |attachment|
       File.open("./kite-allure-reports/#{attachment["source"]}") do |f|
@@ -49,7 +49,7 @@ def explain_failure(failed_run)
   get_run_configuration(failed_run["name"])
   puts "Failure details:"
   failed_run["steps"].each do |step|
-    if (step["status"] == "FAILED")
+    if ["FAILED", "BROKEN"].include?(step["status"])
       puts "\s#{step["name"]}"
       failure_reason(step)
     end
@@ -64,7 +64,7 @@ resultFiles = Dir["./kite-allure-reports/*result.json"]
 resultFiles.each do |resultFile|
   file = File.read(resultFile)
   result = JSON.parse(file)
-  if (result["status"]) == "FAILED"
+  if ["FAILED", "BROKEN"].include?(result["status"])
     isFailed = true
     explain_failure(result)
   end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.6';
+    return '1.6.7';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
- Remove the : prefix when checking for message since it is no longer there with the latest change in the demo app
- Make sure we also fail in Travis if the test return BROKEN which happens when Selenium errors out.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
