### PR TITLE
Updated cloudwatch log stream ID to have attendee_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Updated cloudwatch log stream ID to have attendee_id
 
 ## [1.9.0] - 2020-06-12
 

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -106,7 +106,7 @@ exports.logs = async (event, context) => {
     return response(200, 'application/json', JSON.stringify({}));
   }
 
-  const logStreamName = `ChimeSDKMeeting_${body.meetingId.toString()}`;
+  const logStreamName = `ChimeSDKMeeting_${body.meetingId.toString()}_${body.attendeeId.toString()}`;
   const cloudWatchClient = new AWS.CloudWatchLogs({ apiVersion: '2014-03-28' });
   const putLogEventsInput = {
     logGroupName: logGroupName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.9.3';
+    return '1.9.4';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Updated cloudwatch log stream ID to have attendee_id to avoid `invalidSequenceToken` errors.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Deployed the serverless app and verified we see log streams in the format `ChimeSDKMeeting_<meeting_id>_<attendee_id>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
