### PR TITLE
Fix typo in MeetingNotificaionsEvent present in CloudFormation template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix video audio preview for mobile devices
 - Fix black remote video tiles on reconnect
 - Fix LED light issue
+- Fix typo in MeetingNotificaionsEvent present in template.yaml
 
 ## [1.7.0] - 2020-05-23
 

--- a/demos/device/serverless/template.yaml
+++ b/demos/device/serverless/template.yaml
@@ -183,7 +183,7 @@ Resources:
       Handler: notification_handlers.sqs_handler
       CodeUri: src/
       Events:
-        MeetingNotificaionsEvent:
+        MeetingNotificationsEvent:
           Type: SQS
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -142,7 +142,7 @@ Resources:
       Handler: handlers.sqs_handler
       CodeUri: src/
       Events:
-        MeetingNotificaionsEvent:
+        MeetingNotificationsEvent:
           Type: SQS
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -11,7 +11,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.7.9';
+    return '1.7.10';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Fix typo in MeetingNotificaionsEvent (to MeetingNotificationsEvent)

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Running the serverless demo app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
