### PR TITLE
Return media stream for content share screen capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use POST instead of GET for TURN control endpoint
+- Return the screen capture media stream for startContentShareFromScreenCapture
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,14 @@ meetingSession.audioVideo.addContentShareObserver(observer);
 meetingSession.audioVideo.addObserver(observer);
 
 // A browser will prompt the user to choose the screen.
-await meetingSession.audioVideo.startContentShareFromScreenCapture();
+const contentShareStream = await meetingSession.audioVideo.startContentShareFromScreenCapture();
+```
+
+If you want to display the content share stream for the sharer, you can bind the returned content share stream to a
+ video element using `connectVideoStreamToVideoElement` from DefaultVideoTile.
+ 
+```js
+DefaultVideoTile.connectVideoStreamToVideoElement(contentShareStream, videoElement, false);
 ```
 
 **Use case 17.** Start sharing your screen in an environment that does not support a screen picker dialog. e.g. Electron

--- a/docs/classes/defaultaudiovideofacade.html
+++ b/docs/classes/defaultaudiovideofacade.html
@@ -1775,7 +1775,7 @@
 					<a name="startcontentsharefromscreencapture" class="tsd-anchor"></a>
 					<h3>start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -1794,7 +1794,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> frameRate: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/classes/defaultcontentsharecontroller.html
+++ b/docs/classes/defaultcontentsharecontroller.html
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L86">src/contentsharecontroller/DefaultContentShareController.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L90">src/contentsharecontroller/DefaultContentShareController.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -217,7 +217,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstart">audioVideoDidStart</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L104">src/contentsharecontroller/DefaultContentShareController.ts:104</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L108">src/contentsharecontroller/DefaultContentShareController.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -235,7 +235,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstop">audioVideoDidStop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L110">src/contentsharecontroller/DefaultContentShareController.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L114">src/contentsharecontroller/DefaultContentShareController.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L94">src/contentsharecontroller/DefaultContentShareController.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L98">src/contentsharecontroller/DefaultContentShareController.ts:98</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L65">src/contentsharecontroller/DefaultContentShareController.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L69">src/contentsharecontroller/DefaultContentShareController.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -318,7 +318,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L90">src/contentsharecontroller/DefaultContentShareController.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L94">src/contentsharecontroller/DefaultContentShareController.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -359,7 +359,7 @@
 					<a name="startcontentsharefromscreencapture" class="tsd-anchor"></a>
 					<h3>start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -378,7 +378,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> frameRate: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -393,7 +393,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L81">src/contentsharecontroller/DefaultContentShareController.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L85">src/contentsharecontroller/DefaultContentShareController.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -411,7 +411,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L73">src/contentsharecontroller/DefaultContentShareController.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L77">src/contentsharecontroller/DefaultContentShareController.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,7 +568,10 @@ meetingSession.audioVideo.addContentShareObserver(observer);
 meetingSession.audioVideo.addObserver(observer);
 
 <span class="hljs-comment">// A browser will prompt the user to choose the screen.</span>
-<span class="hljs-keyword">await</span> meetingSession.audioVideo.startContentShareFromScreenCapture();</code></pre>
+<span class="hljs-keyword">const</span> contentShareStream = <span class="hljs-keyword">await</span> meetingSession.audioVideo.startContentShareFromScreenCapture();</code></pre>
+				<p>If you want to display the content share stream for the sharer, you can bind the returned content share stream to a
+				video element using <code>connectVideoStreamToVideoElement</code> from DefaultVideoTile.</p>
+				<pre><code class="language-js">DefaultVideoTile.connectVideoStreamToVideoElement(contentShareStream, videoElement, <span class="hljs-literal">false</span>);</code></pre>
 				<p><strong>Use case 17.</strong> Start sharing your screen in an environment that does not support a screen picker dialog. e.g. Electron</p>
 				<pre><code class="language-js"><span class="hljs-keyword">const</span> sourceId = <span class="hljs-comment">/* Window or screen ID e.g. the ID of a DesktopCapturerSource object in Electron */</span>;
 

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -1792,7 +1792,7 @@
 					<a name="startcontentsharefromscreencapture" class="tsd-anchor"></a>
 					<h3>start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -1816,7 +1816,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> frameRate: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/interfaces/contentsharecontroller.html
+++ b/docs/interfaces/contentsharecontroller.html
@@ -268,7 +268,7 @@
 					<a name="startcontentsharefromscreencapture" class="tsd-anchor"></a>
 					<h3>start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -292,7 +292,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> frameRate: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/docs/interfaces/contentsharecontrollerfacade.html
+++ b/docs/interfaces/contentsharecontrollerfacade.html
@@ -213,7 +213,7 @@
 					<a name="startcontentsharefromscreencapture" class="tsd-anchor"></a>
 					<h3>start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">start<wbr>Content<wbr>Share<wbr>From<wbr>Screen<wbr>Capture<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span>, frameRate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -236,7 +236,7 @@
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> frameRate: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
 				</section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -405,7 +405,7 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     return result;
   }
 
-  startContentShareFromScreenCapture(sourceId?: string, frameRate?: number): Promise<void> {
+  startContentShareFromScreenCapture(sourceId?: string, frameRate?: number): Promise<MediaStream> {
     const result = this.contentShareController.startContentShareFromScreenCapture(
       sourceId,
       frameRate

--- a/src/contentsharecontroller/ContentShareControllerFacade.ts
+++ b/src/contentsharecontroller/ContentShareControllerFacade.ts
@@ -12,7 +12,7 @@ export default interface ContentShareControllerFacade {
   /**
    * Start screen sharing
    */
-  startContentShareFromScreenCapture(sourceId?: string, frameRate?: number): Promise<void>;
+  startContentShareFromScreenCapture(sourceId?: string, frameRate?: number): Promise<MediaStream>;
 
   /**
    * Pause content sharing

--- a/src/contentsharecontroller/DefaultContentShareController.ts
+++ b/src/contentsharecontroller/DefaultContentShareController.ts
@@ -54,12 +54,16 @@ export default class DefaultContentShareController
     }
   }
 
-  async startContentShareFromScreenCapture(sourceId?: string, frameRate?: number): Promise<void> {
+  async startContentShareFromScreenCapture(
+    sourceId?: string,
+    frameRate?: number
+  ): Promise<MediaStream> {
     const mediaStream = await this.mediaStreamBroker.acquireScreenCaptureDisplayInputStream(
       sourceId,
       frameRate
     );
     await this.startContentShare(mediaStream);
+    return mediaStream;
   }
 
   pauseContentShare(): void {

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.13.0';
+    return '1.13.1';
   }
 
   /**

--- a/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
+++ b/test/audiovideofacade/DefaultAudioVideoFacade.test.ts
@@ -33,7 +33,9 @@ describe('DefaultAudioVideoFacade', () => {
   class NoOpContentShareController implements ContentShareController {
     async startContentShare(_stream: MediaStream): Promise<void> {}
 
-    async startContentShareFromScreenCapture(_sourceId?: string): Promise<void> {}
+    async startContentShareFromScreenCapture(_sourceId?: string): Promise<MediaStream> {
+      return new MediaStream();
+    }
 
     pauseContentShare(): void {}
 


### PR DESCRIPTION
**Issue #569 : 

**Description of changes:**
Return the media stream for screen capture so that it can be bound to a video element and shown for the content sharer.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually test with meeting demo app.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
