### PR TITLE
Fix content share video to be displayed below the data message text box in the demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling WebRTC Track event with no associated streams
 - Increase log interval to avoid multiple Cloudwatch requests at once
 - Fix incorrect log level for terminal error code
+- Fix content share video to be displayed below the data message text box
 
 ## [1.11.0] - 2020-06-30
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -290,17 +290,18 @@
       </div>
     </div>
     <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100">
-      <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-6 col-md-5 col-lg-4 h-100">
+      <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-6 col-md-5 col-lg-4 h-100" style="overflow-y: scroll;">
         <div class="bs-component" style="flex: 1 1 auto; overflow-y: scroll; height: 50%;">
           <ul id="roster" class="list-group"></ul>
         </div>
-        <div class="message d-flex flex-column pt-3" style="flex: 1 1 auto; overflow: hidden; height: 50%;">
-          <div class="list-group receive-message" id="receive-message" style="flex: 1 1 auto; overflow-y: scroll;
+        <div class="message d-flex flex-column pt-3" style="flex: 1 1 auto; overflow: scroll; height: 100%;">
+          <div class="list-group receive-message" id="receive-message" style="flex: 1 1 auto; min-height:30%; overflow-y: scroll;
             border: 1px solid rgba(0, 0, 0, 0.125); background-color: #fff"></div>
           <div class="input-group send-message" style="display:flex;flex:0 0 auto;margin-top:0.2rem">
             <textarea class="form-control shadow-none" id="send-message" rows="1" placeholder="Type a message (markdown supported)" style="display:inline-block; width:100%;
               resize:none; border-color: rgba(0, 0, 0, 0.125); outline: none; padding-left: 1.4rem"></textarea>
           </div>
+          <video id="content-share-video" crossOrigin="anonymous" style="display:none;width: 100%;margin-top: 5px;" ></video>
         </div>
       </div>
       <div id="tile-container" class="col-12 col-sm-6 col-md-7 col-lg-8 my-4 my-sm-0 h-100">
@@ -397,7 +398,6 @@
           </div>
         </div>
       </div>
-      <video id="content-share-video" crossOrigin="anonymous" style="display:none"></video>
     </div>
   </div>
 </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1267,6 +1267,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         if (videoUrl) {
           videoFile.src = videoUrl;
         }
+        videoFile.style.display = 'block';
         await videoFile.play();
         // @ts-ignore
         const mediaStream: MediaStream = videoFile.captureStream();

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -394,10 +394,6 @@ svg {
     display: none !important;
   }
 
-  #content-share-video {
-    display: none !important;
-  }
-
   #meeting-container {
     height: auto !important;
   }


### PR DESCRIPTION
**Issue #:** 
When the content share test video is turned on in the mobile browser, it appears behind the roaster in the landscape mode and does not display in the portrait mode, even though the content share actually keeps playing.

**Description of changes:**
 The content share test video is brought below the data message text box. Changed the meetingV2.html file and the display property of the content share video

Repro Steps:
    User joins in the meeting with PIN and name in landscape mode in mobile device.
    User clicks on the share content->test video

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Manually testing and verifying it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
