### PR TITLE
Add error message for TaskFailed errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add content share video test integration test
 - Add function to query outbound WebRTC video stats in browser demo
+- Add error message for TaskFailed errors
 
 ### Changed
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.718.0",
+    "aws-sdk": "^2.719.0",
     "bootstrap": "^4.3.1",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -607,7 +607,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L572">src/audiovideocontroller/DefaultAudioVideoController.ts:572</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L571">src/audiovideocontroller/DefaultAudioVideoController.ts:571</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -671,7 +671,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L644">src/audiovideocontroller/DefaultAudioVideoController.ts:644</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L642">src/audiovideocontroller/DefaultAudioVideoController.ts:642</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -735,7 +735,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L635">src/audiovideocontroller/DefaultAudioVideoController.ts:635</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L633">src/audiovideocontroller/DefaultAudioVideoController.ts:633</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -782,7 +782,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L706">src/audiovideocontroller/DefaultAudioVideoController.ts:706</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L713">src/audiovideocontroller/DefaultAudioVideoController.ts:713</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -799,20 +799,23 @@
 					<a name="handlemeetingsessionstatus" class="tsd-anchor"></a>
 					<h3>handle<wbr>Meeting<wbr>Session<wbr>Status</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a>, error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L658">src/audiovideocontroller/DefaultAudioVideoController.ts:658</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L656">src/audiovideocontroller/DefaultAudioVideoController.ts:656</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
 									<h5>status: <a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a></h5>
+								</li>
+								<li>
+									<h5>error: <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -830,7 +833,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L728">src/audiovideocontroller/DefaultAudioVideoController.ts:728</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L735">src/audiovideocontroller/DefaultAudioVideoController.ts:735</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -972,7 +975,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L734">src/audiovideocontroller/DefaultAudioVideoController.ts:734</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L741">src/audiovideocontroller/DefaultAudioVideoController.ts:741</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -996,7 +999,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L697">src/audiovideocontroller/DefaultAudioVideoController.ts:697</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L704">src/audiovideocontroller/DefaultAudioVideoController.ts:704</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1073,7 +1076,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L631">src/audiovideocontroller/DefaultAudioVideoController.ts:631</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L629">src/audiovideocontroller/DefaultAudioVideoController.ts:629</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/monitortask.html
+++ b/docs/classes/monitortask.html
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L336">src/task/MonitorTask.ts:336</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L337">src/task/MonitorTask.ts:337</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -416,7 +416,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L287">src/task/MonitorTask.ts:287</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L288">src/task/MonitorTask.ts:288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L319">src/task/MonitorTask.ts:319</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L320">src/task/MonitorTask.ts:320</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -530,7 +530,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L354">src/task/MonitorTask.ts:354</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L355">src/task/MonitorTask.ts:355</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L706">src/audiovideocontroller/DefaultAudioVideoController.ts:706</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L713">src/audiovideocontroller/DefaultAudioVideoController.ts:713</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -427,7 +427,7 @@
 					<a name="handlemeetingsessionstatus" class="tsd-anchor"></a>
 					<h3>handle<wbr>Meeting<wbr>Session<wbr>Status</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a>, error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -435,13 +435,16 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L658">src/audiovideocontroller/DefaultAudioVideoController.ts:658</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L656">src/audiovideocontroller/DefaultAudioVideoController.ts:656</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
 									<h5>status: <a href="meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a></h5>
+								</li>
+								<li>
+									<h5>error: <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -460,7 +463,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L728">src/audiovideocontroller/DefaultAudioVideoController.ts:728</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L735">src/audiovideocontroller/DefaultAudioVideoController.ts:735</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -607,7 +610,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L734">src/audiovideocontroller/DefaultAudioVideoController.ts:734</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L741">src/audiovideocontroller/DefaultAudioVideoController.ts:741</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -632,7 +635,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L697">src/audiovideocontroller/DefaultAudioVideoController.ts:697</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L704">src/audiovideocontroller/DefaultAudioVideoController.ts:704</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/audiovideocontroller.html
+++ b/docs/interfaces/audiovideocontroller.html
@@ -357,7 +357,7 @@
 					<a name="handlemeetingsessionstatus" class="tsd-anchor"></a>
 					<h3>handle<wbr>Meeting<wbr>Session<wbr>Status</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="../classes/meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+						<li class="tsd-signature tsd-kind-icon">handle<wbr>Meeting<wbr>Session<wbr>Status<span class="tsd-signature-symbol">(</span>status<span class="tsd-signature-symbol">: </span><a href="../classes/meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a>, error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -375,6 +375,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>status: <a href="../classes/meetingsessionstatus.html" class="tsd-signature-type">MeetingSessionStatus</a></h5>
+								</li>
+								<li>
+									<h5>error: <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/audiovideocontroller/AudioVideoController.ts
+++ b/src/audiovideocontroller/AudioVideoController.ts
@@ -47,7 +47,7 @@ export default interface AudioVideoController extends AudioVideoControllerFacade
   /**
    * Handles the meeting session status and returns true if it will restart the session.
    */
-  handleMeetingSessionStatus(status: MeetingSessionStatus): boolean;
+  handleMeetingSessionStatus(status: MeetingSessionStatus, error: Error | null): boolean;
 
   /**
    * Sets the max bandwidth for video publishing

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -359,7 +359,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
           this.getMeetingStatusCode(error) || MeetingSessionStatusCode.TaskFailed
         );
         await this.actionDisconnect(status, true);
-        if (!this.handleMeetingSessionStatus(status)) {
+        if (!this.handleMeetingSessionStatus(status, error)) {
           this.forEachObserver(observer => {
             Maybe.of(observer.audioVideoDidStop).map(f => f.bind(observer)(status));
           });
@@ -528,7 +528,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
         if (status.statusCode() !== MeetingSessionStatusCode.IncompatibleSDP) {
           this.logger.info('failed to update audio-video session');
         }
-        this.handleMeetingSessionStatus(status);
+        this.handleMeetingSessionStatus(status, error);
       });
     }
   }
@@ -559,7 +559,6 @@ export default class DefaultAudioVideoController implements AudioVideoController
         this.logger.info('canceled retry');
       }
     );
-
     if (!willRetry) {
       this.sessionStateController.perform(SessionStateControllerAction.Fail, () => {
         this.actionDisconnect(status, false);
@@ -618,11 +617,10 @@ export default class DefaultAudioVideoController implements AudioVideoController
       // To perform the "Reconnect" action again, the session should be in the "Connected" state.
       this.sessionStateController.perform(SessionStateControllerAction.FinishConnecting, () => {
         this.logger.info('failed to reconnect audio-video session');
-        this.handleMeetingSessionStatus(
-          new MeetingSessionStatus(
-            this.getMeetingStatusCode(error) || MeetingSessionStatusCode.TaskFailed
-          )
+        const status = new MeetingSessionStatus(
+          this.getMeetingStatusCode(error) || MeetingSessionStatusCode.TaskFailed
         );
+        this.handleMeetingSessionStatus(status, error);
       });
     }
     this.connectionHealthData.setConnectionStartTime();
@@ -655,7 +653,7 @@ export default class DefaultAudioVideoController implements AudioVideoController
     }
   }
 
-  handleMeetingSessionStatus(status: MeetingSessionStatus): boolean {
+  handleMeetingSessionStatus(status: MeetingSessionStatus, error: Error | null): boolean {
     this.logger.info(`handling status: ${MeetingSessionStatusCode[status.statusCode()]}`);
     if (!status.isTerminal()) {
       if (this.meetingSessionContext.statsCollector) {
@@ -675,11 +673,6 @@ export default class DefaultAudioVideoController implements AudioVideoController
       });
       return false;
     }
-    if (status.isFailure()) {
-      this.logger.warn(
-        `connection failed with status code: ${MeetingSessionStatusCode[status.statusCode()]}`
-      );
-    }
     if (status.isTerminal()) {
       this.logger.error('session will not be reconnected');
       if (this.meetingSessionContext.reconnectController) {
@@ -688,7 +681,21 @@ export default class DefaultAudioVideoController implements AudioVideoController
     }
     if (status.isFailure() || status.isTerminal()) {
       if (this.meetingSessionContext.reconnectController) {
-        return this.reconnect(status);
+        const willRetry = this.reconnect(status);
+        if (willRetry) {
+          this.logger.warn(
+            `will retry due to status code ${MeetingSessionStatusCode[status.statusCode()]}${
+              error ? ` and error: ${error.message}` : ``
+            }`
+          );
+        } else {
+          this.logger.error(
+            `failed with status code ${MeetingSessionStatusCode[status.statusCode()]}${
+              error ? ` and error: ${error.message}` : ``
+            }`
+          );
+        }
+        return willRetry;
       }
     }
     return false;

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -655,8 +655,8 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
     } catch (error) {
       this.logger.error(
         `failed to get ${kind} device for constraints ${JSON.stringify(proposedConstraints)}: ${
-          error.message
-        }`
+          error.name
+        }: ${error.message}`
       );
       return Date.now() - startTimeMs <
         DefaultDeviceController.permissionDeniedOriginDetectionThresholdMs

--- a/src/task/MonitorTask.ts
+++ b/src/task/MonitorTask.ts
@@ -257,7 +257,8 @@ export default class MonitorTask extends BaseTask
       this.logger.info(`reconnection health is now: ${reconnectionValue}`);
       if (reconnectionValue === 0) {
         this.context.audioVideoController.handleMeetingSessionStatus(
-          new MeetingSessionStatus(MeetingSessionStatusCode.ConnectionHealthReconnect)
+          new MeetingSessionStatus(MeetingSessionStatusCode.ConnectionHealthReconnect),
+          null
         );
       }
     }
@@ -329,7 +330,7 @@ export default class MonitorTask extends BaseTask
     }
     const status = MeetingSessionStatus.fromSignalFrame(event.message);
     if (status.statusCode() !== MeetingSessionStatusCode.OK) {
-      this.context.audioVideoController.handleMeetingSessionStatus(status);
+      this.context.audioVideoController.handleMeetingSessionStatus(status, null);
     }
   }
 
@@ -354,7 +355,8 @@ export default class MonitorTask extends BaseTask
   private realtimeFatalErrorCallback = (error: Error): void => {
     this.logger.error(`realtime error: ${error}: ${error.stack}`);
     this.context.audioVideoController.handleMeetingSessionStatus(
-      new MeetingSessionStatus(MeetingSessionStatusCode.RealtimeApiFailed)
+      new MeetingSessionStatus(MeetingSessionStatusCode.RealtimeApiFailed),
+      error
     );
   };
 }

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.13.3';
+    return '1.13.4';
   }
 
   /**

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -137,6 +137,7 @@ describe('DefaultAudioVideoController', () => {
     audioStreamIdInfoBuffer.set(buffer, 1);
     return audioStreamIdInfoBuffer;
   }
+
   // For ListenForVolumeIndicatorsTask
   function makeAudioMetadataFrame(): Uint8Array {
     const frame = SdkAudioMetadataFrame.create();
@@ -413,7 +414,8 @@ describe('DefaultAudioVideoController', () => {
       await delay();
       configuration.connectionTimeoutMs = 15000;
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.Left)
+        new MeetingSessionStatus(MeetingSessionStatusCode.Left),
+        null
       );
       await stop();
       expect(spy.called).to.be.true;
@@ -475,9 +477,12 @@ describe('DefaultAudioVideoController', () => {
 
     it('can fail but does not reconnect', done => {
       configuration.connectionTimeoutMs = 100;
+      const logger = new NoOpDebugLogger();
+      const spy = sinon.spy(logger, 'error');
+
       audioVideoController = new DefaultAudioVideoController(
         configuration,
-        new NoOpDebugLogger(),
+        logger,
         webSocketAdapter,
         new NoOpMediaStreamBroker(),
         reconnectController
@@ -485,6 +490,8 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.TaskFailed);
+          expect(spy.calledWith(sinon.match('failed with status code TaskFailed'))).to.be.true;
+          spy.restore();
           done();
         }
       }
@@ -1055,9 +1062,12 @@ describe('DefaultAudioVideoController', () => {
       setUserAgent('Chrome/77.0.3865.75');
 
       configuration.connectionTimeoutMs = 6000;
+      const logger = new NoOpDebugLogger();
+      const spy = sinon.spy(logger, 'warn');
+
       audioVideoController = new DefaultAudioVideoController(
         configuration,
-        new NoOpDebugLogger(),
+        logger,
         webSocketAdapter,
         new NoOpMediaStreamBroker(),
         reconnectController
@@ -1065,6 +1075,11 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.Left);
+          expect(
+            spy.calledWith(
+              sinon.match('will retry due to status code ICEGatheringTimeoutWorkaround')
+            )
+          ).to.be.true;
           done();
         }
       }
@@ -1095,9 +1110,12 @@ describe('DefaultAudioVideoController', () => {
 
     it('reconnects when the start operation fails with a task failed meeting status', function(done) {
       configuration.connectionTimeoutMs = 100;
+      const logger = new NoOpDebugLogger();
+      const spy = sinon.spy(logger, 'warn');
+
       audioVideoController = new DefaultAudioVideoController(
         configuration,
-        new NoOpDebugLogger(),
+        logger,
         webSocketAdapter,
         new NoOpMediaStreamBroker(),
         reconnectController
@@ -1105,6 +1123,8 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.Left);
+          expect(spy.calledWith(sinon.match('will retry due to status code TaskFailed'))).to.be
+            .true;
           done();
         }
       }
@@ -1133,9 +1153,12 @@ describe('DefaultAudioVideoController', () => {
     });
 
     it('reconnects when the reconnect operation itself fails', done => {
+      const logger = new NoOpDebugLogger();
+      const loggerSpy = sinon.spy(logger, 'warn');
+
       audioVideoController = new DefaultAudioVideoController(
         configuration,
-        new NoOpDebugLogger(),
+        logger,
         webSocketAdapter,
         new NoOpMediaStreamBroker(),
         reconnectController
@@ -1143,6 +1166,9 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.Left);
+          expect(loggerSpy.calledWith(sinon.match('will retry due to status code TaskFailed'))).to
+            .be.true;
+          loggerSpy.restore();
           done();
         }
       }
@@ -1224,8 +1250,8 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.Left);
-          expect(spy.calledWith('connection failed with status code: NoAttendeePresent')).to.be
-            .true;
+          expect(spy.calledWith(sinon.match('will retry due to status code NoAttendeePresent'))).to
+            .be.true;
           spy.restore();
           done();
         }
@@ -1263,7 +1289,7 @@ describe('DefaultAudioVideoController', () => {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
-      const spy = sinon.spy(logger, 'error');
+      const spy = sinon.spy(logger, 'warn');
 
       class TestMediaStreamBroker extends NoOpMediaStreamBroker {
         requestAudioInputStream(): Promise<void> {
@@ -1283,8 +1309,8 @@ describe('DefaultAudioVideoController', () => {
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
           expect(sessionStatus.statusCode()).to.equal(MeetingSessionStatusCode.Left);
-          expect(spy.calledWith('connection failed with status code: NoAttendeePresent')).to.be
-            .false;
+          expect(spy.calledWith(sinon.match('will retry due to status code NoAttendeePresent'))).to
+            .be.false;
           spy.restore();
           done();
         }
@@ -1355,7 +1381,8 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.addObserver(new TestObserver());
       await start();
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.VideoCallSwitchToViewOnly)
+        new MeetingSessionStatus(MeetingSessionStatusCode.VideoCallSwitchToViewOnly),
+        null
       );
       await delay();
       expect(spy.called).to.be.true;
@@ -1377,7 +1404,8 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.addObserver(new TestObserver());
       await start();
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.IncompatibleSDP)
+        new MeetingSessionStatus(MeetingSessionStatusCode.IncompatibleSDP),
+        null
       );
       await delay();
       await sendICEEventAndSubscribeAckFrame();
@@ -1400,11 +1428,13 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.addObserver(new TestObserver());
       await start();
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.Left)
+        new MeetingSessionStatus(MeetingSessionStatusCode.Left),
+        null
       );
       await delay();
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.AudioDisconnectAudio)
+        new MeetingSessionStatus(MeetingSessionStatusCode.AudioDisconnectAudio),
+        null
       );
       expect(called).to.be.false;
       await stop();
@@ -1413,7 +1443,8 @@ describe('DefaultAudioVideoController', () => {
     it('does not reconnect if the reconnectController is not set in the context', async () => {
       const spy = sinon.spy(reconnectController, 'disableReconnect');
       audioVideoController.handleMeetingSessionStatus(
-        new MeetingSessionStatus(MeetingSessionStatusCode.Left)
+        new MeetingSessionStatus(MeetingSessionStatusCode.Left),
+        null
       );
       await delay();
       expect(spy.called).to.be.false;


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**
Add error message for TaskFailed errors in DefaultAudioVideoController, so that a detailed error message will show after unknown TaskFailed warning 

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
By manually throw errors in tasks and checking console error messages in browser demo app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
