### PR TITLE
Fixed CHANGELOG entry for 2 previous commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add error message for TaskFailed errors
 
 ### Changed
+- Return the screen capture media stream for startContentShareFromScreenCapture
 
 ### Removed
 
 ### Fixed
+- Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made
 
 ## [1.13.0] - 2020-07-21
 
@@ -24,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use POST instead of GET for TURN control endpoint
-- Return the screen capture media stream for startContentShareFromScreenCapture
 
 ### Removed
 
@@ -32,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix demo app responsiveness issue
 - Fix content share test video in Firefox
 - Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting
-- Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made
 
 ## [1.12.0] - 2020-07-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.13.4';
+    return '1.13.5';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Updated the CHANGELOG to  correct the last few entries

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes (but it were randomly failing sometime but seems unrelated to this change)

2. How did you test these changes?
Not testable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
