### PR TITLE
Add option to run integration tests in Sauce Labs headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add an integration tests to check remote video when reconnecting
 - Add device controller tests
+- Add option to run integration tests in Sauce Labs headless
 
 ### Changed
 - Switch demo DDB table to on demand

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.7.8';
+    return '1.7.9';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Add option to run integration tests in Sauce Labs headless

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually started the tests from my machine and verified that they ran successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
