### PR TITLE
Fix race condition in Chromium browsers when consecutive audio bind operations take place 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure all simulcast stream resolution are 16-aligned to avoid pixel3(XL) encoder issue
+- Fix race condition in Chromium browsers when consecutive audio bind operations take place 
 
 ## [1.14.0] - 2020-07-28
 

--- a/docs/classes/defaultaudiomixcontroller.html
+++ b/docs/classes/defaultaudiomixcontroller.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Device<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L10">src/audiomixcontroller/DefaultAudioMixController.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L9">src/audiomixcontroller/DefaultAudioMixController.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLAudioElement</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L11">src/audiomixcontroller/DefaultAudioMixController.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L10">src/audiomixcontroller/DefaultAudioMixController.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L12">src/audiomixcontroller/DefaultAudioMixController.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L11">src/audiomixcontroller/DefaultAudioMixController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a><span class="tsd-signature-symbol"> = new DefaultBrowserBehavior()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L13">src/audiomixcontroller/DefaultAudioMixController.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L12">src/audiomixcontroller/DefaultAudioMixController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudiodevice">bindAudioDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L39">src/audiomixcontroller/DefaultAudioMixController.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L38">src/audiomixcontroller/DefaultAudioMixController.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -186,7 +186,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L15">src/audiomixcontroller/DefaultAudioMixController.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L14">src/audiomixcontroller/DefaultAudioMixController.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L47">src/audiomixcontroller/DefaultAudioMixController.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L46">src/audiomixcontroller/DefaultAudioMixController.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudiostream">bindAudioStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L31">src/audiomixcontroller/DefaultAudioMixController.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L30">src/audiomixcontroller/DefaultAudioMixController.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L24">src/audiomixcontroller/DefaultAudioMixController.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L23">src/audiomixcontroller/DefaultAudioMixController.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/audiomixcontroller/DefaultAudioMixController.ts
+++ b/src/audiomixcontroller/DefaultAudioMixController.ts
@@ -3,7 +3,6 @@
 
 import BrowserBehavior from '../browserbehavior/BrowserBehavior';
 import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
-import AsyncScheduler from '../scheduler/AsyncScheduler';
 import AudioMixController from './AudioMixController';
 
 export default class DefaultAudioMixController implements AudioMixController {
@@ -56,13 +55,14 @@ export default class DefaultAudioMixController implements AudioMixController {
         const oldSinkId: string = this.audioElement.sinkId;
         if (newSinkId !== oldSinkId) {
           if (this.browserBehavior.hasChromiumWebRTC()) {
-            new AsyncScheduler().start(async () => {
-              const existingStream = await this.audioElement.srcObject;
-              this.audioElement.srcObject = null;
-              // @ts-ignore
-              await this.audioElement.setSinkId(newSinkId);
-              this.audioElement.srcObject = existingStream;
-              this.audioStream = existingStream as MediaStream;
+            const existingAudioElement = this.audioElement;
+            const existingstream = this.audioStream;
+            existingAudioElement.srcObject = null;
+            // @ts-ignore
+            existingAudioElement.setSinkId(newSinkId).then(() => {
+              if (this.audioElement === existingAudioElement) {
+                existingAudioElement.srcObject = existingstream;
+              }
             });
           } else {
             // @ts-ignore

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.14.2';
+    return '1.14.3';
   }
 
   /**

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -855,8 +855,9 @@ export default class DOMMockBuilder {
 
     GlobalAny.HTMLAudioElement = class MockHTMLAudioElement {
       sinkId = 'fakeSinkId';
-      setSinkId(deviceId: string): Promise<undefined> {
+      async setSinkId(deviceId: string): Promise<undefined> {
         this.sinkId = deviceId;
+        await new Promise(resolve => setTimeout(resolve, mockBehavior.asyncWaitMs * 10));
         return undefined;
       }
     };


### PR DESCRIPTION
**Issue #:** 
The sound test button in the 'Select Device' page does not respond in chromium based browsers. In the demo app's [TestSound class](https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts#L70) we see that the audio output bind operations are called consecutively. Upon investigation its found that for chromium browsers, there needs to be a slight delay between binding the audio device and the audio element stream. The order to call these 3 methods should be independent to the SDK

We recently made a modification in our SDK to set the sinkId a bit differently for chromium based browsers to handle an edge case which resulted in DOMException. The bindAudioMix() is a non async function and as per the [publicly available setSinkId documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId) setSinkId() returns a Promise. We had to call the setSinkId() in the bindAudioMix in a AsyncScheduler block. This allows async execution of the block of code.

*Root cause*
When a call to the setSinkId() is made, under the hood chromium based browsers expects the audioElement srcObject to be null while setting up the sinkId as discussed in the PR #522 
With this AsyncScheduler call in the SDK and the 3 consecutive calls to the bind methods in the demo app, a race condition would set up the audio stream (srcObject) of the audio element before the sinkId is set. Thus we cannot listen to the TestSound when the sound test button in the demo app is clicked on any chromium based browser.

**Description of changes:**
Two changes have been made in this PR. 
1) In order to avoid the unexpected race condition, we removed the AsyncScheduler from the the non async method bindAudioMix.
2) For chromium based browsers, in order to accommodate some time for the setSinkId() operation to complete before the stream is attached back to the srcObject of the audio element, then() was introduced over the setSinkId()

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
I have tested the following three major scenarios on the browser:
1) Being able listen to the beep upon clicking the Test speaker button on the device selection page of the demo app. Thus testing that the consecutive calls to the bind operations does not result in race condition.
2) The DOMException does not occur as tested for PR #522.
3) We are able to switch between audio output devices while in an active meeting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
