### PR TITLE
Fix typo in MeetingNotificaionsEvent present in template.yaml

### DIFF
--- a/demos/device/serverless/template.yaml
+++ b/demos/device/serverless/template.yaml
@@ -183,7 +183,7 @@ Resources:
       Handler: notification_handlers.sqs_handler
       CodeUri: src/
       Events:
-        MeetingNotificaionsEvent:
+        MeetingNotificationsEvent:
           Type: SQS
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -142,7 +142,7 @@ Resources:
       Handler: handlers.sqs_handler
       CodeUri: src/
       Events:
-        MeetingNotificaionsEvent:
+        MeetingNotificationsEvent:
           Type: SQS
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/341

**Description of changes:**
- Fix typo in **MeetingNotificaionsEvent** (to **MeetingNotificationsEvent**)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
