### PR TITLE
Fix typo in VideoStreamDescription when stream is disabled by WebRTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix typo in VideoStreamDescription when stream is disabled by WebRTC
+
 ## [1.11.0] - 2020-06-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/task/CreateSDPTask.ts
+++ b/src/task/CreateSDPTask.ts
@@ -52,10 +52,7 @@ export default class CreateSDPTask extends BaseTask {
 
       try {
         this.context.sdpOfferInit = await this.context.peer.createOffer(offerOptions);
-        this.context.logger.info(
-          `peer connection created offer ${JSON.stringify(this.context.sdpOfferInit)}`
-        );
-
+        this.context.logger.info('peer connection created offer');
         if (this.context.previousSdpOffer) {
           if (
             new DefaultSDP(this.context.sdpOfferInit.sdp).videoSendSectionHasDifferentSSRC(

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.11.0';
+    return '1.11.1';
   }
 
   /**

--- a/src/videostreamindex/VideoStreamDescription.ts
+++ b/src/videostreamindex/VideoStreamDescription.ts
@@ -55,7 +55,7 @@ export default class VideoStreamDescription {
     descriptor.groupId = this.groupId;
     descriptor.framerate = this.maxFrameRate;
     descriptor.maxBitrateKbps =
-      this.disabledByUplinkPolicy || this.disabledByUplinkPolicy ? 0 : this.maxBitrateKbps;
+      this.disabledByUplinkPolicy || this.disabledByWebRTC ? 0 : this.maxBitrateKbps;
     descriptor.avgBitrateBps = this.avgBitrateKbps;
     return descriptor;
   }


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Fix a typo in `descriptor.maxBitrateKbps =
      this.disabledByUplinkPolicy || this.disabledByUplinkPolicy ? 0 : this.maxBitrateKbps;`
Second `disabledByUplinkPolicy` should be `disabledByWebRTC`. 

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Test with demo with simulcast 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
