### PR TITLE
Use HTTP GET method to obtain turn credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump websocket-extensions from 0.1.3 to 0.1.4
 - Updated SignalingProtocol.proto and use SDK version in JoinFrame
+- Use GET instead of POST to obtain Turn credentials
 
 ### Removed
 

--- a/src/meetingsession/MeetingSessionStatusCode.ts
+++ b/src/meetingsession/MeetingSessionStatusCode.ts
@@ -120,7 +120,7 @@ export enum MeetingSessionStatusCode {
   IncompatibleSDP = 21,
 
   /**
-   * This can happen when you attempt to join a meeting which has ended
+   * This can happen when you attempt to join a meeting which has ended or attendee got removed
    */
   TURNCredentialsForbidden = 22,
 
@@ -128,6 +128,11 @@ export enum MeetingSessionStatusCode {
    * The attendee is not present.
    */
   NoAttendeePresent = 23,
+
+  /**
+   *  This can happen when you attempt to join a meeting which has ended
+   */
+  TURNMeetingEnded = 24,
 }
 
 export default MeetingSessionStatusCode;

--- a/src/task/ReceiveTURNCredentialsTask.ts
+++ b/src/task/ReceiveTURNCredentialsTask.ts
@@ -38,20 +38,15 @@ export default class ReceiveTURNCredentialsTask extends BaseTask {
     }
 
     const options: RequestInit = {
-      method: 'POST',
+      method: 'GET',
       mode: 'cors',
       cache: 'no-cache',
       credentials: 'omit',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Chime-Auth-Token':
-          '_aws_wt_session=' + this.joinToken.replace(ContentShareConstants.Modality, ''),
-      },
       redirect: 'follow',
       referrer: 'no-referrer',
-      body: JSON.stringify({ meetingId: this.meetingId }),
     };
 
+    const url: string = this.url + `?m=${this.meetingId}&t=${this.joinToken.replace(ContentShareConstants.Modality, '')}`;
     this.context.logger.info(`requesting TURN credentials from ${this.url}`);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,13 +56,22 @@ export default class ReceiveTURNCredentialsTask extends BaseTask {
       };
 
       try {
-        const responseBody = await fetch(Versioning.urlWithVersion(this.url), options);
+        const responseBody = await fetch(Versioning.urlWithVersion(url), options);
         this.context.logger.info(`received TURN credentials`);
         if (responseBody.status && responseBody.status === 403) {
           reject(
             new Error(
               `canceling ${this.name()} due to the meeting status code: ${
                 MeetingSessionStatusCode.TURNCredentialsForbidden
+              }`
+            )
+          );
+        }
+        if (responseBody.status && responseBody.status === 404) {
+          reject(
+            new Error(
+              `canceling ${this.name()} due to the meeting status code: ${
+                MeetingSessionStatusCode.TURNMeetingEnded
               }`
             )
           );


### PR DESCRIPTION
**Description of changes:**
Switch to GET eliminates the need for pre-flight check.
Also added another status code to handle meeting ended

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
I verified that serverless demo works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
