### PR TITLE
Fix isSupported API in return true for Firefox on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure all simulcast stream resolution are 16-aligned to avoid pixel3(XL) encoder issue
 - Fix race condition in Chromium browsers when consecutive audio bind operations take place 
 - Fix invalid constraints and disable Unified Plan in safari 12.0
+- Fix isSupported API in DefaultBrowserBehavior return true for Firefox on Android
 
 ## [1.14.0] - 2020-07-28
 

--- a/docs/classes/defaultbrowserbehavior.html
+++ b/docs/classes/defaultbrowserbehavior.html
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L188">src/browserbehavior/DefaultBrowserBehavior.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L200">src/browserbehavior/DefaultBrowserBehavior.ts:200</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -289,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L180">src/browserbehavior/DefaultBrowserBehavior.ts:180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L192">src/browserbehavior/DefaultBrowserBehavior.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -306,7 +306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L184">src/browserbehavior/DefaultBrowserBehavior.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L196">src/browserbehavior/DefaultBrowserBehavior.ts:196</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L176">src/browserbehavior/DefaultBrowserBehavior.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L188">src/browserbehavior/DefaultBrowserBehavior.ts:188</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -340,7 +340,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L168">src/browserbehavior/DefaultBrowserBehavior.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L180">src/browserbehavior/DefaultBrowserBehavior.ts:180</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L192">src/browserbehavior/DefaultBrowserBehavior.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L204">src/browserbehavior/DefaultBrowserBehavior.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L172">src/browserbehavior/DefaultBrowserBehavior.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L184">src/browserbehavior/DefaultBrowserBehavior.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L196">src/browserbehavior/DefaultBrowserBehavior.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L208">src/browserbehavior/DefaultBrowserBehavior.ts:208</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -704,7 +704,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#supportstring">supportString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L139">src/browserbehavior/DefaultBrowserBehavior.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L148">src/browserbehavior/DefaultBrowserBehavior.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -722,7 +722,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#supportedvideocodecs">supportedVideoCodecs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L147">src/browserbehavior/DefaultBrowserBehavior.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L159">src/browserbehavior/DefaultBrowserBehavior.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -133,10 +133,22 @@ export default class DefaultBrowserBehavior implements BrowserBehavior {
   }
 
   isSupported(): boolean {
-    return this.majorVersion() >= this.browserSupport[this.browser.name];
+    if (
+      !this.browserSupport[this.browser.name] ||
+      this.majorVersion() < this.browserSupport[this.browser.name]
+    ) {
+      return false;
+    }
+    if (this.browser.name === 'firefox' && this.isAndroid()) {
+      return false;
+    }
+    return true;
   }
 
   supportString(): string {
+    if (this.isAndroid()) {
+      return `${this.browserName['chrome']} ${this.browserSupport['chrome']}+`;
+    }
     const s: string[] = [];
     for (const k in this.browserSupport) {
       s.push(`${this.browserName[k]} ${this.browserSupport[k]}+`);

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -19,6 +19,8 @@ describe('DefaultBrowserBehavior', () => {
   const CHROMIUM_EDGE_USERAGENT =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3729.48 Safari/537.36 Edg/79.1.96.24';
   const OPERA_USERAGENT = 'Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.18';
+  const FIREFOX_ANDROID_USERAGENT =
+    'Mozilla/5.0 (Android 10; Mobile; rv:68.0) Gecko/68.0 Firefox/68.0';
 
   const setUserAgent = (userAgent: string): void => {
     // @ts-ignore
@@ -48,6 +50,14 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().requiresUnifiedPlanMunging()).to.eq(false);
       expect(new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()).to.be.false;
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.eq(false);
+    });
+
+    it('can detect Firefox on Android', () => {
+      setUserAgent(FIREFOX_ANDROID_USERAGENT);
+      expect(new DefaultBrowserBehavior().name()).to.eq('firefox');
+      expect(new DefaultBrowserBehavior().isSupported()).to.eq(false);
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(68);
+      expect(new DefaultBrowserBehavior().supportString()).to.eq('Google Chrome 78+');
     });
 
     it('can detect Chrome', () => {


### PR DESCRIPTION
**Description of changes:**
Fix isSupported API in return true for Firefox on Android when chime JS SDK currently does not support that platform.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run a serverless demo in Firefox Android and verify that this warning message is logged: 
>this browser is not currently supported. Stability may suffer. Supported browsers are: Google Chrome 78+.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
