### PR TITLE
Mark resolution and frame rate constraints as ideal in DefaultDeviceController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Firefox to Travis integration tests
 
 ### Changed
-- Fix title for FAQ guide 
+- Fix title for FAQ guide
+- Change DefaultDeviceController video MediaTrackConstraint parameters to be "ideal" explicitly
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2678,9 +2678,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -693,9 +693,9 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
       trackConstraints = device;
     }
     if (kind === 'video') {
-      trackConstraints.width = trackConstraints.width || this.videoWidth;
-      trackConstraints.height = trackConstraints.height || this.videoHeight;
-      trackConstraints.frameRate = trackConstraints.frameRate || this.videoFrameRate;
+      trackConstraints.width = trackConstraints.width || { ideal: this.videoWidth };
+      trackConstraints.height = trackConstraints.height || { ideal: this.videoHeight };
+      trackConstraints.frameRate = trackConstraints.frameRate || { ideal: this.videoFrameRate };
       // TODO: try to replace hard-code value related to videos into quality-level presets
       // The following configs relaxes CPU overuse detection threshold to offer better encoding quality
       // @ts-ignore

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -137,9 +137,9 @@ describe('DefaultDeviceController', () => {
       const constraints: Device = {};
       await deviceController.chooseVideoInputDevice(constraints);
 
-      expect(constraints.width).to.equal(width);
-      expect(constraints.height).to.equal(height);
-      expect(constraints.frameRate).to.equal(frameRate);
+      expect(JSON.stringify(constraints.width)).to.equal(JSON.stringify({ ideal: width }));
+      expect(JSON.stringify(constraints.height)).to.equal(JSON.stringify({ ideal: height }));
+      expect(JSON.stringify(constraints.frameRate)).to.equal(JSON.stringify({ ideal: frameRate }));
       expect(spy.calledWith(maxBandwidthKbps)).to.be.true;
     });
 
@@ -158,8 +158,8 @@ describe('DefaultDeviceController', () => {
       const constraints: Device = {};
       await deviceController.chooseVideoInputDevice(constraints);
 
-      expect(constraints.width).to.equal(544);
-      expect(constraints.height).to.equal(544);
+      expect(JSON.stringify(constraints.width)).to.equal(JSON.stringify({ ideal: 544 }));
+      expect(JSON.stringify(constraints.height)).to.equal(JSON.stringify({ ideal: 544 }));
     });
   });
 


### PR DESCRIPTION
**Issue #:** 
#423 

**Description of changes:**

The previous behavior should be interpreted as "ideal" but it fails on some mobile browsers.
This PR make the "ideal" constraint explicit. 


**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
smoke tested on desktop browsers, and on iOS and Android.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
