### PR TITLE
Don't throw the "cannot replace" message if the audio-video controller is not bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add connectionDidBecomeGood callback in AudioVideoObserver
 - Add an integration test for Data Message
+- Add the device selection to the "Starting a session" example
 
 ### Changed
 - Styling and Markdown support for meeting demo chat
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix several integration test name
 - Mark 403 (Forbidden) for fetching turn credentials as terminal error and avoid retrying.
 - Fix Android Pixel3 Chrome Video artifacts on far sites
+- Don't throw the "cannot replace" message if the device controller is not bound to any audio-video controller
 
 ## [1.6.2] - 2020-05-18
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,18 @@ meetingSession.audioVideo.addDeviceChangeObserver(observer);
 
 **Use case 5.** Start a session. To hear audio, you need to bind a device and stream to an `<audio>` element.
 Once the session has started, you can talk and listen to attendees.
-Make sure you have chosen your microphone and speaker (See the "Device" section), and at least one other attendee has joined the session.
 
 ```js
+// Before starting a session, make sure you have chosen your microphone and speaker.
+// chooseAudioInputDevice and chooseAudioOutputDevice are async functions that return a Promise.
+// In this example, the await operator is used to wait for a Promise to resolve.
+
+const audioInputDeviceInfo = /* An array item from meetingSession.audioVideo.listAudioInputDevices */;
+await meetingSession.audioVideo.chooseAudioInputDevice(audioInputDeviceInfo.deviceId);
+
+const audioOutputDeviceInfo = /* An array item from meetingSession.audioVideo.listAudioOutputDevices */;
+await meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDeviceInfo.deviceId);
+
 const audioElement = /* HTMLAudioElement object e.g. document.getElementById('audio-element-id') */;
 meetingSession.audioVideo.bindAudioElement(audioElement);
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.680.0",
+    "aws-sdk": "^2.682.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -514,7 +514,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L667">src/devicecontroller/DefaultDeviceController.ts:667</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L669">src/devicecontroller/DefaultDeviceController.ts:669</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -605,7 +605,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L708">src/devicecontroller/DefaultDeviceController.ts:708</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L710">src/devicecontroller/DefaultDeviceController.ts:710</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -628,7 +628,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L578">src/devicecontroller/DefaultDeviceController.ts:578</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L580">src/devicecontroller/DefaultDeviceController.ts:580</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -669,7 +669,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L587">src/devicecontroller/DefaultDeviceController.ts:587</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L589">src/devicecontroller/DefaultDeviceController.ts:589</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -870,7 +870,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L652">src/devicecontroller/DefaultDeviceController.ts:652</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L654">src/devicecontroller/DefaultDeviceController.ts:654</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -937,7 +937,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L700">src/devicecontroller/DefaultDeviceController.ts:700</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L702">src/devicecontroller/DefaultDeviceController.ts:702</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -995,7 +995,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L642">src/devicecontroller/DefaultDeviceController.ts:642</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L644">src/devicecontroller/DefaultDeviceController.ts:644</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1289,7 +1289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L734">src/devicecontroller/DefaultDeviceController.ts:734</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L736">src/devicecontroller/DefaultDeviceController.ts:736</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1306,7 +1306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L726">src/devicecontroller/DefaultDeviceController.ts:726</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L728">src/devicecontroller/DefaultDeviceController.ts:728</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1323,7 +1323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L730">src/devicecontroller/DefaultDeviceController.ts:730</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L732">src/devicecontroller/DefaultDeviceController.ts:732</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1340,7 +1340,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L739">src/devicecontroller/DefaultDeviceController.ts:739</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L741">src/devicecontroller/DefaultDeviceController.ts:741</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1403,7 +1403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L717">src/devicecontroller/DefaultDeviceController.ts:717</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L719">src/devicecontroller/DefaultDeviceController.ts:719</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -260,9 +260,18 @@ meetingSession.audioVideo.addDeviceChangeObserver(observer);</code></pre>
 					<h3>Starting a session</h3>
 				</a>
 				<p><strong>Use case 5.</strong> Start a session. To hear audio, you need to bind a device and stream to an <code>&lt;audio&gt;</code> element.
-					Once the session has started, you can talk and listen to attendees.
-				Make sure you have chosen your microphone and speaker (See the &quot;Device&quot; section), and at least one other attendee has joined the session.</p>
-				<pre><code class="language-js"><span class="hljs-keyword">const</span> audioElement = <span class="hljs-comment">/* HTMLAudioElement object e.g. document.getElementById('audio-element-id') */</span>;
+				Once the session has started, you can talk and listen to attendees.</p>
+				<pre><code class="language-js"><span class="hljs-comment">// Before starting a session, make sure you have chosen your microphone and speaker.</span>
+<span class="hljs-comment">// chooseAudioInputDevice and chooseAudioOutputDevice are async functions that return a Promise.</span>
+<span class="hljs-comment">// In this example, the await operator is used to wait for a Promise to resolve.</span>
+
+<span class="hljs-keyword">const</span> audioInputDeviceInfo = <span class="hljs-comment">/* An array item from meetingSession.audioVideo.listAudioInputDevices */</span>;
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioInputDevice(audioInputDeviceInfo.deviceId);
+
+<span class="hljs-keyword">const</span> audioOutputDeviceInfo = <span class="hljs-comment">/* An array item from meetingSession.audioVideo.listAudioOutputDevices */</span>;
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDeviceInfo.deviceId);
+
+<span class="hljs-keyword">const</span> audioElement = <span class="hljs-comment">/* HTMLAudioElement object e.g. document.getElementById('audio-element-id') */</span>;
 meetingSession.audioVideo.bindAudioElement(audioElement);
 
 <span class="hljs-keyword">const</span> observer = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -563,7 +563,9 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
         this.attachAudioInputStreamToAudioContext(this.activeDevices[kind].stream);
       } else {
         try {
-          await this.boundAudioVideoController.restartLocalAudio(() => {});
+          if (this.boundAudioVideoController) {
+            await this.boundAudioVideoController.restartLocalAudio(() => {});
+          }
         } catch (error) {
           this.logger.info(`cannot replace audio track due to: ${error.message}`);
         }

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.10';
+    return '1.6.11';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
https://github.com/aws/amazon-chime-sdk-js/issues/370

**Description of changes:**
- Add the device selection example
- Don't log this info message:
  `[INFO] cannot replace audio track due to: undefined is not an object`

   The device controller logs this message if no audio-video controller is bound. Using the device controller solely shouldn't be an issue.

**Testing**

1. Have you successfully run `npm run build:release` locally?
   Yes
2. How did you test these changes?
   I tested these changes by instantiating `DeviceController` and calling `chooseAudioInputDevice`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
