### PR TITLE
Fix CloudWatch metrics for Linux and Android integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- Fix CloudWatch metrics for Linux and Android integration tests
+
 ## [1.10.0] - 2020-06-23
 
 ### Added

--- a/integration/js/utils/CloudWatch.js
+++ b/integration/js/utils/CloudWatch.js
@@ -1,6 +1,4 @@
 const AWS = require('../node_modules/aws-sdk');
-const {getOS, getOSVersion} = require('./WebdriverBrowserStack');
-
 AWS.config.update({region: 'us-east-1'});
 var cloudWatch = new AWS.CloudWatch({
   apiVersion: '2010-08-01'
@@ -24,7 +22,7 @@ module.exports.emitMetric = async (namespace, capabilities, metric_name, value) 
           },
           {
             Name: 'BrowserVersion',
-            Value: capabilities.version
+            Value: capabilities.version ? capabilities.version : 'default'
           },
           {
             Name: 'OS',
@@ -94,5 +92,39 @@ const publishMetricToCloudWatch = async (params) => {
     await cloudWatch.putMetricData(params).promise();
   } catch (error) {
     console.log(`Unable to emit metric: ${error}`)
+  }
+};
+
+const getOS = (capabilities) => {
+  switch (capabilities.platform) {
+    case 'MAC':
+      return 'OS X';
+    case 'WINDOWS':
+      return 'windows';
+    case 'LINUX':
+      return 'Linux';
+    case 'IOS':
+      return 'iOS';
+    case 'ANDROID':
+      return 'Android';
+    default:
+      return '';
+  }
+};
+
+const getOSVersion = (capabilities) => {
+  switch (capabilities.platform) {
+    case 'MAC':
+      return 'Mojave';
+    case 'WINDOWS':
+      return '10';
+    case 'LINUX':
+      return 'Linux';
+    case 'IOS':
+      return capabilities.version? capabilities.version : 'default';
+    case 'ANDROID':
+      return capabilities.version? capabilities.version : 'default';
+    default:
+      return '';
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.10.0';
+    return '1.10.1';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Fix CloudWatch metrics for Linux and Android integration tests
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually modify canary and verify that the metrics are published successfully.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
