### PR TITLE
Catch the exceptions taking place when putLogEvents() fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Firefox to Travis integration tests
 - Add README for integration tests
 - Add log to list the set of constraints supported by the browser
+- Catch exceptions taking place when putLogEvents fails
 
 ### Changed
 - Fix title for FAQ guide

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -127,7 +127,11 @@ exports.logs = async (event, context) => {
     });
   }
   putLogEventsInput.logEvents = logEvents;
-  await cloudWatchClient.putLogEvents(putLogEventsInput).promise();
+  try {
+    await cloudWatchClient.putLogEvents(putLogEventsInput).promise();
+  } catch (error) {
+    console.error(`Failed to put CloudWatch log events with error ${error.message} and params ${JSON.stringify(putLogEventsInput)}`);
+  }
   return response(200, 'application/json', JSON.stringify({}));
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.12",
+  "version": "1.11.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.12",
+  "version": "1.11.13",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.11.12';
+    return '1.11.13';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
We can see a few DataAlreadyAcceptedException in our CloudWatch logs. These exceptions are taking place due to the retries that take place cloudwatch backend.

**Description of changes:**
This PR is adding try catch block to the putLogEvents() to catch the exceptions taking place when putLogEvents() fails

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Manually tested it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
