### PR TITLE
Add auth-token based npm login and logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .idea
 .nyc_output
+.npmrc
 build
 coverage
 demos/browser/logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added auth-token based npm login and logout scripts for package publishing
 
 ### Changed
 - Update the dependency version for the singlejs demo
@@ -35,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure all simulcast stream resolution are 16-aligned to avoid pixel3(XL) encoder issue
-- Fix race condition in Chromium browsers when consecutive audio bind operations take place 
+- Fix race condition in Chromium browsers when consecutive audio bind operations take place
 - Fix invalid constraints and disable Unified Plan in safari 12.0
 - Fix isSupported API in DefaultBrowserBehavior return true for Firefox on Android
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -11,6 +11,8 @@
     "clean": "rm -rf .nyc_output build node_modules",
     "copy": "node script/copy-protocol.js",
     "check": "node script/check-code-style.js",
+    "login": "node script/login.js",
+    "logout": "node script/logout.js",
     "prepublishOnly": "script/publish",
     "postpublish": "script/postpublish",
     "lint": "eslint . --ext .ts,.tsx,.js --fix",

--- a/script/login.js
+++ b/script/login.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const readline = require('readline');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { exec } = require('child_process');
+
+process.cwd(path.join(__dirname, '..'));
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.question('Enter the NPM auth token: ', function(token) {
+  fs.writeFileSync('.npmrc', `//registry.npmjs.org/:_authToken=${token}`);
+  rl.close();
+});
+
+rl.on('close', function() {
+  exec('npm whoami', (err, stdout, _) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    } else {
+      console.log(`Logged in as: ${stdout.trim()}`);
+      process.exit(0);
+    }
+  });
+});

--- a/script/logout.js
+++ b/script/logout.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { exec } = require('child_process');
+
+process.cwd(path.join(__dirname, '..'));
+
+exec('npm logout', (err, _, _) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  } else {
+    console.log('Logged out (auth token deleted)');
+    fs.unlinkSync('.npmrc');
+    process.exit(0);
+  }
+});

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.15.3';
+    return '1.15.4';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**

This PR adds convenience commands `npm run login` and `npm run logout` which use auth tokens, to allow for package publishing via auth token. Based on: https://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules

**Testing**

1. Have you successfully run `npm run build:release` locally?

Yes.

2. How did you test these changes?

Tested logging in and out with read-only npm auth token and confirmed login with `npm whoami`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
