### PR TITLE
Log info when stop pinging due to Websocket closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bump elliptic from 6.5.2 to 6.5.3 in /demos/device
+- Log info when stop pinging due to Websocket closed
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/pingpong/DefaultPingPong.ts
+++ b/src/pingpong/DefaultPingPong.ts
@@ -116,9 +116,12 @@ export default class DefaultPingPong implements SignalingClientObserver, PingPon
         break;
       case SignalingClientEventType.WebSocketFailed:
       case SignalingClientEventType.WebSocketError:
+        this.logger.warn(`stopped pinging (${SignalingClientEventType[event.type]})`);
+        this.stopPingInterval();
+        break;
       case SignalingClientEventType.WebSocketClosing:
       case SignalingClientEventType.WebSocketClosed:
-        this.logger.warn(`stopped pinging (${SignalingClientEventType[event.type]})`);
+        this.logger.info(`stopped pinging (${SignalingClientEventType[event.type]})`);
         this.stopPingInterval();
         break;
       case SignalingClientEventType.ReceivedSignalFrame:

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.14.4';
+    return '1.14.5';
   }
 
   /**


### PR DESCRIPTION
**Issue #591:** 

**Description of changes:**
When WebSocket close, log stop pinging at info level instead of warn

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
Leave and end meeting and verify that the message "stopped pinging (WebSocketClosed) / (WebSocketClosing)" is logged as info.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
