### PR TITLE
Suppress presence leave when attendee has already joined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump websocket-extensions from 0.1.3 to 0.1.4
 - Updated SignalingProtocol.proto and use SDK version in JoinFrame
+
 ### Removed
 
 ### Fixed
 - Fix duplicate tiles and error logs due to external id race condition
+- Suppress presence leave when attendee has already joined from another device (#427)
 
 ## [1.8.0] - 2020-06-05
 

--- a/docs/classes/defaultvolumeindicatoradapter.html
+++ b/docs/classes/defaultvolumeindicatoradapter.html
@@ -293,7 +293,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L118">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L127">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L153">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L162">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:162</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L111">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L120">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L103">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L112">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:112</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L76">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L85">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.8.3';
+    return '1.8.4';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** #427  

**Description of changes:**

Suppress presence leave when attendee has already joined. In some cases, such as when an attendee joins from another device, the server may signal back the remove of the attendee's old stream after the add of the attendee's new stream. This change suppresses any presence leave when a newer stream id for the same attendee is detected.

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

Tested with a local server and simulated joining from another device. I was able to reproduce the issue and confirm that this patch fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
