### PR TITLE
Change content share video check integration tests to use attendee name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log info when stop pinging due to Websocket closed
 - Change the demo app to show content share video back to sharer
 - Change bootstrap version for meeting demo to 4.5.0
+- Change content share video check to use attendee name instead of video element index
 
 ### Removed
 

--- a/integration/js/AppQuitContentShareTest.js
+++ b/integration/js/AppQuitContentShareTest.js
@@ -28,13 +28,13 @@ class AppQuitContentShareTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
 
     await test_window.close();
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 1));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id));
   }
 }
 

--- a/integration/js/ContentShareJoinLaterTest.js
+++ b/integration/js/ContentShareJoinLaterTest.js
@@ -23,17 +23,17 @@ class ContentShareJoinLaterTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
-    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
 
     await monitor_window.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, monitor_attendee_id, session));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
 
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id));
   }
 }
 

--- a/integration/js/ContentShareOnlyAllowTwoTest.js
+++ b/integration/js/ContentShareOnlyAllowTwoTest.js
@@ -38,37 +38,40 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     //Turn on Content Share for first participant
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
 
     //Turn on Content Share for second participant
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
 
     //Turn on Content Share for third participant
     await test_window_3.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_3));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_3));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_3));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
   }
 }

--- a/integration/js/ContentShareScreenCapture.js
+++ b/integration/js/ContentShareScreenCapture.js
@@ -35,39 +35,39 @@ class ContentShareScreenCapture extends SdkBaseTest {
     //Turn on Content Share
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
 
     //Pause
     await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(1000);
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", test_attendee_id_1));
 
     //Unpause
     await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(1000);
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
 
     //Switch Content Share between attendees and verify that only one can share
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
 
     //Turn off Content Share
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(5000);
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_2));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 2));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_2));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
   }
 }

--- a/integration/js/ContentShareVideoTest.js
+++ b/integration/js/ContentShareVideoTest.js
@@ -1,4 +1,4 @@
-const {ClickContentShareVideoTestButton, ClickContentShareButton} = require('./steps');
+const {ClickContentShareVideoTestButton, ClickContentShareButton, ClickContentSharePauseButton} = require('./steps');
 const {ContentShareVideoCheck} = require('./checks');
 const {RosterCheck} = require('./checks');
 const {TestUtils} = require('./node_modules/kite-common');
@@ -33,17 +33,29 @@ class ContentShareVideoTest extends SdkBaseTest {
     //Turn on Content Share
     await test_window_1.runCommands(async () => await ClickContentShareVideoTestButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+
+    //Pause
+    await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "ON"));
+    await TestUtils.waitAround(1000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "PAUSE", test_attendee_id_1));
+
+    //Unpause
+    await test_window_1.runCommands(async () => await ClickContentSharePauseButton.executeStep(this, session, "OFF"));
+    await TestUtils.waitAround(1000);
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
 
     //Turn off Content Share
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
     await TestUtils.waitAround(5000);
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_1));
     await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_1));
     await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
   }
 }

--- a/integration/js/MeetingLeaveContentShareTest.js
+++ b/integration/js/MeetingLeaveContentShareTest.js
@@ -28,14 +28,14 @@ class MeetingLeaveContentShareTest extends SdkBaseTest {
     await test_window.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
     await TestUtils.waitAround(5000);
     await test_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await test_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id));
 
     await test_window.runCommands(async () => await LeaveMeetingStep.executeStep(this, session));
     await TestUtils.waitAround(5000);
     await monitor_window.runCommands(async () => await RosterCheck.executeStep(this, session, 1));
-    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", 1));
+    await monitor_window.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id));
   }
 }
 

--- a/integration/js/checks/ContentShareVideoCheck.js
+++ b/integration/js/checks/ContentShareVideoCheck.js
@@ -2,7 +2,7 @@ const {KiteTestError, Status} = require('kite-common');
 const AppTestStep = require('../utils/AppTestStep');
 
 class ContentShareVideoCheck extends AppTestStep {
-  constructor(kiteBaseTest, sessionInfo, testType, videoIndex) {
+  constructor(kiteBaseTest, sessionInfo, testType, attendeeName) {
     super(kiteBaseTest, sessionInfo);
     switch(testType) {
       case 'ON':
@@ -14,21 +14,21 @@ class ContentShareVideoCheck extends AppTestStep {
       default:
         this.expectedState = 'blank';
     }
-    this.videoIndex = videoIndex;
+    this.attendeeName = attendeeName;
   }
 
-  static async executeStep(KiteBaseTest, sessionInfo, testType, videoIndex) {
-    const step = new ContentShareVideoCheck(KiteBaseTest, sessionInfo, testType, videoIndex);
+  static async executeStep(KiteBaseTest, sessionInfo, testType, attendeeName) {
+    const step = new ContentShareVideoCheck(KiteBaseTest, sessionInfo, testType, attendeeName);
     await step.execute(KiteBaseTest);
   }
 
   stepDescription() {
-    return 'Check the content share video in video index ' + this.videoIndex + " is " + this.expectedState;
+    return 'Check the content share video with attendee name ' + this.attendeeName + " is " + this.expectedState;
   }
 
   async run() {
     try {
-      const result = await this.page.videoCheck(this, this.videoIndex, this.expectedState);
+      const result = await this.page.videoCheckByAttendeeName(this, this.attendeeName, this.expectedState);
       if (result !== this.expectedState) {
         this.testReporter.textAttachment(this.report, 'Content share video', result, 'plain');
         throw new KiteTestError(Status.FAILED, 'The content share video is ' + result);

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -309,34 +309,32 @@ class AppPage {
     return checked.result;
   }
 
-  async videoCheckLong(stepInfo, index, expectedState) {
-    let checked; // Result of the verification
-    let i = 0; // iteration indicator
-    let timeout = 10;
-    checked = await TestUtils.verifyVideoDisplayByIndex(stepInfo.driver, index);
-    while ((checked.result !== expectedState) && i < timeout) {
-      checked = await TestUtils.verifyVideoDisplayByIndex(stepInfo.driver, index);
-      i++;
-      await TestUtils.waitAround(1000);
-    }
-    // after the video is in desired state, monitor it for 30 secs to check if it stays in that state.
-    i = 0;
-    timeout = 60;
-    let success = 0;
-    let total = 0;
-    while (i < timeout) {
-      checked = await TestUtils.verifyVideoDisplayByIndex(stepInfo.driver, index);
-      i++;
-      if (checked.result === expectedState) {
-        success++;
+  async videoCheckByAttendeeName(stepInfo, attendeeName, expectedState = 'video') {
+    let checked;
+    let videos = await this.driver.findElements(By.css('video[id^="video-"]'));
+    for (let i = 0; i < videos.length; i++) {
+      const videoElementId = await videos[i].getAttribute('id');
+      const seperatorIndex = videoElementId.lastIndexOf("-");
+      if (seperatorIndex >= -1) {
+        const tileIndex = parseInt(videoElementId.slice(seperatorIndex+1))
+        if (tileIndex != NaN && tileIndex >= 0) {
+          const nameplate = await this.driver.findElement(By.id(`nameplate-${tileIndex}`));
+          const nameplateText = await nameplate.getText();
+          if (nameplate && nameplateText === attendeeName) {
+            let numRetries = 10;
+            let retry = 0;
+            let checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
+            while ((checked.result !== expectedState) && retry < numRetries) {
+              checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
+              retry++;
+              await TestUtils.waitAround(1000);
+            }
+            return checked.result;
+          }
+        }
       }
-      total++;
-      await TestUtils.waitAround(1000);
     }
-    if (success / total > 0.75) {
-      return true
-    }
-    return false;
+    return 'blank';
   }
 
   async audioCheck(stepInfo, expectedState) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.14.8';
+    return '1.14.9';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
This is to update the video check for content share integration tests to use attendee name instead of video element index so that we do not need to rely on knowing how demo app assign video elements and reduce the breaking whenever we add or modify video elements in the demo app.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
Manually run all content share video tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
