### PR TITLE
Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix demo app responsiveness issue
+- Fix content share test video in Firefox
 - Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting
+- Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made 
 
 ## [1.12.0] - 2020-07-17
 

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L98">src/videotile/DefaultVideoTile.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L92">src/videotile/DefaultVideoTile.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<wbr>Monitor<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicepixelratiomonitor.html" class="tsd-signature-type">DevicePixelRatioMonitor</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L104">src/videotile/DefaultVideoTile.ts:104</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L98">src/videotile/DefaultVideoTile.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L103">src/videotile/DefaultVideoTile.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L97">src/videotile/DefaultVideoTile.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L188">src/videotile/DefaultVideoTile.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L182">src/videotile/DefaultVideoTile.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -231,7 +231,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L142">src/videotile/DefaultVideoTile.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L136">src/videotile/DefaultVideoTile.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L244">src/videotile/DefaultVideoTile.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L238">src/videotile/DefaultVideoTile.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ImageData</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L111">src/videotile/DefaultVideoTile.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L105">src/videotile/DefaultVideoTile.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratioobserver.html">DevicePixelRatioObserver</a>.<a href="../interfaces/devicepixelratioobserver.html#devicepixelratiochanged">devicePixelRatioChanged</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L125">src/videotile/DefaultVideoTile.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L119">src/videotile/DefaultVideoTile.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#id">id</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L130">src/videotile/DefaultVideoTile.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L124">src/videotile/DefaultVideoTile.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L226">src/videotile/DefaultVideoTile.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L220">src/videotile/DefaultVideoTile.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L212">src/videotile/DefaultVideoTile.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L206">src/videotile/DefaultVideoTile.ts:206</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L257">src/videotile/DefaultVideoTile.ts:257</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L251">src/videotile/DefaultVideoTile.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#state">state</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L134">src/videotile/DefaultVideoTile.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L128">src/videotile/DefaultVideoTile.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#stateref">stateRef</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L138">src/videotile/DefaultVideoTile.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L132">src/videotile/DefaultVideoTile.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L235">src/videotile/DefaultVideoTile.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L229">src/videotile/DefaultVideoTile.ts:229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L219">src/videotile/DefaultVideoTile.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L213">src/videotile/DefaultVideoTile.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L264">src/videotile/DefaultVideoTile.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L258">src/videotile/DefaultVideoTile.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -492,7 +492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L274">src/videotile/DefaultVideoTile.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L268">src/videotile/DefaultVideoTile.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -509,7 +509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L289">src/videotile/DefaultVideoTile.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L283">src/videotile/DefaultVideoTile.ts:283</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L58">src/videotile/DefaultVideoTile.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L52">src/videotile/DefaultVideoTile.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L304">src/videotile/DefaultVideoTile.ts:304</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L298">src/videotile/DefaultVideoTile.ts:298</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/videoelementfactory/NoOpVideoElementFactory.ts
+++ b/src/videoelementfactory/NoOpVideoElementFactory.ts
@@ -22,9 +22,6 @@ export default class NoOpVideoElementFactory implements VideoElementFactory {
       setAttribute: (): void => {},
       srcObject: false,
       pause: (): void => {},
-      play: (): Promise<void> => {
-        return Promise.resolve();
-      },
     };
     // @ts-ignore
     return element;

--- a/src/videotile/DefaultVideoTile.ts
+++ b/src/videotile/DefaultVideoTile.ts
@@ -47,12 +47,6 @@ export default class DefaultVideoTile implements DevicePixelRatioObserver, Video
     if (videoElement.srcObject !== videoStream) {
       videoElement.srcObject = videoStream;
     }
-
-    if (new DefaultBrowserBehavior().requiresVideoElementWorkaround()) {
-      new AsyncScheduler().start(async () => {
-        await videoElement.play();
-      });
-    }
   }
 
   static disconnectVideoStreamFromVideoElement(

--- a/test/videotile/DefaultVideoTile.test.ts
+++ b/test/videotile/DefaultVideoTile.test.ts
@@ -181,44 +181,6 @@ describe('DefaultVideoTile', () => {
       expect(tileControllerSpy.called).to.be.true;
     });
 
-    it('binds a video stream in Safari', done => {
-      domMockBehavior.browserName = 'safari';
-      domMockBuilder = new DOMMockBuilder(domMockBehavior);
-      tile = new DefaultVideoTile(tileId, true, tileController, monitor);
-      const videoElement = videoElementFactory.create();
-      const videoElementSpy = sinon.spy(videoElement, 'play');
-      tile.bindVideoElement(videoElement);
-
-      const boundAttendeeId = 'attendee';
-      const localTile = true;
-      const videoStreamContentWidth = 1;
-      const videoStreamContentHeight = 1;
-      const streamId = 1;
-
-      tile.bindVideoStream(
-        boundAttendeeId,
-        localTile,
-        mockVideoStream,
-        videoStreamContentWidth,
-        videoStreamContentHeight,
-        streamId
-      );
-
-      expect(tile.state().boundAttendeeId).to.equal(boundAttendeeId);
-      expect(tile.state().localTile).to.equal(localTile);
-      expect(tile.state().boundVideoStream).to.equal(mockVideoStream);
-      expect(tile.state().videoStreamContentWidth).to.equal(videoStreamContentWidth);
-      expect(tile.state().videoStreamContentHeight).to.equal(videoStreamContentHeight);
-      expect(tile.state().streamId).to.equal(streamId);
-      expect(tile.state().isContent).to.be.false;
-
-      expect(tileControllerSpy.called).to.be.true;
-      new TimeoutScheduler(10).start(() => {
-        expect(videoElementSpy.calledOnce).to.be.true;
-        done();
-      });
-    });
-
     it('unbinds a video stream', () => {
       tile = new DefaultVideoTile(tileId, true, tileController, monitor);
       tile.bindVideoStream('attendee', true, mockVideoStream, 1, 1, 1);


### PR DESCRIPTION
**Issue #:** 
We observed uncaught exception in startVideoPreviewForVideoInput() on safari when multiple calls to startVideoPreviewForVideoInput() are made in quick successions. The play() is explicitly being called on a video element for Safari browser while the video element is already playing. This is leading to the exception as a call to the video element is made before the first one is resolved.

Repro using the SDK APIs:
In safari console, 
1. var videoElement = document.createElement("VIDEO");
2. document.body.appendChild(videoElement);
3. app.audioVideo.chooseVideoInputDevice(videoElement)
4. app.audioVideo.startVideoPreviewForVideoInput(videoElement)
5. app.audioVideo.stopVideoPreviewForVideoInput(videoElement)
6. app.audioVideo.chooseVideoInputDevice(videoElement)
//Perform step 8 immediately after the 7 (before the video camera switches on)
7. app.audioVideo.startVideoPreviewForVideoInput(videoElement)
8. app.audioVideo.stopVideoPreviewForVideoInput(videoElement)

**Description of changes:**
In this PR, we are removing the explicit call to the play() on the video element for safari browser

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Yes, tested manually


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
