### PR TITLE
Add function in demo to query outbound video stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add content share video test integration test
+- Add function to query outbound WebRTC video stats in browser demo
 
 ### Changed
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix demo app responsiveness issue
 - Fix content share test video in Firefox
 - Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting
-- Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made 
+- Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made
 
 ## [1.12.0] - 2020-07-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.13.2';
+    return '1.13.3';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Add a function in demo to easily query outbound video stats

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
test with demo app. It is for debugging, the PR does not touch SDK source code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
