### PR TITLE
Change bootstrap version for meeting demo to 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump elliptic from 6.5.2 to 6.5.3 in /demos/device
 - Log info when stop pinging due to Websocket closed
 - Change the demo app to show content share video back to sharer
+- Change bootstrap version for meeting demo to 4.5.0
 
 ### Removed
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.725.0",
-    "bootstrap": "^4.3.1",
+    "aws-sdk": "^2.726.0",
+    "bootstrap": "4.5.0",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.7",
+  "version": "1.14.8",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.14.7';
+    return '1.14.8';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Bootstrap v4.5.1 broke our demo app layout (See https://github.com/twbs/bootstrap/pull/30940) so temporarily set it to the previous version 4.5.0

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the demo application and verify the layout is ok.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
