### PR TITLE
Disable w3c check for Chrome Android webdriver integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix create meeting request for audio and video e2e integration tests
 - Fix multiple issues with integration tests
 - Fix uuidv4 import
-- Fix missing uuidv4 import in integration test.
+- Fix missing uuidv4 import in integration test
+- Disable w3c check for Chrome Android webdriver integration tests
 
 ## [1.10.0] - 2020-06-23
 

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -130,6 +130,7 @@ const getChromeAndroidConfig = capabilities => {
     deviceOrientation: 'portrait',
     chromeOptions: {
       'args': ['use-fake-device-for-media-stream', 'use-fake-ui-for-media-stream'],
+      'w3c': false
     },
     name: capabilities.name,
   };


### PR DESCRIPTION
**Description of changes:**
DIsable w3c check for Chrome Android webdriver that causes mobile tests to fail sometimes to load the meeting app demo with this error `UnsupportedOperationError: unknown command: Cannot call non W3C standard command while in W3C mode`

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Run tests manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
