### PR TITLE
Fix create meeting request for audio and video e2e integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix CloudWatch metrics for Linux and Android integration tests
+- Fix create meeting request for audio and video e2e integration tests
 
 ## [1.10.0] - 2020-06-23
 

--- a/integration/js/server.js
+++ b/integration/js/server.js
@@ -40,7 +40,7 @@ createMeeting = async (createMeetingUrl) => {
       const data = await response.data;
       meetingMap[createMeetingUrl] = "created";
       console.log("Meeting created");
-      console.log(`Chime meeting id : ${data.JoinInfo.Meeting.MeetingId}`);
+      console.log(`Chime meeting id : ${data.JoinInfo.Meeting.Meeting.MeetingId}`);
       return data;
     } catch (error) {
       console.log(`Unable to create meeting, server error: ${error}`);

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -10,7 +10,11 @@ const fs = require('fs');
 class SdkBaseTest extends KiteBaseTest {
   constructor(name, kiteConfig, testName) {
     super(name, kiteConfig);
-    this.baseUrl = this.url;
+    if (this.url.endsWith('v2')) {
+      this.baseUrl = this.url.slice(0, -2);
+    } else {
+      this.baseUrl = this.url;
+    }
     if (testName === 'ContentShareOnlyAllowTwoTest') {
       this.url = this.url + '?max-content-share=true' + '&m=' + kiteConfig.uuid;
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.10.2';
+    return '1.10.3';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Creating meeting request for audio and video contains v2 in the request which causes the request to fail. 
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
