### PR TITLE
Switch demo DDB tables to on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Switch demo DDB table to on demand
 
 ### Removed
 

--- a/demos/device/serverless/template.yaml
+++ b/demos/device/serverless/template.yaml
@@ -68,12 +68,10 @@ Resources:
           AttributeType: "S"
         - AttributeName: "Passcode"
           AttributeType: "S"
+      BillingMode: PAY_PER_REQUEST
       KeySchema:
         - AttributeName: "Title"
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
       GlobalSecondaryIndexes:
         - IndexName: "Passcode"
           KeySchema:
@@ -81,9 +79,6 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
       TimeToLiveSpecification:
         AttributeName: "TTL"
         Enabled: true
@@ -93,12 +88,10 @@ Resources:
       AttributeDefinitions:
         - AttributeName: "AttendeeId"
           AttributeType: "S"
+      BillingMode: PAY_PER_REQUEST
       KeySchema:
         - AttributeName: "AttendeeId"
           KeyType: "HASH"
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
   MeetingNotificationsQueue:
     Type: AWS::SQS::Queue
   ChimeSdkIndexLambda:

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -65,12 +65,10 @@ Resources:
           AttributeType: "S"
         - AttributeName: "Passcode"
           AttributeType: "S"
+      BillingMode: PAY_PER_REQUEST
       KeySchema:
         - AttributeName: "Title"
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
       GlobalSecondaryIndexes:
         - IndexName: "Passcode"
           KeySchema:
@@ -78,9 +76,6 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
       TimeToLiveSpecification:
         AttributeName: "TTL"
         Enabled: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.7.4';
+    return '1.7.5';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Switch demo DDB tables to on demand from provision.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually deploy serverless demo and verify that it succeeds. Also tested the newly generated meeting URL and verified that I could join and re-join meeting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
