### PR TITLE
Fix black tiles after peerConnection reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix log line to print device constraints
 - Fix build line to take out duplicate npm install
 - Fix video audio preview for mobile devices
+- Fix black remote video tiles on reconnect
 
 ## [1.7.0] - 2020-05-23
 

--- a/docs/classes/createpeerconnectiontask.html
+++ b/docs/classes/createpeerconnectiontask.html
@@ -486,7 +486,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L272">src/task/CreatePeerConnectionTask.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L278">src/task/CreatePeerConnectionTask.ts:278</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.7.5';
+    return '1.7.6';
   }
 
   /**

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -806,7 +806,7 @@ describe('CreatePeerConnectionTask', () => {
       await new Promise(resolve =>
         new TimeoutScheduler(domMockBehavior.asyncWaitMs + 10).start(resolve)
       );
-      expect(called).to.be.false;
+      expect(called).to.be.true;
       expect(peerRemoveEventListenerSpy.called).to.be.true;
     });
 
@@ -840,7 +840,7 @@ describe('CreatePeerConnectionTask', () => {
       await new Promise(resolve =>
         new TimeoutScheduler(domMockBehavior.asyncWaitMs + 10).start(resolve)
       );
-      expect(called).to.be.false;
+      expect(called).to.be.true;
       expect(peerRemoveEventListenerSpy.called).to.be.false;
     });
   });


### PR DESCRIPTION

**Description of changes:**
When the peer connection reconnects, the existing webrtc
tracks are ended, but the associated video tiles were not being
removed.  This caused a conflict when the new track was added and
an existing tile was already found for the remove video.

Fix is to close the remote video tile when the track ends.

**Testing**
Verified tiles were properly displayed on the various browsers after:
- Remote start/stop of video
- Local pause of remote video
- peerConnection reconnect
- far side disconnected



1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tested with local server.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
