### PR TITLE
Add function in demo to query outbound video stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add function to query outbound WebRTC video stats in browser demo
 
 ### Changed
 - Use POST instead of GET for TURN control endpoint

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.12.4';
+    return '1.12.5';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
To make it easy to verify outbound stream identifiers

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
tested with demo, and type this in console
`await app. getStatsForOutbound('video-16')`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
