### PR TITLE
Fix uplink max bitrate value calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MultiLogger to support logging to multiple Logger instances
 - Add resize listener on HTMLVideoElement in demo
 - Add simulcast integration tests
+- Fix uplink max bitrate value calculation
 
 ### Changed
 - Use GET instead of POST to obtain TURN credentials

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -47,7 +47,7 @@
               <label for="optional-features">Optional Features</label>
               <select id="optional-features" class="custom-select" style="width:100%" multiple>
                 <option value="">--Please choose an option--</option>
-                <option value="simulcast">Enable Simulcast</option>
+                <option value="simulcast">Enable Simulcast For Chrome</option>
                 <option value="webaudio">Use WebAudio</option>
               </select>
             </div>

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -134,7 +134,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
 
   // feature flags
   enableWebAudio = false;
-  enableUnifiedPlanForChromiumBasedBrowsers = true;
+  enableUnifiedPlanForChromiumBasedBrowsers = false;
   enableSimulcast = false;
 
   constructor() {
@@ -303,8 +303,11 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
         // hard code magic
         if (collections[i].label === 'simulcast') {
           this.enableSimulcast = true;
+          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
         } else if (collections[i].label === 'webaudio') {
           this.enableWebAudio = true;
+        } else if (collections[i].label === 'unifiedplan') {
+          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
         }
       }
     });

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -47,7 +47,7 @@
           <label for="optional-features">Optional Features</label>
           <select id="optional-features" class="custom-select" style="width:100%" multiple>
             <option value="">--Please choose an option--</option>
-            <option value="simulcast">Enable Simulcast</option>
+            <option value="simulcast">Enable Simulcast For Chrome</option>
             <option value="webaudio">Use WebAudio</option>
           </select>
         </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -146,7 +146,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
 
   // feature flags
   enableWebAudio = false;
-  enableUnifiedPlanForChromiumBasedBrowsers = true;
+  enableUnifiedPlanForChromiumBasedBrowsers = false;
   enableSimulcast = false;
 
   markdown = require('markdown-it')({linkify: true});
@@ -319,10 +319,14 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         // hard code magic
         if (collections[i].value === 'simulcast') {
           this.enableSimulcast = true;
+          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
           this.log('attempt to enable simulcast');
         } else if (collections[i].value === 'webaudio') {
           this.enableWebAudio = true;
           this.log('attempt to enable webaudio');
+        } else if (collections[i].value === 'unifiedplan') {
+          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
+          this.log('attempt to enable unified plan');
         }
       }
     });

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.700.0",
+    "aws-sdk": "^2.702.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.9.11",
+  "version": "1.9.12",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/task/SubscribeAndReceiveSubscribeAckTask.ts
+++ b/src/task/SubscribeAndReceiveSubscribeAckTask.ts
@@ -57,7 +57,7 @@ export default class SubscribeAndReceiveSubscribeAckTask extends BaseTask {
       }
       const param: RTCRtpEncodingParameters = {
         rid: 'hi',
-        maxBitrate: maxEncodeBitrateKbps,
+        maxBitrate: maxEncodeBitrateKbps * 1000,
         maxFramerate: frameRate,
         active: true,
       };

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.9.11';
+    return '1.9.12';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

Videos are not displayed after two or three video tiles

**Description of changes:**

* Fix uplink max bitrate value calculation.
* Disable Unified Plan on demo to test what most users use

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
smoke test with iOS Safari / iPad Safari / Android / Firefox 77 and Chrome 83 on Desktop.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
