### PR TITLE
Fix content share test video in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increase log interval to avoid multiple Cloudwatch requests at once
 - Fix incorrect log level for terminal error code
 - Catch exceptions taking place when putLogEvents fails
+- Fix content share test video in Firefox
 
 ## [1.11.0] - 2020-06-30
 

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ inputElement.addEventListener('change', async () => {
   videoElement.src = url;
   await videoElement.play();
 
-  const mediaSream = videoElement.captureStream();
+  const mediaSream = videoElement.captureStream(); /* use mozCaptureStream for Firefox e.g. videoElement.mozCaptureStream(); */
   await meetingSession.audioVideo.startContentShare(mediaSream);
   inputElement.value = '';
 });

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -18,6 +18,7 @@ import {
   DefaultMeetingSession,
   DefaultModality,
   Device,
+  DefaultBrowserBehavior,
   DeviceChangeObserver,
   LogLevel,
   Logger,
@@ -126,6 +127,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   audioVideo: AudioVideoFacade | null = null;
   tileOrganizer: DemoTileOrganizer = new DemoTileOrganizer();
   canStartLocalVideo: boolean = true;
+  defaultBrowserBehaviour: DefaultBrowserBehavior;
   // eslint-disable-next-line
   roster: any = {};
   tileIndexToTileId: { [id: number]: number } = {};
@@ -184,6 +186,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     } else {
       (document.getElementById('inputMeeting') as HTMLInputElement).focus();
     }
+    this.defaultBrowserBehaviour = new DefaultBrowserBehavior();
   }
 
   initEventListeners(): void {
@@ -527,7 +530,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   }
 
   async getNearestMediaRegion(): Promise<string> {
-     const nearestMediaRegionResponse = await fetch(
+    const nearestMediaRegionResponse = await fetch(
       `https://nearest-media-region.l.chime.aws`,
       {
         method: 'GET',
@@ -1276,8 +1279,14 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           videoFile.src = videoUrl;
         }
         await videoFile.play();
-        // @ts-ignore
-        const mediaStream: MediaStream = videoFile.captureStream();
+        let mediaStream: MediaStream;
+        if(this.defaultBrowserBehaviour.hasFirefoxWebRTC()) {
+          // @ts-ignore
+          mediaStream = videoFile.mozCaptureStream();
+        } else {
+          // @ts-ignore
+          mediaStream = videoFile.captureStream();
+        }
         this.audioVideo.startContentShare(mediaStream);
         break;
     }

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.715.0",
+    "aws-sdk": "^2.716.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/docs/index.html
+++ b/docs/index.html
@@ -583,7 +583,7 @@ inputElement.addEventListener(<span class="hljs-string">'change'</span>, <span c
   videoElement.src = url;
   <span class="hljs-keyword">await</span> videoElement.play();
 
-  <span class="hljs-keyword">const</span> mediaSream = videoElement.captureStream();
+  <span class="hljs-keyword">const</span> mediaSream = videoElement.captureStream(); <span class="hljs-comment">/* use mozCaptureStream for Firefox e.g. videoElement.mozCaptureStream(); */</span>
   <span class="hljs-keyword">await</span> meetingSession.audioVideo.startContentShare(mediaSream);
   inputElement.value = <span class="hljs-string">''</span>;
 });</code></pre>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.12.1';
+    return '1.12.2';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
When the content share test video is started on a Firefox browser, we are not able to see the test video being played at the receivers end on a chrome/firefox browser. The captureStream() used is not supported by firefox browsers. Instead it needs to use mozCaptureStream()

**Issue Repro steps#:** 
1) User A starts a meeting from firefox and user B joins the same meeting from either chrome / firefox
2) User A starts content share test video, and hear the audio of the content share test video
3) User B is not able to view the test video
4) Neither user A nor user B is able to see the <<content share>> in the roaster.

**Description of changes:**
In this PR we are calling the mozCaptureMediaStream() on a video element with a MediaStream while the video element is playing.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Tested manually on Firefox v77.0.1 on MAC


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
