### PR TITLE
Differentiate between attendee dropped and left.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an integration test for Data Message
 - Add the device selection to the "Starting a session" example
 - Added Bandwidth and connectivity guide
+- Add 'dropped' boolean attribute to realtime interface to indicate attendee drop
 
 ### Changed
 - Styling and Markdown support for meeting demo chat

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -747,13 +747,14 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   }
 
   setupSubscribeToAttendeeIdPresenceHandler(): void {
-    const handler = (attendeeId: string, present: boolean, externalUserId: string): void => {
+    const handler = (attendeeId: string, present: boolean, externalUserId: string, dropped: boolean): void => {
       this.log(`${attendeeId} present = ${present} (${externalUserId})`);
       const isContentAttendee = new DefaultModality(attendeeId).hasModality(DefaultModality.MODALITY_CONTENT);
       const isSelfAttendee = new DefaultModality(attendeeId).base() === this.meetingSession.configuration.credentials.attendeeId;
       if (!present) {
         delete this.roster[attendeeId];
         this.updateRoster();
+        this.log(`${attendeeId} dropped = ${dropped} (${externalUserId})`);
         return;
       }
       //If someone else share content, stop the current content share

--- a/docs/classes/createpeerconnectiontask.html
+++ b/docs/classes/createpeerconnectiontask.html
@@ -145,7 +145,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L32">src/task/CreatePeerConnectionTask.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L37">src/task/CreatePeerConnectionTask.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L35">src/task/CreatePeerConnectionTask.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L40">src/task/CreatePeerConnectionTask.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">external<wbr>User<wbr>IdTimeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L36">src/task/CreatePeerConnectionTask.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L41">src/task/CreatePeerConnectionTask.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
 					<a name="presencehandlerset" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> presence<wbr>Handler<wbr>Set</h3>
-					<div class="tsd-signature tsd-kind-icon">presence<wbr>Handler<wbr>Set<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;(attendeeId: string, present: boolean, externalUserId?: string | null) &#x3D;&gt; void&gt;()</span></div>
+					<div class="tsd-signature tsd-kind-icon">presence<wbr>Handler<wbr>Set<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, dropped<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;(attendeeId: string,present: boolean,externalUserId: string | null,dropped: boolean | null) &#x3D;&gt; void&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L19">src/task/CreatePeerConnectionTask.ts:19</a></li>
@@ -251,7 +251,7 @@
 					<div class="tsd-signature tsd-kind-icon">remove<wbr>Video<wbr>Track<wbr>Event<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L30">src/task/CreatePeerConnectionTask.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L35">src/task/CreatePeerConnectionTask.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">track<wbr>Events<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&#x27;ended&#x27;,&#x27;mute&#x27;,&#x27;unmute&#x27;,&#x27;isolationchange&#x27;,&#x27;overconstrained&#x27;,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L23">src/task/CreatePeerConnectionTask.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L28">src/task/CreatePeerConnectionTask.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -290,7 +290,7 @@
 					<div class="tsd-signature tsd-kind-icon">REMOVE_<wbr>HANDLER_<wbr>INTERVAL_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L32">src/task/CreatePeerConnectionTask.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L37">src/task/CreatePeerConnectionTask.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -307,7 +307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L52">src/task/CreatePeerConnectionTask.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L57">src/task/CreatePeerConnectionTask.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -324,7 +324,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L180">src/task/CreatePeerConnectionTask.ts:180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L190">src/task/CreatePeerConnectionTask.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -350,7 +350,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L155">src/task/CreatePeerConnectionTask.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L160">src/task/CreatePeerConnectionTask.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -469,7 +469,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L41">src/task/CreatePeerConnectionTask.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L46">src/task/CreatePeerConnectionTask.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -486,7 +486,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L262">src/task/CreatePeerConnectionTask.ts:262</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L272">src/task/CreatePeerConnectionTask.ts:272</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -514,7 +514,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L77">src/task/CreatePeerConnectionTask.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L82">src/task/CreatePeerConnectionTask.ts:82</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -556,7 +556,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L118">src/task/CreatePeerConnectionTask.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L123">src/task/CreatePeerConnectionTask.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -579,7 +579,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L136">src/task/CreatePeerConnectionTask.ts:136</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L141">src/task/CreatePeerConnectionTask.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultaudiovideofacade.html
+++ b/docs/classes/defaultaudiovideofacade.html
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L422">src/audiovideofacade/DefaultAudioVideoFacade.ts:422</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L432">src/audiovideofacade/DefaultAudioVideoFacade.ts:432</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L335">src/audiovideofacade/DefaultAudioVideoFacade.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L345">src/audiovideofacade/DefaultAudioVideoFacade.ts:345</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -460,7 +460,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L317">src/audiovideofacade/DefaultAudioVideoFacade.ts:317</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L327">src/audiovideofacade/DefaultAudioVideoFacade.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L329">src/audiovideofacade/DefaultAudioVideoFacade.ts:329</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L339">src/audiovideofacade/DefaultAudioVideoFacade.ts:339</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -508,7 +508,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L323">src/audiovideofacade/DefaultAudioVideoFacade.ts:323</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L333">src/audiovideofacade/DefaultAudioVideoFacade.ts:333</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -532,7 +532,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L372">src/audiovideofacade/DefaultAudioVideoFacade.ts:372</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L382">src/audiovideofacade/DefaultAudioVideoFacade.ts:382</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -565,7 +565,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L345">src/audiovideofacade/DefaultAudioVideoFacade.ts:345</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L355">src/audiovideofacade/DefaultAudioVideoFacade.ts:355</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AnalyserNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -583,7 +583,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L387">src/audiovideofacade/DefaultAudioVideoFacade.ts:387</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L397">src/audiovideofacade/DefaultAudioVideoFacade.ts:397</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -727,7 +727,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L299">src/audiovideofacade/DefaultAudioVideoFacade.ts:299</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L309">src/audiovideofacade/DefaultAudioVideoFacade.ts:309</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -745,7 +745,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L311">src/audiovideofacade/DefaultAudioVideoFacade.ts:311</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L321">src/audiovideofacade/DefaultAudioVideoFacade.ts:321</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -763,7 +763,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L305">src/audiovideofacade/DefaultAudioVideoFacade.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L315">src/audiovideofacade/DefaultAudioVideoFacade.ts:315</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -781,7 +781,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L366">src/audiovideofacade/DefaultAudioVideoFacade.ts:366</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L376">src/audiovideofacade/DefaultAudioVideoFacade.ts:376</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -805,7 +805,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L407">src/audiovideofacade/DefaultAudioVideoFacade.ts:407</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L417">src/audiovideofacade/DefaultAudioVideoFacade.ts:417</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -847,7 +847,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L188">src/audiovideofacade/DefaultAudioVideoFacade.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L198">src/audiovideofacade/DefaultAudioVideoFacade.ts:198</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -865,7 +865,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L214">src/audiovideofacade/DefaultAudioVideoFacade.ts:214</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L224">src/audiovideofacade/DefaultAudioVideoFacade.ts:224</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -883,7 +883,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L194">src/audiovideofacade/DefaultAudioVideoFacade.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L204">src/audiovideofacade/DefaultAudioVideoFacade.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -901,7 +901,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L249">src/audiovideofacade/DefaultAudioVideoFacade.ts:249</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L259">src/audiovideofacade/DefaultAudioVideoFacade.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -931,7 +931,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L174">src/audiovideofacade/DefaultAudioVideoFacade.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L184">src/audiovideofacade/DefaultAudioVideoFacade.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -948,7 +948,7 @@
 					<a name="realtimesubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -960,11 +960,11 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -978,6 +978,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1001,7 +1004,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L271">src/audiovideofacade/DefaultAudioVideoFacade.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L281">src/audiovideofacade/DefaultAudioVideoFacade.ts:281</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1042,7 +1045,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L239">src/audiovideofacade/DefaultAudioVideoFacade.ts:239</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L249">src/audiovideofacade/DefaultAudioVideoFacade.ts:249</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1083,7 +1086,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L205">src/audiovideofacade/DefaultAudioVideoFacade.ts:205</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L215">src/audiovideofacade/DefaultAudioVideoFacade.ts:215</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1124,7 +1127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L258">src/audiovideofacade/DefaultAudioVideoFacade.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L268">src/audiovideofacade/DefaultAudioVideoFacade.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1168,7 +1171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L179">src/audiovideofacade/DefaultAudioVideoFacade.ts:179</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L189">src/audiovideofacade/DefaultAudioVideoFacade.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1209,7 +1212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L220">src/audiovideofacade/DefaultAudioVideoFacade.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L230">src/audiovideofacade/DefaultAudioVideoFacade.ts:230</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1266,7 +1269,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L199">src/audiovideofacade/DefaultAudioVideoFacade.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L209">src/audiovideofacade/DefaultAudioVideoFacade.ts:209</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1284,7 +1287,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L266">src/audiovideofacade/DefaultAudioVideoFacade.ts:266</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L276">src/audiovideofacade/DefaultAudioVideoFacade.ts:276</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1308,7 +1311,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L234">src/audiovideofacade/DefaultAudioVideoFacade.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L244">src/audiovideofacade/DefaultAudioVideoFacade.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1325,23 +1328,23 @@
 					<a name="realtimeunsubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L167">src/audiovideofacade/DefaultAudioVideoFacade.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L172">src/audiovideofacade/DefaultAudioVideoFacade.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -1355,6 +1358,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1378,7 +1384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L275">src/audiovideofacade/DefaultAudioVideoFacade.ts:275</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L285">src/audiovideofacade/DefaultAudioVideoFacade.ts:285</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1419,7 +1425,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L244">src/audiovideofacade/DefaultAudioVideoFacade.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L254">src/audiovideofacade/DefaultAudioVideoFacade.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1460,7 +1466,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L210">src/audiovideofacade/DefaultAudioVideoFacade.ts:210</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L220">src/audiovideofacade/DefaultAudioVideoFacade.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1501,7 +1507,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L184">src/audiovideofacade/DefaultAudioVideoFacade.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L194">src/audiovideofacade/DefaultAudioVideoFacade.ts:194</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1561,7 +1567,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L427">src/audiovideofacade/DefaultAudioVideoFacade.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L437">src/audiovideofacade/DefaultAudioVideoFacade.ts:437</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1585,7 +1591,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L340">src/audiovideofacade/DefaultAudioVideoFacade.ts:340</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L350">src/audiovideofacade/DefaultAudioVideoFacade.ts:350</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1698,7 +1704,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L361">src/audiovideofacade/DefaultAudioVideoFacade.ts:361</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L371">src/audiovideofacade/DefaultAudioVideoFacade.ts:371</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1752,7 +1758,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L392">src/audiovideofacade/DefaultAudioVideoFacade.ts:392</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L402">src/audiovideofacade/DefaultAudioVideoFacade.ts:402</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1776,7 +1782,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L398">src/audiovideofacade/DefaultAudioVideoFacade.ts:398</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L408">src/audiovideofacade/DefaultAudioVideoFacade.ts:408</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1821,7 +1827,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L351">src/audiovideofacade/DefaultAudioVideoFacade.ts:351</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L361">src/audiovideofacade/DefaultAudioVideoFacade.ts:361</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1863,7 +1869,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L417">src/audiovideofacade/DefaultAudioVideoFacade.ts:417</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L427">src/audiovideofacade/DefaultAudioVideoFacade.ts:427</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1899,7 +1905,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L356">src/audiovideofacade/DefaultAudioVideoFacade.ts:356</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L366">src/audiovideofacade/DefaultAudioVideoFacade.ts:366</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1922,7 +1928,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L279">src/audiovideofacade/DefaultAudioVideoFacade.ts:279</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L289">src/audiovideofacade/DefaultAudioVideoFacade.ts:289</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1995,7 +2001,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L433">src/audiovideofacade/DefaultAudioVideoFacade.ts:433</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L443">src/audiovideofacade/DefaultAudioVideoFacade.ts:443</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2067,7 +2073,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L412">src/audiovideofacade/DefaultAudioVideoFacade.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L422">src/audiovideofacade/DefaultAudioVideoFacade.ts:422</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2108,7 +2114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L294">src/audiovideofacade/DefaultAudioVideoFacade.ts:294</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L304">src/audiovideofacade/DefaultAudioVideoFacade.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultrealtimecontroller.html
+++ b/docs/classes/defaultrealtimecontroller.html
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L418">src/realtimecontroller/DefaultRealtimeController.ts:418</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L429">src/realtimecontroller/DefaultRealtimeController.ts:429</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L486">src/realtimecontroller/DefaultRealtimeController.ts:486</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L497">src/realtimecontroller/DefaultRealtimeController.ts:497</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L141">src/realtimecontroller/DefaultRealtimeController.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L152">src/realtimecontroller/DefaultRealtimeController.ts:152</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeexternaluseridfromattendeeid">realtimeExternalUserIdFromAttendeeId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L321">src/realtimecontroller/DefaultRealtimeController.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L332">src/realtimecontroller/DefaultRealtimeController.ts:332</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L212">src/realtimecontroller/DefaultRealtimeController.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L223">src/realtimecontroller/DefaultRealtimeController.ts:223</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -318,7 +318,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L149">src/realtimecontroller/DefaultRealtimeController.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L160">src/realtimecontroller/DefaultRealtimeController.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -336,7 +336,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimereceivedatamessage">realtimeReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L377">src/realtimecontroller/DefaultRealtimeController.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L388">src/realtimecontroller/DefaultRealtimeController.ts:388</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -360,7 +360,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L346">src/realtimecontroller/DefaultRealtimeController.ts:346</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L357">src/realtimecontroller/DefaultRealtimeController.ts:357</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -383,7 +383,7 @@
 					<a name="realtimesetattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Set<wbr>Attendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Set<wbr>Attendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Set<wbr>Attendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, dropped<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -403,6 +403,9 @@
 								<li>
 									<h5>externalUserId: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
+								<li>
+									<h5>dropped: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
 						</li>
@@ -419,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L114">src/realtimecontroller/DefaultRealtimeController.ts:114</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L125">src/realtimecontroller/DefaultRealtimeController.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -469,7 +472,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesetlocalaudioinput">realtimeSetLocalAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L101">src/realtimecontroller/DefaultRealtimeController.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L112">src/realtimecontroller/DefaultRealtimeController.ts:112</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -486,23 +489,23 @@
 					<a name="realtimesubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L80">src/realtimecontroller/DefaultRealtimeController.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L81">src/realtimecontroller/DefaultRealtimeController.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -516,6 +519,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -539,7 +545,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L389">src/realtimecontroller/DefaultRealtimeController.ts:389</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L400">src/realtimecontroller/DefaultRealtimeController.ts:400</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -580,7 +586,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L302">src/realtimecontroller/DefaultRealtimeController.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L313">src/realtimecontroller/DefaultRealtimeController.ts:313</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -621,7 +627,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L197">src/realtimecontroller/DefaultRealtimeController.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L208">src/realtimecontroller/DefaultRealtimeController.ts:208</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -662,7 +668,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L358">src/realtimecontroller/DefaultRealtimeController.ts:358</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L369">src/realtimecontroller/DefaultRealtimeController.ts:369</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -706,7 +712,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L325">src/realtimecontroller/DefaultRealtimeController.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L336">src/realtimecontroller/DefaultRealtimeController.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -753,7 +759,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L126">src/realtimecontroller/DefaultRealtimeController.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L137">src/realtimecontroller/DefaultRealtimeController.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -794,7 +800,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L222">src/realtimecontroller/DefaultRealtimeController.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L233">src/realtimecontroller/DefaultRealtimeController.ts:233</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -851,7 +857,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L169">src/realtimecontroller/DefaultRealtimeController.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L180">src/realtimecontroller/DefaultRealtimeController.ts:180</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -869,7 +875,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L371">src/realtimecontroller/DefaultRealtimeController.ts:371</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L382">src/realtimecontroller/DefaultRealtimeController.ts:382</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -892,7 +898,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L334">src/realtimecontroller/DefaultRealtimeController.ts:334</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L345">src/realtimecontroller/DefaultRealtimeController.ts:345</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -940,7 +946,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L247">src/realtimecontroller/DefaultRealtimeController.ts:247</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L258">src/realtimecontroller/DefaultRealtimeController.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -957,23 +963,23 @@
 					<a name="realtimeunsubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L88">src/realtimecontroller/DefaultRealtimeController.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L94">src/realtimecontroller/DefaultRealtimeController.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -987,6 +993,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1010,7 +1019,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L395">src/realtimecontroller/DefaultRealtimeController.ts:395</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L406">src/realtimecontroller/DefaultRealtimeController.ts:406</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1051,7 +1060,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L312">src/realtimecontroller/DefaultRealtimeController.ts:312</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L323">src/realtimecontroller/DefaultRealtimeController.ts:323</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1092,7 +1101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L203">src/realtimecontroller/DefaultRealtimeController.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L214">src/realtimecontroller/DefaultRealtimeController.ts:214</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1133,7 +1142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L132">src/realtimecontroller/DefaultRealtimeController.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L143">src/realtimecontroller/DefaultRealtimeController.ts:143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1174,7 +1183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L253">src/realtimecontroller/DefaultRealtimeController.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L264">src/realtimecontroller/DefaultRealtimeController.ts:264</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1209,7 +1218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L469">src/realtimecontroller/DefaultRealtimeController.ts:469</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L480">src/realtimecontroller/DefaultRealtimeController.ts:480</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1235,7 +1244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L433">src/realtimecontroller/DefaultRealtimeController.ts:433</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L444">src/realtimecontroller/DefaultRealtimeController.ts:444</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1270,7 +1279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L406">src/realtimecontroller/DefaultRealtimeController.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L417">src/realtimecontroller/DefaultRealtimeController.ts:417</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1293,7 +1302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L493">src/realtimecontroller/DefaultRealtimeController.ts:493</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L504">src/realtimecontroller/DefaultRealtimeController.ts:504</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1316,7 +1325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L497">src/realtimecontroller/DefaultRealtimeController.ts:497</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L508">src/realtimecontroller/DefaultRealtimeController.ts:508</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvolumeindicatoradapter.html
+++ b/docs/classes/defaultvolumeindicatoradapter.html
@@ -293,7 +293,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L113">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L118">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L148">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L153">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L106">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L111">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L98">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L103">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L71">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L76">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/realtimestate.html
+++ b/docs/classes/realtimestate.html
@@ -113,7 +113,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="attendeeidchangescallbacks" class="tsd-anchor"></a>
 					<h3>attendee<wbr>IdChanges<wbr>Callbacks</h3>
-					<div class="tsd-signature tsd-kind-icon">attendee<wbr>IdChanges<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
+					<div class="tsd-signature tsd-kind-icon">attendee<wbr>IdChanges<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L24">src/realtimecontroller/RealtimeState.ts:24</a></li>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>IdTo<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L63">src/realtimecontroller/RealtimeState.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L64">src/realtimecontroller/RealtimeState.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L53">src/realtimecontroller/RealtimeState.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L54">src/realtimecontroller/RealtimeState.ts:54</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">can<wbr>Unmute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L33">src/realtimecontroller/RealtimeState.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L34">src/realtimecontroller/RealtimeState.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">fatal<wbr>Error<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L86">src/realtimecontroller/RealtimeState.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L87">src/realtimecontroller/RealtimeState.ts:87</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Signal<wbr>Strength<wbr>Change<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>signalStrength<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L81">src/realtimecontroller/RealtimeState.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L82">src/realtimecontroller/RealtimeState.ts:82</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">mute<wbr>And<wbr>Unmute<wbr>Local<wbr>Audio<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>muted<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L48">src/realtimecontroller/RealtimeState.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L49">src/realtimecontroller/RealtimeState.ts:49</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">muted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L43">src/realtimecontroller/RealtimeState.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L44">src/realtimecontroller/RealtimeState.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 					<div class="tsd-signature tsd-kind-icon">receive<wbr>Data<wbr>Message<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>dataMessage<span class="tsd-signature-symbol">: </span><a href="datamessage.html" class="tsd-signature-type">DataMessage</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L100">src/realtimecontroller/RealtimeState.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L101">src/realtimecontroller/RealtimeState.ts:101</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -289,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<wbr>Data<wbr>Message<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>topic<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">any</span>, lifetimeMs<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L91">src/realtimecontroller/RealtimeState.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L92">src/realtimecontroller/RealtimeState.ts:92</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>Can<wbr>Unmute<wbr>Local<wbr>Audio<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>canUnmute<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L38">src/realtimecontroller/RealtimeState.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L39">src/realtimecontroller/RealtimeState.ts:39</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<wbr>Indicator<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L68">src/realtimecontroller/RealtimeState.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L69">src/realtimecontroller/RealtimeState.ts:69</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<wbr>Indicator<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L58">src/realtimecontroller/RealtimeState.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L59">src/realtimecontroller/RealtimeState.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -823,7 +823,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L16">src/realtimecontroller/RealtimeControllerFacade.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L26">src/realtimecontroller/RealtimeControllerFacade.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -841,7 +841,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L21">src/realtimecontroller/RealtimeControllerFacade.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L31">src/realtimecontroller/RealtimeControllerFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -859,7 +859,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L17">src/realtimecontroller/RealtimeControllerFacade.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L27">src/realtimecontroller/RealtimeControllerFacade.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -877,7 +877,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L35">src/realtimecontroller/RealtimeControllerFacade.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -907,7 +907,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L13">src/realtimecontroller/RealtimeControllerFacade.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L23">src/realtimecontroller/RealtimeControllerFacade.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -924,7 +924,7 @@
 					<a name="realtimesubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -937,11 +937,11 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -955,6 +955,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -979,7 +982,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetofatalerror">realtimeSubscribeToFatalError</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L55">src/realtimecontroller/RealtimeControllerFacade.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1021,7 +1024,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetolocalsignalstrengthchange">realtimeSubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L33">src/realtimecontroller/RealtimeControllerFacade.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L43">src/realtimecontroller/RealtimeControllerFacade.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1063,7 +1066,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetomuteandunmutelocalaudio">realtimeSubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L19">src/realtimecontroller/RealtimeControllerFacade.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L29">src/realtimecontroller/RealtimeControllerFacade.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1105,7 +1108,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetoreceivedatamessage">realtimeSubscribeToReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L40">src/realtimecontroller/RealtimeControllerFacade.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L50">src/realtimecontroller/RealtimeControllerFacade.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1150,7 +1153,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetosetcanunmutelocalaudio">realtimeSubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L14">src/realtimecontroller/RealtimeControllerFacade.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L24">src/realtimecontroller/RealtimeControllerFacade.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1192,7 +1195,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L22">src/realtimecontroller/RealtimeControllerFacade.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1249,7 +1252,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L18">src/realtimecontroller/RealtimeControllerFacade.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L28">src/realtimecontroller/RealtimeControllerFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1267,7 +1270,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L44">src/realtimecontroller/RealtimeControllerFacade.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L54">src/realtimecontroller/RealtimeControllerFacade.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1291,7 +1294,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L42">src/realtimecontroller/RealtimeControllerFacade.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1308,24 +1311,24 @@
 					<a name="realtimeunsubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetoattendeeidpresence">realtimeUnsubscribeToAttendeeIdPresence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L10">src/realtimecontroller/RealtimeControllerFacade.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L15">src/realtimecontroller/RealtimeControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -1339,6 +1342,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1363,7 +1369,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetofatalerror">realtimeUnsubscribeToFatalError</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L46">src/realtimecontroller/RealtimeControllerFacade.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L56">src/realtimecontroller/RealtimeControllerFacade.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1405,7 +1411,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetolocalsignalstrengthchange">realtimeUnsubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L34">src/realtimecontroller/RealtimeControllerFacade.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L44">src/realtimecontroller/RealtimeControllerFacade.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1447,7 +1453,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetomuteandunmutelocalaudio">realtimeUnsubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L20">src/realtimecontroller/RealtimeControllerFacade.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L30">src/realtimecontroller/RealtimeControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1489,7 +1495,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetosetcanunmutelocalaudio">realtimeUnsubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L15">src/realtimecontroller/RealtimeControllerFacade.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L25">src/realtimecontroller/RealtimeControllerFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/realtimecontroller.html
+++ b/docs/interfaces/realtimecontroller.html
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L97">src/realtimecontroller/RealtimeController.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L108">src/realtimecontroller/RealtimeController.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L66">src/realtimecontroller/RealtimeController.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L77">src/realtimecontroller/RealtimeController.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L130">src/realtimecontroller/RealtimeController.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L141">src/realtimecontroller/RealtimeController.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L106">src/realtimecontroller/RealtimeController.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L117">src/realtimecontroller/RealtimeController.ts:117</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L222">src/realtimecontroller/RealtimeController.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L233">src/realtimecontroller/RealtimeController.ts:233</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L200">src/realtimecontroller/RealtimeController.ts:200</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L211">src/realtimecontroller/RealtimeController.ts:211</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L82">src/realtimecontroller/RealtimeController.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L93">src/realtimecontroller/RealtimeController.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L74">src/realtimecontroller/RealtimeController.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L85">src/realtimecontroller/RealtimeController.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,13 +365,13 @@
 					<a name="realtimesubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L52">src/realtimecontroller/RealtimeController.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L53">src/realtimecontroller/RealtimeController.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -383,11 +383,11 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -401,6 +401,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -424,7 +427,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L232">src/realtimecontroller/RealtimeController.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L243">src/realtimecontroller/RealtimeController.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -473,7 +476,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L176">src/realtimecontroller/RealtimeController.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L187">src/realtimecontroller/RealtimeController.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -519,7 +522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L120">src/realtimecontroller/RealtimeController.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L131">src/realtimecontroller/RealtimeController.ts:131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -565,7 +568,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L209">src/realtimecontroller/RealtimeController.ts:209</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L220">src/realtimecontroller/RealtimeController.ts:220</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -614,7 +617,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L186">src/realtimecontroller/RealtimeController.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L197">src/realtimecontroller/RealtimeController.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -666,7 +669,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L87">src/realtimecontroller/RealtimeController.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L98">src/realtimecontroller/RealtimeController.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -712,7 +715,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L140">src/realtimecontroller/RealtimeController.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L151">src/realtimecontroller/RealtimeController.ts:151</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -776,7 +779,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L115">src/realtimecontroller/RealtimeController.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L126">src/realtimecontroller/RealtimeController.ts:126</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -802,7 +805,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L217">src/realtimecontroller/RealtimeController.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L228">src/realtimecontroller/RealtimeController.ts:228</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -830,7 +833,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L193">src/realtimecontroller/RealtimeController.ts:193</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L204">src/realtimecontroller/RealtimeController.ts:204</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -882,7 +885,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L154">src/realtimecontroller/RealtimeController.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L165">src/realtimecontroller/RealtimeController.ts:165</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -904,13 +907,13 @@
 					<a name="realtimeunsubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L59">src/realtimecontroller/RealtimeController.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L65">src/realtimecontroller/RealtimeController.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -921,11 +924,11 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -939,6 +942,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -962,7 +968,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L237">src/realtimecontroller/RealtimeController.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L248">src/realtimecontroller/RealtimeController.ts:248</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1008,7 +1014,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L181">src/realtimecontroller/RealtimeController.ts:181</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L192">src/realtimecontroller/RealtimeController.ts:192</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1054,7 +1060,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L125">src/realtimecontroller/RealtimeController.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L136">src/realtimecontroller/RealtimeController.ts:136</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1100,7 +1106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L92">src/realtimecontroller/RealtimeController.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L103">src/realtimecontroller/RealtimeController.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/realtimecontrollerfacade.html
+++ b/docs/interfaces/realtimecontrollerfacade.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L16">src/realtimecontroller/RealtimeControllerFacade.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L26">src/realtimecontroller/RealtimeControllerFacade.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L21">src/realtimecontroller/RealtimeControllerFacade.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L31">src/realtimecontroller/RealtimeControllerFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L17">src/realtimecontroller/RealtimeControllerFacade.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L27">src/realtimecontroller/RealtimeControllerFacade.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L35">src/realtimecontroller/RealtimeControllerFacade.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L13">src/realtimecontroller/RealtimeControllerFacade.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L23">src/realtimecontroller/RealtimeControllerFacade.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -220,7 +220,7 @@
 					<a name="realtimesubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Subscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -232,11 +232,11 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -250,6 +250,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -273,7 +276,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L55">src/realtimecontroller/RealtimeControllerFacade.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -314,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L33">src/realtimecontroller/RealtimeControllerFacade.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L43">src/realtimecontroller/RealtimeControllerFacade.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -355,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L19">src/realtimecontroller/RealtimeControllerFacade.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L29">src/realtimecontroller/RealtimeControllerFacade.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -396,7 +399,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L40">src/realtimecontroller/RealtimeControllerFacade.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L50">src/realtimecontroller/RealtimeControllerFacade.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -440,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L14">src/realtimecontroller/RealtimeControllerFacade.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L24">src/realtimecontroller/RealtimeControllerFacade.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -481,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L22">src/realtimecontroller/RealtimeControllerFacade.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -537,7 +540,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L18">src/realtimecontroller/RealtimeControllerFacade.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L28">src/realtimecontroller/RealtimeControllerFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -554,7 +557,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L44">src/realtimecontroller/RealtimeControllerFacade.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L54">src/realtimecontroller/RealtimeControllerFacade.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -577,7 +580,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L42">src/realtimecontroller/RealtimeControllerFacade.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -594,23 +597,23 @@
 					<a name="realtimeunsubscribetoattendeeidpresence" class="tsd-anchor"></a>
 					<h3>realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">realtime<wbr>Unsubscribe<wbr>ToAttendee<wbr>IdPresence<span class="tsd-signature-symbol">(</span>callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L10">src/realtimecontroller/RealtimeControllerFacade.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L15">src/realtimecontroller/RealtimeControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
+									<h5>callback: <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></h5>
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
@@ -624,6 +627,9 @@
 														</li>
 														<li>
 															<h5><span class="tsd-flag ts-flagOptional">Optional</span> externalUserId: <span class="tsd-signature-type">string</span></h5>
+														</li>
+														<li>
+															<h5><span class="tsd-flag ts-flagOptional">Optional</span> dropped: <span class="tsd-signature-type">boolean</span></h5>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -647,7 +653,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L46">src/realtimecontroller/RealtimeControllerFacade.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L56">src/realtimecontroller/RealtimeControllerFacade.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -688,7 +694,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L34">src/realtimecontroller/RealtimeControllerFacade.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L44">src/realtimecontroller/RealtimeControllerFacade.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -729,7 +735,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L20">src/realtimecontroller/RealtimeControllerFacade.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L30">src/realtimecontroller/RealtimeControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -770,7 +776,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L15">src/realtimecontroller/RealtimeControllerFacade.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L25">src/realtimecontroller/RealtimeControllerFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -33,7 +33,8 @@
     "test:integration-video": "cd ./integration/js && npm run test -- video && npm run upload-logs-to-s3",
     "test:integration-meeting-end": "cd ./integration/js && npm run test -- meeting_end && npm run upload-logs-to-s3",
     "test:integration-screen-share": "cd ./integration/js && npm run test -- screen_share && npm run upload-logs-to-s3",
-    "test:integration-content-share": "cd ./integration/js && npm run test -- content_share && npm run upload-logs-to-s3"
+    "test:integration-content-share": "cd ./integration/js && npm run test -- content_share && npm run upload-logs-to-s3",
+    "test:integration-data-message": "cd ./integration/js && npm run test -- data_message && npm run upload-logs-to-s3"
   },
   "devDependencies": {
     "@fluffy-spoon/substitute": "^1.89.0",

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -158,14 +158,24 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
   }
 
   realtimeSubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void {
     this.realtimeController.realtimeSubscribeToAttendeeIdPresence(callback);
     this.trace('realtimeSubscribeToAttendeeIdPresence');
   }
 
   realtimeUnsubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void {
     this.realtimeController.realtimeUnsubscribeToAttendeeIdPresence(callback);
     this.trace('realtimeUnsubscribeToAttendeeIdPresence');

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -65,20 +65,26 @@ export default class DefaultRealtimeController implements RealtimeController {
   realtimeSetAttendeeIdPresence(
     attendeeId: string,
     present: boolean,
-    externalUserId: string | null
+    externalUserId: string | null,
+    dropped: boolean | null
   ): void {
     this.wrap(() => {
       if (present) {
         this.state.attendeeIdToExternalUserId[attendeeId] = externalUserId;
       }
       for (const fn of this.state.attendeeIdChangesCallbacks) {
-        fn(attendeeId, present, externalUserId);
+        fn(attendeeId, present, externalUserId, dropped);
       }
     });
   }
 
   realtimeSubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void {
     this.wrap(() => {
       this.state.attendeeIdChangesCallbacks.push(callback);
@@ -86,7 +92,12 @@ export default class DefaultRealtimeController implements RealtimeController {
   }
 
   realtimeUnsubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void {
     this.wrap(() => {
       const index = this.state.attendeeIdChangesCallbacks.indexOf(callback);

--- a/src/realtimecontroller/RealtimeController.ts
+++ b/src/realtimecontroller/RealtimeController.ts
@@ -42,7 +42,8 @@ export default interface RealtimeController {
   realtimeSetAttendeeIdPresence(
     attendeeId: string,
     present: boolean,
-    externalUserId: string | null
+    externalUserId: string | null,
+    dropped: boolean | null
   ): void;
 
   /**
@@ -50,14 +51,24 @@ export default interface RealtimeController {
    * subscribe and unsubscribe to for volume indicator updates.
    */
   realtimeSubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void;
 
   /**
    * Unsubscribes to changes in attendee ids
    */
   realtimeUnsubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void;
 
   /**

--- a/src/realtimecontroller/RealtimeControllerFacade.ts
+++ b/src/realtimecontroller/RealtimeControllerFacade.ts
@@ -5,10 +5,20 @@ import DataMessage from '../datamessage/DataMessage';
 
 export default interface RealtimeControllerFacade {
   realtimeSubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void;
   realtimeUnsubscribeToAttendeeIdPresence(
-    callback: (attendeeId: string, present: boolean, externalUserId?: string) => void
+    callback: (
+      attendeeId: string,
+      present: boolean,
+      externalUserId?: string,
+      dropped?: boolean
+    ) => void
   ): void;
   realtimeSetCanUnmuteLocalAudio(canUnmute: boolean): void;
   realtimeSubscribeToSetCanUnmuteLocalAudio(callback: (canUnmute: boolean) => void): void;

--- a/src/realtimecontroller/RealtimeState.ts
+++ b/src/realtimecontroller/RealtimeState.ts
@@ -24,7 +24,8 @@ export default class RealtimeState {
   attendeeIdChangesCallbacks: ((
     attendeeId: string,
     present: boolean,
-    externalUserId?: string
+    externalUserId: string,
+    dropped: boolean
   ) => void)[] = [];
 
   /**

--- a/src/task/CreatePeerConnectionTask.ts
+++ b/src/task/CreatePeerConnectionTask.ts
@@ -17,7 +17,12 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
   private removeTrackAddedEventListener: (() => void) | null = null;
   private removeTrackRemovedEventListeners: { [trackId: string]: () => void } = {};
   private presenceHandlerSet = new Set<
-    (attendeeId: string, present: boolean, externalUserId?: string | null) => void
+    (
+      attendeeId: string,
+      present: boolean,
+      externalUserId: string | null,
+      dropped: boolean | null
+    ) => void
   >();
 
   private readonly trackEvents: string[] = [
@@ -161,8 +166,13 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     streamId: number
   ): void {
     const timeoutScheduler = new TimeoutScheduler(this.externalUserIdTimeoutMs);
-    const handler = (presentAttendeeId: string, present: boolean, externalUserId: string): void => {
-      if (attendeeId === presentAttendeeId && present && externalUserId !== null) {
+    const handler = (
+      presentAttendeeId: string,
+      present: boolean,
+      externalUserId: string,
+      dropped: boolean
+    ): void => {
+      if (attendeeId === presentAttendeeId && present && externalUserId !== null && !dropped) {
         tile.bindVideoStream(attendeeId, false, stream, width, height, streamId, externalUserId);
         this.context.realtimeController.realtimeUnsubscribeToAttendeeIdPresence(handler);
         this.presenceHandlerSet.delete(handler);

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.13';
+    return '1.6.14';
   }
 
   /**

--- a/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
+++ b/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
@@ -34,8 +34,7 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
       const hasAttendeeId = !!stream.attendeeId;
       const hasExternalUserId = !!stream.externalUserId;
       const hasMuted = stream.hasOwnProperty('muted');
-      // TODO: wire dropped through to the realtime interface
-      // const hasDropped = !!stream.dropped;
+      const hasDropped = !!stream.dropped;
       if (hasAttendeeId) {
         this.streamIdToAttendeeId[stream.audioStreamId] = stream.attendeeId;
         const externalUserId = hasExternalUserId ? stream.externalUserId : stream.attendeeId;
@@ -43,7 +42,8 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
         this.realtimeController.realtimeSetAttendeeIdPresence(
           stream.attendeeId,
           true,
-          externalUserId
+          externalUserId,
+          false
         );
       }
       if (hasMuted) {
@@ -63,7 +63,12 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
         delete this.streamIdToAttendeeId[stream.audioStreamId];
         delete this.streamIdToExternalUserId[stream.audioStreamId];
         delete this.warnedAboutMissingStreamIdMapping[stream.audioStreamId];
-        this.realtimeController.realtimeSetAttendeeIdPresence(attendeeId, false, externalUserId);
+        this.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeId,
+          false,
+          externalUserId,
+          hasDropped
+        );
       }
     }
   }

--- a/test/activespeakerdetector/DefaultActiveSpeakerDetector.test.ts
+++ b/test/activespeakerdetector/DefaultActiveSpeakerDetector.test.ts
@@ -40,7 +40,7 @@ describe('DefaultActiveSpeakerDetector', () => {
         callbackFired = true;
       };
       detector.subscribe(policy, callback);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null, false);
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 10, false, 1, null);
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 10, false, 1, null);
       expect(callbackFired).to.be.true;
@@ -48,7 +48,7 @@ describe('DefaultActiveSpeakerDetector', () => {
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 10, false, 1, null);
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 0, false, 1, null);
       expect(callbackFired).to.be.false;
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, false, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, false, null, true);
       expect(callbackFired).to.be.true;
       detector.unsubscribe(callback);
     });
@@ -64,8 +64,8 @@ describe('DefaultActiveSpeakerDetector', () => {
         expect(attendeeIds[0] === fooAttendee2);
       };
       detector.subscribe(policy, callback);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee1, true, null);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee2, true, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee1, true, null, false);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee2, true, null, false);
       rt.realtimeUpdateVolumeIndicator(fooAttendee1, 10, false, 1, null);
       rt.realtimeUpdateVolumeIndicator(fooAttendee1, 20, false, 1, null);
       rt.realtimeUpdateVolumeIndicator(fooAttendee2, 10, false, 1, null);
@@ -86,7 +86,7 @@ describe('DefaultActiveSpeakerDetector', () => {
       };
       detector.subscribe(policy, callback);
       detector.unsubscribe(callback);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null, false);
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 10, false, 1, null);
       rt.realtimeUpdateVolumeIndicator(fooAttendee, 10, false, 1, null);
       expect(callbackFired).to.be.false;

--- a/test/realtimecontroller/DefaultRealtimeController.test.ts
+++ b/test/realtimecontroller/DefaultRealtimeController.test.ts
@@ -849,9 +849,9 @@ describe('DefaultRealtimeController', () => {
         callbackIndex += 1;
       });
       expect(callbackIndex).to.equal(0);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, true, null, false);
       expect(callbackIndex).to.equal(1);
-      rt.realtimeSetAttendeeIdPresence(fooAttendee, false, null);
+      rt.realtimeSetAttendeeIdPresence(fooAttendee, false, null, false);
       expect(callbackIndex).to.equal(2);
     });
   });
@@ -860,7 +860,7 @@ describe('DefaultRealtimeController', () => {
     const rt: RealtimeController = new DefaultRealtimeController();
     const attendeeId = 'fake-attendee';
     const externalUserId = 'fake-external-id';
-    rt.realtimeSetAttendeeIdPresence(attendeeId, true, externalUserId);
+    rt.realtimeSetAttendeeIdPresence(attendeeId, true, externalUserId, false);
     expect(rt.realtimeExternalUserIdFromAttendeeId(attendeeId)).to.be.equal(externalUserId);
   });
 
@@ -1117,7 +1117,7 @@ describe('DefaultRealtimeController', () => {
 
       // attempt to trigger a fake error after unsubscribing to fatal errors
       rt.realtimeUnsubscribeToFatalError(fatalErrorCallback);
-      rt.realtimeSetAttendeeIdPresence('unused', true, null);
+      rt.realtimeSetAttendeeIdPresence('unused', true, null, false);
       expect(fatalErrorCallbackRemoved).to.be.true;
 
       // unsubscribe from other callbacks
@@ -1131,7 +1131,7 @@ describe('DefaultRealtimeController', () => {
       rt.realtimeUnsubscribeFromReceiveDataMessage('topic');
 
       // attempt to trigger callbacks
-      rt.realtimeSetAttendeeIdPresence('unused', true, null);
+      rt.realtimeSetAttendeeIdPresence('unused', true, null, false);
       rt.realtimeSetCanUnmuteLocalAudio(false);
       rt.realtimeMuteLocalAudio();
       // also triggers local signal strength callbacks

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -301,7 +301,12 @@ describe('CreatePeerConnectionTask', () => {
         const streamId = 1;
         let tile: VideoTile;
         const attendeeIdForTrack = 'attendee-id';
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         class TestVideoStreamIndex extends DefaultVideoStreamIndex {
           streamIdForTrack(_trackId: string): number {
             return streamId;
@@ -342,7 +347,12 @@ describe('CreatePeerConnectionTask', () => {
 
         let tile: VideoTile;
         const attendeeIdForTrack = 'attendee-id';
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         class TestVideoStreamIndex extends DefaultVideoStreamIndex {
           attendeeIdForTrack(_trackId: string): string {
             return attendeeIdForTrack;
@@ -387,7 +397,12 @@ describe('CreatePeerConnectionTask', () => {
         let tile: VideoTile;
 
         const attendeeIdForTrack = 'attendee-id';
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         class TestVideoStreamIndex extends DefaultVideoStreamIndex {
           attendeeIdForTrack(_trackId: string): string {
             return attendeeIdForTrack;
@@ -448,7 +463,12 @@ describe('CreatePeerConnectionTask', () => {
           'realtimeSubscribeToAttendeeIdPresence'
         );
         context.realtimeController = new DefaultRealtimeController();
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         class TestVideoStreamIndex extends DefaultVideoStreamIndex {
           attendeeIdForTrack(_trackId: string): string {
             return attendeeIdForTrack;
@@ -466,7 +486,12 @@ describe('CreatePeerConnectionTask', () => {
           new TimeoutScheduler(domMockBehavior.asyncWaitMs + 10).start(resolve)
         );
         expect(spyRealtimeSubscribeToAttendeeIdPresence.called).to.be.false;
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, false, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          false,
+          'foo',
+          false
+        );
         expect(spyRealtimeSubscribeToAttendeeIdPresence.called).to.be.false;
         context.removableObservers[0].removeObserver();
       });
@@ -477,7 +502,12 @@ describe('CreatePeerConnectionTask', () => {
         task = new CreatePeerConnectionTask(context, externalUserIdTimeOutMs);
 
         context.realtimeController = new DefaultRealtimeController();
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, null);
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          null,
+          false
+        );
 
         const spyRealtimeSubscribeToAttendeeIdPresence = sinon.spy(
           context.realtimeController,
@@ -513,7 +543,12 @@ describe('CreatePeerConnectionTask', () => {
         task = new CreatePeerConnectionTask(context, externalUserIdTimeOutMs);
         const attendeeIdForTrack = 'attendee-id';
         context.realtimeController = new DefaultRealtimeController();
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, null);
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          null,
+          false
+        );
         const spyRealtimeSubscribeToAttendeeIdPresence = sinon.spy(
           context.realtimeController,
           'realtimeSubscribeToAttendeeIdPresence'
@@ -538,9 +573,14 @@ describe('CreatePeerConnectionTask', () => {
           new TimeoutScheduler(domMockBehavior.asyncWaitMs + 10).start(resolve)
         );
         expect(spyRealtimeSubscribeToAttendeeIdPresence.called).to.be.true;
-        context.realtimeController.realtimeSetAttendeeIdPresence('new-attendee', true, null);
+        context.realtimeController.realtimeSetAttendeeIdPresence('new-attendee', true, null, false);
         expect(spyRealtimeUnsubscribeToAttendeeIdPresence.called).to.be.false;
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         expect(spyRealtimeUnsubscribeToAttendeeIdPresence.called).to.be.true;
 
         context.removableObservers[0].removeObserver();
@@ -582,7 +622,12 @@ describe('CreatePeerConnectionTask', () => {
       it('removes stream ID from the paused video stream ID set if stream ID exists', done => {
         let called = false;
         const attendeeIdForTrack = 'attendee-id';
-        context.realtimeController.realtimeSetAttendeeIdPresence(attendeeIdForTrack, true, 'foo');
+        context.realtimeController.realtimeSetAttendeeIdPresence(
+          attendeeIdForTrack,
+          true,
+          'foo',
+          false
+        );
         class TestVideoStreamIndex extends DefaultVideoStreamIndex {
           streamIdForTrack(_trackId: string): number {
             return 1;

--- a/test/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.test.ts
+++ b/test/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.test.ts
@@ -83,11 +83,12 @@ describe('DefaultVolumeIndicatorAdapter', () => {
       );
       let attendeeIdUpdate = 0;
       rt.realtimeSubscribeToAttendeeIdPresence(
-        (attendeeId: string, present: boolean, externalUserId: string) => {
+        (attendeeId: string, present: boolean, externalUserId: string, dropped: boolean) => {
           if (attendeeIdUpdate === 0) {
             expect(attendeeId).to.equal(fooAttendee);
             expect(present).to.be.true;
             expect(externalUserId).to.equal(fooExternal);
+            expect(dropped).to.be.false;
           } else if (attendeeIdUpdate === 1) {
             expect(attendeeId).to.equal(fooAttendee);
             expect(present).to.be.false;
@@ -138,11 +139,14 @@ describe('DefaultVolumeIndicatorAdapter', () => {
       const rt: RealtimeController = new DefaultRealtimeController();
       let attendeeIdUpdate = 0;
       rt.realtimeSubscribeToAttendeeIdPresence(
-        (attendeeId: string, present: boolean, externalUserId: string) => {
+        (attendeeId: string, present: boolean, externalUserId: string, dropped: boolean) => {
           let expected = false;
           if (attendeeIdUpdate === 0) {
             expected =
-              attendeeId === fooAttendee && present === true && externalUserId === fooExternal;
+              attendeeId === fooAttendee &&
+              present === true &&
+              externalUserId === fooExternal &&
+              dropped === false;
           } else if (attendeeIdUpdate === 1) {
             expected =
               attendeeId === fooAttendee && present === false && externalUserId === fooExternal;


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/362

**Description of changes:**
Add 'dropped' boolean attribute to realtime interface to indicate attendee drop.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tested locally. All unit tests passed.

Used demo app to check the dropped flag and here is the result.

```
audioStreamId: 3
dropped: true
__proto__:
	attendeeId: ""
	audioStreamId: 0
	dropped: false
	externalUserId: ""
	muted: false
	toJSON: ƒ toJSON()
	constructor: ƒ SdkAudioStreamIdInfo(properties)
	__proto__: Object
```

Console logs: `[DEMO] f443ce02-301e-418f-8632-20d11fd50854 dropped = true (dc31a8fa#c)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
