### PR TITLE
Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix demo app responsiveness issue
+- Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting
 
 ## [1.12.0] - 2020-07-17
 

--- a/docs/classes/meetingsessionstatus.html
+++ b/docs/classes/meetingsessionstatus.html
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L61">src/meetingsession/MeetingSessionStatus.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L62">src/meetingsession/MeetingSessionStatus.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L91">src/meetingsession/MeetingSessionStatus.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L92">src/meetingsession/MeetingSessionStatus.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L79">src/meetingsession/MeetingSessionStatus.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L80">src/meetingsession/MeetingSessionStatus.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L120">src/meetingsession/MeetingSessionStatus.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L121">src/meetingsession/MeetingSessionStatus.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/meetingsession/MeetingSessionStatus.ts
+++ b/src/meetingsession/MeetingSessionStatus.ts
@@ -47,6 +47,7 @@ export default class MeetingSessionStatus {
       case MeetingSessionStatusCode.AudioInternalServerError:
       case MeetingSessionStatusCode.AudioDisconnected:
       case MeetingSessionStatusCode.TURNCredentialsForbidden:
+      case MeetingSessionStatusCode.TURNMeetingEnded:
       case MeetingSessionStatusCode.SignalingBadRequest:
       case MeetingSessionStatusCode.SignalingInternalServerError:
       case MeetingSessionStatusCode.SignalingRequestFailed:

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.12.2';
+    return '1.12.3';
   }
 
   /**

--- a/test/meetingsession/MeetingSessionStatus.test.ts
+++ b/test/meetingsession/MeetingSessionStatus.test.ts
@@ -32,6 +32,7 @@ describe('MeetingSessionStatus', () => {
     MeetingSessionStatusCode.SignalingRequestFailed,
     MeetingSessionStatusCode.StateMachineTransitionFailed,
     MeetingSessionStatusCode.TURNCredentialsForbidden,
+    MeetingSessionStatusCode.TURNMeetingEnded,
     MeetingSessionStatusCode.ICEGatheringTimeoutWorkaround,
     MeetingSessionStatusCode.ConnectionHealthReconnect,
     MeetingSessionStatusCode.RealtimeApiFailed,
@@ -75,6 +76,7 @@ describe('MeetingSessionStatus', () => {
         MeetingSessionStatusCode.SignalingInternalServerError,
         MeetingSessionStatusCode.SignalingRequestFailed,
         MeetingSessionStatusCode.TURNCredentialsForbidden,
+        MeetingSessionStatusCode.TURNMeetingEnded,
         MeetingSessionStatusCode.VideoCallAtSourceCapacity,
         MeetingSessionStatusCode.RealtimeApiFailed,
       ]);


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/483

**Description of changes:** `TURNMeetingEnded` error event is fired when a user tries to join a meeting which has ended. Marking this error as `terminal` ensures there is no reconnection attempt when this error is encountered.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Used the serverless demo app to test this scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
