### PR TITLE
Use the SDK default sample rate 48,000 Hz for an AudioBuffer object o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix title for FAQ guide
 - Change DefaultDeviceController video MediaTrackConstraint parameters to be "ideal" explicitly
 - Use a single instance of AudioContext
-- Use the SDK default sample rate 48,000 Hz for an AudioBuffer object
+- Use the SDK default sample rate 48,000 Hz for an AudioBuffer object if the AudioContext sample rate doesn't work
 
 ### Removed
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.711.0",
+    "aws-sdk": "^2.714.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/demos/device/package-lock.json
+++ b/demos/device/package-lock.json
@@ -3952,9 +3952,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "loglevel": {

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">already<wbr>Handling<wbr>Device<wbr>Change<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L435">src/devicecontroller/DefaultDeviceController.ts:435</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L452">src/devicecontroller/DefaultDeviceController.ts:452</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -541,7 +541,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L785">src/devicecontroller/DefaultDeviceController.ts:785</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L802">src/devicecontroller/DefaultDeviceController.ts:802</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -606,7 +606,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L492">src/devicecontroller/DefaultDeviceController.ts:492</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L509">src/devicecontroller/DefaultDeviceController.ts:509</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -632,7 +632,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L817">src/devicecontroller/DefaultDeviceController.ts:817</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L834">src/devicecontroller/DefaultDeviceController.ts:834</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -655,7 +655,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L696">src/devicecontroller/DefaultDeviceController.ts:696</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L713">src/devicecontroller/DefaultDeviceController.ts:713</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -696,7 +696,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L705">src/devicecontroller/DefaultDeviceController.ts:705</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L722">src/devicecontroller/DefaultDeviceController.ts:722</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -770,7 +770,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L565">src/devicecontroller/DefaultDeviceController.ts:565</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L582">src/devicecontroller/DefaultDeviceController.ts:582</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -874,7 +874,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L499">src/devicecontroller/DefaultDeviceController.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L516">src/devicecontroller/DefaultDeviceController.ts:516</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -897,7 +897,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L770">src/devicecontroller/DefaultDeviceController.ts:770</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L787">src/devicecontroller/DefaultDeviceController.ts:787</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -964,7 +964,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L481">src/devicecontroller/DefaultDeviceController.ts:481</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L498">src/devicecontroller/DefaultDeviceController.ts:498</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1005,7 +1005,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L549">src/devicecontroller/DefaultDeviceController.ts:549</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L566">src/devicecontroller/DefaultDeviceController.ts:566</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1028,7 +1028,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L524">src/devicecontroller/DefaultDeviceController.ts:524</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L541">src/devicecontroller/DefaultDeviceController.ts:541</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1051,7 +1051,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L512">src/devicecontroller/DefaultDeviceController.ts:512</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L529">src/devicecontroller/DefaultDeviceController.ts:529</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1077,7 +1077,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L827">src/devicecontroller/DefaultDeviceController.ts:827</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L844">src/devicecontroller/DefaultDeviceController.ts:844</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStreamAudioDestinationNode</span></h4>
@@ -1094,7 +1094,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L436">src/devicecontroller/DefaultDeviceController.ts:436</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L453">src/devicecontroller/DefaultDeviceController.ts:453</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1111,7 +1111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L468">src/devicecontroller/DefaultDeviceController.ts:468</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L485">src/devicecontroller/DefaultDeviceController.ts:485</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1137,7 +1137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L504">src/devicecontroller/DefaultDeviceController.ts:504</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L521">src/devicecontroller/DefaultDeviceController.ts:521</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1202,7 +1202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L425">src/devicecontroller/DefaultDeviceController.ts:425</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L442">src/devicecontroller/DefaultDeviceController.ts:442</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1225,7 +1225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L389">src/devicecontroller/DefaultDeviceController.ts:389</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L406">src/devicecontroller/DefaultDeviceController.ts:406</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1420,7 +1420,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L863">src/devicecontroller/DefaultDeviceController.ts:863</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L880">src/devicecontroller/DefaultDeviceController.ts:880</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1437,7 +1437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L855">src/devicecontroller/DefaultDeviceController.ts:855</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L872">src/devicecontroller/DefaultDeviceController.ts:872</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1454,7 +1454,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L859">src/devicecontroller/DefaultDeviceController.ts:859</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L876">src/devicecontroller/DefaultDeviceController.ts:876</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1471,7 +1471,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L868">src/devicecontroller/DefaultDeviceController.ts:868</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L885">src/devicecontroller/DefaultDeviceController.ts:885</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1500,7 +1500,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L396">src/devicecontroller/DefaultDeviceController.ts:396</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L413">src/devicecontroller/DefaultDeviceController.ts:413</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1517,7 +1517,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L383">src/devicecontroller/DefaultDeviceController.ts:383</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L400">src/devicecontroller/DefaultDeviceController.ts:400</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1534,7 +1534,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L848">src/devicecontroller/DefaultDeviceController.ts:848</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L865">src/devicecontroller/DefaultDeviceController.ts:865</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1585,7 +1585,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L340">src/devicecontroller/DefaultDeviceController.ts:340</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L357">src/devicecontroller/DefaultDeviceController.ts:357</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1611,7 +1611,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L834">src/devicecontroller/DefaultDeviceController.ts:834</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L851">src/devicecontroller/DefaultDeviceController.ts:851</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -1651,7 +1651,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L316">src/devicecontroller/DefaultDeviceController.ts:316</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L333">src/devicecontroller/DefaultDeviceController.ts:333</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -260,16 +260,16 @@
 						<h3><strong>When I join a meeting in Chrome in Android 8 or 9 with speakerphone, other people could not hear me. Switch to default mic fixes the issue.</strong></h3>
 					</a>
 					<p>This seems to be a <a href="https://bugs.chromium.org/p/webrtc/issues/detail?id=11677">bug</a> with Android 8 or 9 when using getUserMedia with speakerphone device Id that the audio stream will end after a brief moment. Using default device Id will fix this issue. Note that this only happens if users select speakerphone first. If you use default device when joining the meeting then switch to Speakerphone, this issue does not happen.</p>
-					<a href="#i-see-a-slate-which-says-your-client-does-not-support-hardware-acceleration-when-i-enable-video-on-my-device" id="i-see-a-slate-which-says-your-client-does-not-support-hardware-acceleration-when-i-enable-video-on-my-device" style="color: inherit; text-decoration: none;">
-						<h3>I see a slate which says “Your client does not support hardware acceleration” when I enable video on my device?</h3>
+					<a href="#i-see-a-slate-which-says-quotyour-client-does-not-support-hardware-accelerationquot-when-i-enable-video-on-my-device" id="i-see-a-slate-which-says-quotyour-client-does-not-support-hardware-accelerationquot-when-i-enable-video-on-my-device" style="color: inherit; text-decoration: none;">
+						<h3>I see a slate which says &quot;Your client does not support hardware acceleration&quot; when I enable video on my device?</h3>
 					</a>
 					<p>This error indicates that the device you are using does not support hardware acceleration decoding. However this does not impact the ability of this user to participate in Amazon Chime SDK meetings as the device can render and transmit VP8 streams to other parties in the call. Specifically for Chrome, you will need to enable Unified Plan support by setting this <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers">flag</a> to true or enable <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers">Simulcast</a>.
 					In some cases, H.264 may be missing from the initial SDP offer <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1047994">tracking Chromium bug</a>) causing this slate to appear. Rejoining the meeting can fix the videos to be rendered once again.</p>
 					<a href="#audio-and-video" id="audio-and-video" style="color: inherit; text-decoration: none;">
 						<h2>Audio and video</h2>
 					</a>
-					<a href="#my-clients-are-unable-to-join-the-meeting-and-i-see-navigatormediadevices-is-undefinedquot-what-could-be-the-reason" id="my-clients-are-unable-to-join-the-meeting-and-i-see-navigatormediadevices-is-undefinedquot-what-could-be-the-reason" style="color: inherit; text-decoration: none;">
-						<h3>My clients are unable to join the meeting and I see “<code>navigator.mediaDevices is undefined</code>&quot;, what could be the reason?</h3>
+					<a href="#my-clients-are-unable-to-join-the-meeting-and-i-see-navigatormediadevices-is-undefined-what-could-be-the-reason" id="my-clients-are-unable-to-join-the-meeting-and-i-see-navigatormediadevices-is-undefined-what-could-be-the-reason" style="color: inherit; text-decoration: none;">
+						<h3>My clients are unable to join the meeting and I see <code>navigator.mediaDevices is undefined</code>, what could be the reason?</h3>
 					</a>
 					<p>Amazon Chime SDK for JavaScript uses WebRTC’s getUserMedia() when you invoke the chooseVideoInputDevice API which can operate in <a href="https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Privacy_and_security">secure contexts inside a browser only</a> for privacy concerns so you will need to access your browsers using HTTPS://. The hostname <code>localhost</code> and the loopback address <code>127.0.0.1</code> are exceptions.</p>
 					<a href="#how-can-i-create-a-video-tile-layout-for-my-application" id="how-can-i-create-a-video-tile-layout-for-my-application" style="color: inherit; text-decoration: none;">
@@ -279,8 +279,8 @@
 					<ul>
 						<li>A video whose source is a mobile device in portrait mode will display quite differently compared to a video in landscape mode from a laptop camera. The CSS object-fit rule can be applied to the video element to change how the content scales to fit the parent video element.</li>
 						<li>Use the <code>VideoTileState</code> <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L20">videoStreamContentWidth and videoStreamContentHeight</a> properties to determine the aspect ratio of the content.</li>
-						<li>For landscape aspect ratios (width &gt; height), apply the CSS rule “<code>object-fit:cover&quot;</code> to the HTML element that will contain the video to crop and scale the video to the aspect ratio of the video element.</li>
-						<li>For portrait aspect ratios (height &gt; width), apply the CSS rule “<code>object-fit:contain&quot;</code> to the HTML element that will contain the video to ensure that all video content can be seen.</li>
+						<li>For landscape aspect ratios (width &gt; height), apply the CSS rule <code>object-fit:cover</code> to the HTML element that will contain the video to crop and scale the video to the aspect ratio of the video element.</li>
+						<li>For portrait aspect ratios (height &gt; width), apply the CSS rule <code>object-fit:contain</code> to the HTML element that will contain the video to ensure that all video content can be seen.</li>
 					</ul>
 					<a href="#after-leaving-a-meeting-the-camera-led-is-still-on-indicating-that-the-camera-has-not-been-released-what-could-be-wrong" id="after-leaving-a-meeting-the-camera-led-is-still-on-indicating-that-the-camera-has-not-been-released-what-could-be-wrong" style="color: inherit; text-decoration: none;">
 						<h3>After leaving a meeting, the camera LED is still on indicating that the camera has not been released. What could be wrong?</h3>
@@ -298,11 +298,24 @@ meetingSession.audioVideo.stopVideoPreviewForVideoInput(previewVideoElement);
 // <span class="hljs-keyword">Stop</span> the meeting <span class="hljs-keyword">session</span> (audio <span class="hljs-keyword">and</span> video)
 meetingSession.audioVideo.stop();</code></pre>
 					<a href="#my-clients-are-unable-to-successfully-join-audio-calls-from-safari-they-get-a-failed-to-get-audio-device-for-constraints-null-type-error-what-could-be-the-issue" id="my-clients-are-unable-to-successfully-join-audio-calls-from-safari-they-get-a-failed-to-get-audio-device-for-constraints-null-type-error-what-could-be-the-issue" style="color: inherit; text-decoration: none;">
-						<h3>My clients are unable to successfully join audio calls from Safari, they get a “failed to get audio device for constraints null: Type error”, what could be the issue?</h3>
+						<h3>My clients are unable to successfully join audio calls from Safari, they get a <code>failed to get audio device for constraints null: Type error</code>, what could be the issue?</h3>
 					</a>
 					<p>This error message is an indication that the browser application did not successfully acquire the media stream for audio or video from the device before the meeting starts. Application has not passed in the right device Id to the <code>chooseVideoInputDevice</code> API. In this case you will see the following entry in the log where an empty string after <code>chooseVideoInputDevice</code>:</p>
 					<pre><code>[<span class="hljs-builtin-name">Info</span>] 2020-06-18T17:43:55.380Z [<span class="hljs-builtin-name">INFO</span>] VLR - API/DefaultDeviceController/chooseVideoInputDevice <span class="hljs-string">""</span> -&gt; <span class="hljs-string">"PermissionDeniedByBrowser"</span></code></pre><p>This applies for video input as well.</p>
-					<p><a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=FAQs%20feedback">Give feedback on this guide</a></p>
+					<a href="#how-can-i-show-a-custom-ux-when-the-browser-prompts-the-user-for-permission-to-use-microphone-and-camera" id="how-can-i-show-a-custom-ux-when-the-browser-prompts-the-user-for-permission-to-use-microphone-and-camera" style="color: inherit; text-decoration: none;">
+						<h3>How can I show a custom UX when the browser prompts the user for permission to use microphone and camera?</h3>
+					</a>
+					<p>Device labels are privileged since they add to the fingerprinting surface area of the browser session. In Chrome private tabs and in all Firefox tabs, the labels can only be read once a MediaStream is active. How to deal with this restriction depends on the desired UX. The device controller includes an injectable device label trigger which allows you to perform custom behavior in case there are no labels, such as creating a temporary audio/video stream to unlock the device names, which is the default behavior.</p>
+					<p>You may want to override this behavior to provide a custom UX such as a prompt explaining why microphone and camera access is being asked for by supplying your own function to setDeviceLabelTrigger(). See the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts#L928">meeting demo application</a> for an example.</p>
+					<pre><code>meetingSession.audioVideo.setDeviceLabelTrigger(
+  <span class="hljs-keyword">async</span> (): Promise&lt;MediaStream&gt; =&gt; {
+    <span class="hljs-comment">// For example, let the user know that the browser is asking for microphone and camera permissions.</span>
+    showCustomUX();
+    <span class="hljs-keyword">const</span> stream = <span class="hljs-keyword">await</span> navigator.mediaDevices.getUserMedia({ audio: <span class="hljs-keyword">true</span>, video: <span class="hljs-keyword">true</span> });
+    hideCustomUX();
+    <span class="hljs-keyword">return</span> stream;
+  }
+);</code></pre><p><a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=FAQs%20feedback">Give feedback on this guide</a></p>
 				</div>
 			</section>
 		</div>

--- a/guides/06_FAQs.md
+++ b/guides/06_FAQs.md
@@ -191,14 +191,14 @@ Note that for Android, if an attendee joins later after the video stream is in b
 
 This seems to be a [bug](https://bugs.chromium.org/p/webrtc/issues/detail?id=11677) with Android 8 or 9 when using getUserMedia with speakerphone device Id that the audio stream will end after a brief moment. Using default device Id will fix this issue. Note that this only happens if users select speakerphone first. If you use default device when joining the meeting then switch to Speakerphone, this issue does not happen.
 
-### I see a slate which says “Your client does not support hardware acceleration” when I enable video on my device?
+### I see a slate which says "Your client does not support hardware acceleration" when I enable video on my device?
 
 This error indicates that the device you are using does not support hardware acceleration decoding. However this does not impact the ability of this user to participate in Amazon Chime SDK meetings as the device can render and transmit VP8 streams to other parties in the call. Specifically for Chrome, you will need to enable Unified Plan support by setting this [flag](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers) to true or enable [Simulcast](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers). 
 In some cases, H.264 may be missing from the initial SDP offer [tracking Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1047994)) causing this slate to appear. Rejoining the meeting can fix the videos to be rendered once again.
 
 ## Audio and video
 
-### My clients are unable to join the meeting and I see “`navigator.mediaDevices is undefined`", what could be the reason?
+### My clients are unable to join the meeting and I see `navigator.mediaDevices is undefined`, what could be the reason?
 
 Amazon Chime SDK for JavaScript uses WebRTC’s getUserMedia() when you invoke the chooseVideoInputDevice API which can operate in [secure contexts inside a browser only](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Privacy_and_security) for privacy concerns so you will need to access your browsers using HTTPS://. The hostname `localhost` and the loopback address `127.0.0.1` are exceptions.
 
@@ -208,8 +208,8 @@ Applications that show multiple video tiles on the screen will need to decide wh
 
 * A video whose source is a mobile device in portrait mode will display quite differently compared to a video in landscape mode from a laptop camera. The CSS object-fit rule can be applied to the video element to change how the content scales to fit the parent video element.
 * Use the `VideoTileState` [videoStreamContentWidth and videoStreamContentHeight](https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L20) properties to determine the aspect ratio of the content.
-* For landscape aspect ratios (width > height), apply the CSS rule “`object-fit:cover"` to the HTML element that will contain the video to crop and scale the video to the aspect ratio of the video element.
-* For portrait aspect ratios (height > width), apply the CSS rule “`object-fit:contain"` to the HTML element that will contain the video to ensure that all video content can be seen.
+* For landscape aspect ratios (width > height), apply the CSS rule `object-fit:cover` to the HTML element that will contain the video to crop and scale the video to the aspect ratio of the video element.
+* For portrait aspect ratios (height > width), apply the CSS rule `object-fit:contain` to the HTML element that will contain the video to ensure that all video content can be seen.
 
 ### After leaving a meeting, the camera LED is still on indicating that the camera has not been released. What could be wrong?
 
@@ -229,7 +229,7 @@ meetingSession.audioVideo.stopVideoPreviewForVideoInput(previewVideoElement);
 meetingSession.audioVideo.stop();
 ```
 
-### My clients are unable to successfully join audio calls from Safari, they get a “failed to get audio device for constraints null: Type error”, what could be the issue?
+### My clients are unable to successfully join audio calls from Safari, they get a `failed to get audio device for constraints null: Type error`, what could be the issue?
 
 This error message is an indication that the browser application did not successfully acquire the media stream for audio or video from the device before the meeting starts. Application has not passed in the right device Id to the `chooseVideoInputDevice` API. In this case you will see the following entry in the log where an empty string after `chooseVideoInputDevice`:
 
@@ -239,3 +239,20 @@ This error message is an indication that the browser application did not success
 
 This applies for video input as well.
 
+### How can I show a custom UX when the browser prompts the user for permission to use microphone and camera?
+
+Device labels are privileged since they add to the fingerprinting surface area of the browser session. In Chrome private tabs and in all Firefox tabs, the labels can only be read once a MediaStream is active. How to deal with this restriction depends on the desired UX. The device controller includes an injectable device label trigger which allows you to perform custom behavior in case there are no labels, such as creating a temporary audio/video stream to unlock the device names, which is the default behavior.
+
+You may want to override this behavior to provide a custom UX such as a prompt explaining why microphone and camera access is being asked for by supplying your own function to setDeviceLabelTrigger(). See the [meeting demo application](https://github.com/aws/amazon-chime-sdk-js/blob/b0e1b16b83b9d56b2a6354b0509aa888ef7b983c/demos/browser/app/meetingV2/meetingV2.ts#L928) for an example.
+
+```
+meetingSession.audioVideo.setDeviceLabelTrigger(
+  async (): Promise<MediaStream> => {
+    // For example, let the user know that the browser is asking for microphone and camera permissions.
+    showCustomUX();
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    hideCustomUX();
+    return stream;
+  }
+);
+```

--- a/integration/js/package-lock.json
+++ b/integration/js/package-lock.json
@@ -681,9 +681,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1186,9 +1186,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.14",
+  "version": "1.11.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.11.14",
+  "version": "1.11.15",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.11.14';
+    return '1.11.15';
   }
 
   /**

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -63,4 +63,6 @@ export default class DOMMockBehavior {
   responseStatusCode: number = 200;
   hasInactiveTransceiver: boolean = false;
   createElementCaptureStream: MediaStream = undefined;
+  audioContextDefaultSampleRate = 48000;
+  audioContextCreateBufferSucceeds = true;
 }

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -903,7 +903,15 @@ export default class DOMMockBuilder {
     };
 
     GlobalAny.AudioContext = class MockAudioContext {
-      constructor(_contextOptions?: AudioContextOptions) {}
+      sampleRate: number = 48000;
+
+      constructor(contextOptions?: AudioContextOptions) {
+        if (contextOptions && contextOptions.sampleRate) {
+          this.sampleRate = contextOptions.sampleRate;
+        } else {
+          this.sampleRate = mockBehavior.audioContextDefaultSampleRate;
+        }
+      }
 
       createMediaStreamDestination(): MediaStreamAudioDestinationNode {
         return new GlobalAny.MediaStreamAudioDestinationNode();
@@ -948,7 +956,17 @@ export default class DOMMockBuilder {
         };
       }
 
-      createBuffer(_numberOfChannels: number, _length: number, _sampleRate: number): AudioBuffer {
+      createBuffer(_numberOfChannels: number, _length: number, sampleRate: number): AudioBuffer {
+        if (!mockBehavior.audioContextCreateBufferSucceeds) {
+          throw new Error('Unknown error');
+        }
+
+        if (sampleRate < 8000 || sampleRate > 96000) {
+          const error = new Error('The operation is not supported');
+          error.name = 'NotSupportedError';
+          throw error;
+        }
+
         return new GlobalAny.AudioBuffer();
       }
 


### PR DESCRIPTION
…nly when the AudioContext sample rate doesn't work

**Issue #:** 
N/A

**Description of changes:**
- Add a simple retry logic. Try creating an AudioBuffer with the AudioContext's sample rate. If failed, use 48,000 Hz.
- Add the device label trigger to FAQs (the comments from DeviceController and the demo file)
- Bump lodash in package-lock.json of the device demo and the integation.

**Testing**

1. Have you successfully run `npm run build:release` locally?
   Yes
2. How did you test these changes?
   Tested changes on macOS and iOS Safari, trying to choose null and 440 hz options multiple times in the SDK demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
