### PR TITLE
Fix incorrect log level for terminal error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where audio input is not able to switch in Firefox
 - Fix handling WebRTC Track event with no associated streams
 - Increase log interval to avoid multiple Cloudwatch requests at once
+- Fix incorrect log level for terminal error code
 
 ## [1.11.0] - 2020-06-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -676,12 +676,12 @@ export default class DefaultAudioVideoController implements AudioVideoController
       return false;
     }
     if (status.isFailure()) {
-      this.logger.error(
+      this.logger.warn(
         `connection failed with status code: ${MeetingSessionStatusCode[status.statusCode()]}`
       );
     }
     if (status.isTerminal()) {
-      this.logger.info('session will not be reconnected');
+      this.logger.error('session will not be reconnected');
       if (this.meetingSessionContext.reconnectController) {
         this.meetingSessionContext.reconnectController.disableReconnect();
       }

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.11.9';
+    return '1.11.10';
   }
 
   /**

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -1204,7 +1204,7 @@ describe('DefaultAudioVideoController', () => {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
-      const spy = sinon.spy(logger, 'error');
+      const spy = sinon.spy(logger, 'warn');
       const noAttendeeTimeout = configuration.attendeePresenceTimeoutMs;
 
       class TestMediaStreamBroker extends NoOpMediaStreamBroker {


### PR DESCRIPTION
**Issue #:** 
SDK logs  "connection failed with status code: ${MeetingSessionStatusCode[status.statusCode()]}" as ERROR for retryable failures and "session will not be reconnected" as INFO for FATAL errors

**Description of changes:**
The message "connection failed with status code: " changed to WARN level and the "session will not be reconnected"  changed to ERROR level for actual terminal error

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Unit Test success


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
