### PR TITLE
Change the demo app to show content share video back to sharer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump elliptic from 6.5.2 to 6.5.3 in /demos/device
 - Log info when stop pinging due to Websocket closed
+- Change the demo app to show content share video back to sharer
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1389,12 +1389,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (!tileState.boundAttendeeId) {
       return;
     }
-    const selfAttendeeId = this.meetingSession.configuration.credentials.attendeeId;
-    const modality = new DefaultModality(tileState.boundAttendeeId);
-    if (modality.base() === selfAttendeeId && modality.hasModality(DefaultModality.MODALITY_CONTENT)) {
-      // don't bind one's own content
-      return;
-    }
     const tileIndex = tileState.localTile
       ? 16
       : this.tileOrganizer.acquireTileIndex(tileState.tileId);

--- a/integration/js/AppQuitContentShareTest.js
+++ b/integration/js/AppQuitContentShareTest.js
@@ -28,6 +28,7 @@ class AppQuitContentShareTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
     await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
 

--- a/integration/js/ContentShareJoinLaterTest.js
+++ b/integration/js/ContentShareJoinLaterTest.js
@@ -23,6 +23,7 @@ class ContentShareJoinLaterTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
 
     await monitor_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, monitor_attendee_id, session));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));

--- a/integration/js/ContentShareOnlyAllowTwoTest.js
+++ b/integration/js/ContentShareOnlyAllowTwoTest.js
@@ -39,6 +39,7 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
@@ -48,11 +49,14 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
-    await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
 
     //Turn on Content Share for third participant
     await test_window_3.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
@@ -61,8 +65,10 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
     await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
   }
 }

--- a/integration/js/ContentShareScreenCapture.js
+++ b/integration/js/ContentShareScreenCapture.js
@@ -35,6 +35,7 @@ class ContentShareScreenCapture extends SdkBaseTest {
     //Turn on Content Share
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
@@ -42,24 +43,29 @@ class ContentShareScreenCapture extends SdkBaseTest {
     //Pause
     await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(1000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", 1));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", 1));
 
     //Unpause
     await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(1000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
 
     //Switch Content Share between attendees and verify that only one can share
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
 
     //Turn off Content Share
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(5000);
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
     await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 2));

--- a/integration/js/ContentShareVideoTest.js
+++ b/integration/js/ContentShareVideoTest.js
@@ -33,6 +33,7 @@ class ContentShareVideoTest extends SdkBaseTest {
     //Turn on Content Share
     await test_window_1.runCommands(async () => await ClickContentShareVideoTestButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
     await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
@@ -40,8 +41,9 @@ class ContentShareVideoTest extends SdkBaseTest {
     //Turn off Content Share
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(5000);
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
   }
 }

--- a/integration/js/MeetingLeaveContentShareTest.js
+++ b/integration/js/MeetingLeaveContentShareTest.js
@@ -28,6 +28,7 @@ class MeetingLeaveContentShareTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
     await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
 


### PR DESCRIPTION
**Description of changes:**
Change the demo app to show content share video back to sharer
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually verify that the sharer sees content share video.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
