### PR TITLE
Fix data already accepted exception on cloudwatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix typo in VideoStreamDescription when stream is disabled by WebRTC
 - Fix issue where audio input is not able to switch in Firefox
 - Fix handling WebRTC Track event with no associated streams
+- Increase log interval to avoid multiple Cloudwatch requests at once
 
 ## [1.11.0] - 2020-06-30
 

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -102,7 +102,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
   static readonly DID: string = '+17035550122';
   static readonly BASE_URL: string = [location.protocol, '//', location.host, location.pathname.replace(/\/*$/, '/')].join('');
   static readonly LOGGER_BATCH_SIZE: number = 85;
-  static readonly LOGGER_INTERVAL_MS: number = 1150;
+  static readonly LOGGER_INTERVAL_MS: number = 2000;
 
   showActiveSpeakerScores = false;
   activeSpeakerLayout = true;

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -111,7 +111,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   static readonly BASE_URL: string = [location.protocol, '//', location.host, location.pathname.replace(/\/*$/, '/').replace('/v2', '')].join('');
   static testVideo: string = 'https://upload.wikimedia.org/wikipedia/commons/transcoded/c/c0/Big_Buck_Bunny_4K.webm/Big_Buck_Bunny_4K.webm.360p.vp9.webm';
   static readonly LOGGER_BATCH_SIZE: number = 85;
-  static readonly LOGGER_INTERVAL_MS: number = 1150;
+  static readonly LOGGER_INTERVAL_MS: number = 2000;
   static readonly DATA_MESSAGE_TOPIC: string = "chat";
   static readonly DATA_MESSAGE_LIFETIME_MS: number = 300000;
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,12 +32,11 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.707.0",
+    "aws-sdk": "^2.711.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",
-    "popper.js": "^1.15.0",
-    "uuid": "^8.2.0"
+    "popper.js": "^1.15.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2501,12 +2501,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
         }
       }
     },
@@ -3212,12 +3206,6 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -4517,6 +4505,12 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
@@ -4536,14 +4530,6 @@
         "log-symbols": "^2.1.0",
         "loglevelnext": "^1.0.1",
         "uuid": "^3.1.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.11.6';
+    return '1.11.7';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
We observed a few 'DataAlreadyAcceptedException' on cloudwatch coming in from the meeting demo app. It seems like a race condition taking place: its already using a sequence number that has already been used before.

**Description of changes:**
As a mitigation we increased the time interval for sending logs to the Cloudwatch

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
By checking logs being written in cloudwatch


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
