### PR TITLE
Fix FinishIceGatheringTask when no turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark 403 (Forbidden) for fetching turn credentials as terminal error and avoid retrying.
 - Fix Android Pixel3 Chrome Video artifacts on far sites
 - Don't throw the "cannot replace" message if the device controller is not bound to any audio-video controller
+- Fix FinishGatheringICECandidatesTask when there is no turn credentials
 
 ## [1.6.2] - 2020-05-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/task/FinishGatheringICECandidatesTask.ts
+++ b/src/task/FinishGatheringICECandidatesTask.ts
@@ -86,6 +86,14 @@ export default class FinishGatheringICECandidatesTask extends BaseTask {
         this.removeEventListener();
         reject(error);
       };
+      if (!this.context.turnCredentials) {
+        this.context.peer.addEventListener('icegatheringstatechange', () => {
+          if (this.context.peer.iceGatheringState === 'complete') {
+            resolve();
+            return;
+          }
+        });
+      }
 
       this.context.iceCandidateHandler = (event: RTCPeerConnectionIceEvent) => {
         this.context.logger.info(

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.6.12';
+    return '1.6.13';
   }
 
   /**

--- a/test/task/FinishGatheringICECandidatesTask.test.ts
+++ b/test/task/FinishGatheringICECandidatesTask.test.ts
@@ -103,6 +103,36 @@ describe('FinishGatheringICECandidatesTask', () => {
   });
 
   describe('run', () => {
+    it('can be run and succeed without turn credentials', done => {
+      const peer = context.peer;
+      setLocalDescription(peer, SDPMock.LOCAL_OFFER_WITHOUT_CANDIDATE);
+      context.turnCredentials = null;
+      task = new FinishGatheringICECandidatesTask(context);
+      task.run().then(() => {
+        done();
+      });
+      const event = new Event('icegatheringstatechange');
+      new AsyncScheduler().start(() => {
+        // @ts-ignore
+        peer.iceGatheringState = 'complete';
+        // fake a complete ice gathering without turn
+        peer.dispatchEvent(event);
+      });
+    });
+
+    it('can be run and timeout without turn credentials', () => {
+      const peer = context.peer;
+      setLocalDescription(peer, SDPMock.LOCAL_OFFER_WITHOUT_CANDIDATE);
+      context.turnCredentials = null;
+      task = new FinishGatheringICECandidatesTask(context, 300);
+      task.run().then(() => {});
+      const event = new Event('icegatheringstatechange');
+      new AsyncScheduler().start(() => {
+        // fake a complete ice gathering without turn
+        peer.dispatchEvent(event);
+      });
+    });
+
     it('can be run and succeed with one rtp candidate', done => {
       const peer = context.peer;
       setLocalDescription(peer, SDPMock.LOCAL_OFFER_WITHOUT_CANDIDATE);


### PR DESCRIPTION
**Issue #:** 
Fix a case when there is no turn credentials, FinishGatheringICECandidates time out because ice gathering state change event is not fired through ice candidate handler in Safari.

**Description of changes:**

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Test demo with local servers,  this only affects local server debugging since turn credentials are required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
