### PR TITLE
Remove "multiple" attribute from browser demo optional feature HTMLSelectElement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
+- Remove browser demo optional feature HTMLSelectElement multiple attribute
 
 ### Fixed
 - Fix CloudWatch metrics for Linux and Android integration tests

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -45,10 +45,11 @@
           <div class="row mt-3">
             <div class="col-12">
               <label for="optional-features">Optional Features</label>
-              <select id="optional-features" class="custom-select" style="width:100%" multiple>
-                <option value="">--Please choose an option--</option>
+              <select id="optional-features" class="custom-select" style="width:100%">
+                <option value="" selected>None</option>
                 <option value="simulcast">Enable Simulcast For Chrome</option>
                 <option value="webaudio">Use WebAudio</option>
+                <option value="unifiedplan">Use Unified Plan for Chrome</option>
               </select>
             </div>
           </div>

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -299,14 +299,17 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       const collections = optionalFeatures.selectedOptions;
       this.enableSimulcast = false;
       this.enableWebAudio = false;
+      this.enableUnifiedPlanForChromiumBasedBrowsers = false;
       for (let i = 0; i < collections.length; i++) {
         // hard code magic
         if (collections[i].label === 'simulcast') {
           this.enableSimulcast = true;
           this.enableUnifiedPlanForChromiumBasedBrowsers = true;
-        } else if (collections[i].label === 'webaudio') {
+        }
+        if (collections[i].label === 'webaudio') {
           this.enableWebAudio = true;
-        } else if (collections[i].label === 'unifiedplan') {
+        }
+        if (collections[i].label === 'unifiedplan') {
           this.enableUnifiedPlanForChromiumBasedBrowsers = true;
         }
       }

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -45,10 +45,11 @@
       <div class="row mt-3">
         <div class="col-12">
           <label for="optional-features">Optional Features</label>
-          <select id="optional-features" class="custom-select" style="width:100%" multiple>
-            <option value="">--Please choose an option--</option>
+          <select id="optional-features" class="custom-select" style="width:100%">
+            <option value="" selected>None</option>
             <option value="simulcast">Enable Simulcast For Chrome</option>
             <option value="webaudio">Use WebAudio</option>
+            <option value="unifiedplan">Use Unified Plan For Chrome</option>
           </select>
         </div>
       </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -314,6 +314,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
       const collections = optionalFeatures.selectedOptions;
       this.enableSimulcast = false;
       this.enableWebAudio = false;
+      this.enableUnifiedPlanForChromiumBasedBrowsers = false;
       this.log("Feature lists:");
       for (let i = 0; i < collections.length; i++) {
         // hard code magic
@@ -321,10 +322,12 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           this.enableSimulcast = true;
           this.enableUnifiedPlanForChromiumBasedBrowsers = true;
           this.log('attempt to enable simulcast');
-        } else if (collections[i].value === 'webaudio') {
+        }
+        if (collections[i].value === 'webaudio') {
           this.enableWebAudio = true;
           this.log('attempt to enable webaudio');
-        } else if (collections[i].value === 'unifiedplan') {
+        }
+        if (collections[i].value === 'unifiedplan') {
           this.enableUnifiedPlanForChromiumBasedBrowsers = true;
           this.log('attempt to enable unified plan');
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.10.7';
+    return '1.10.8';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

HTMLSelectElement causes some confusion on Android Chrome, even when user selects an element, on Android Chrome it showed "0 selected".

**Description of changes:**

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
with demo on android chrome, smoke tested functionality with chrome/safari/firefox.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
