### PR TITLE
Add stale-issue bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,7 @@
+daysUntilStale: 7
+daysUntilClose: 14
+exemptLabels:
+  - Triaged
+staleLabel: Needs More Information
+markComment: false
+closeComment: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add position in frame to attendee updates
+- Add stale-issue bot configuration
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.9.1';
+    return '1.9.2';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**

Automatically mark issues as "Needs more information" after 7 days and close issues after having that tag for 7 days. Based off of configuration here: https://probot.github.io/apps/stale/

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

Unable to test the change directly but ran `npm run build:release`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
