### PR TITLE
Make Unified Plan default for capable Chromium-based browsers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Change WebRTC semantics to Unified Plan by default for Chromium-based browsers
+
 ## [1.16.0] - 2020-08-20
 
 ### Added
@@ -20,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix and modify simulcast uplink policy to fix freezing and reduce switches
 - Exclude self content share video stream index
+
 ## [1.15.0] - 2020-08-10
 
 ### Added

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -53,7 +53,6 @@
                 <option value="" selected>None</option>
                 <option value="simulcast">Enable Simulcast For Chrome</option>
                 <option value="webaudio">Use WebAudio</option>
-                <option value="unifiedplan">Use Unified Plan for Chrome</option>
               </select>
             </div>
           </div>

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -134,7 +134,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
 
   // feature flags
   enableWebAudio = false;
-  enableUnifiedPlanForChromiumBasedBrowsers = false;
+  enableUnifiedPlanForChromiumBasedBrowsers = true;
   enableSimulcast = false;
 
   constructor() {
@@ -299,18 +299,13 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
       const collections = optionalFeatures.selectedOptions;
       this.enableSimulcast = false;
       this.enableWebAudio = false;
-      this.enableUnifiedPlanForChromiumBasedBrowsers = false;
       for (let i = 0; i < collections.length; i++) {
         // hard code magic
         if (collections[i].label === 'simulcast') {
           this.enableSimulcast = true;
-          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
         }
         if (collections[i].label === 'webaudio') {
           this.enableWebAudio = true;
-        }
-        if (collections[i].label === 'unifiedplan') {
-          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
         }
       }
     });

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -53,7 +53,6 @@
             <option value="" selected>None</option>
             <option value="simulcast">Enable Simulcast For Chrome</option>
             <option value="webaudio">Use WebAudio</option>
-            <option value="unifiedplan">Use Unified Plan For Chrome</option>
           </select>
         </div>
       </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -148,7 +148,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
 
   // feature flags
   enableWebAudio = false;
-  enableUnifiedPlanForChromiumBasedBrowsers = false;
+  enableUnifiedPlanForChromiumBasedBrowsers = true;
   enableSimulcast = false;
 
   markdown = require('markdown-it')({linkify: true});
@@ -317,22 +317,17 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
       const collections = optionalFeatures.selectedOptions;
       this.enableSimulcast = false;
       this.enableWebAudio = false;
-      this.enableUnifiedPlanForChromiumBasedBrowsers = false;
+      this.enableUnifiedPlanForChromiumBasedBrowsers = true;
       this.log("Feature lists:");
       for (let i = 0; i < collections.length; i++) {
         // hard code magic
         if (collections[i].value === 'simulcast') {
           this.enableSimulcast = true;
-          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
           this.log('attempt to enable simulcast');
         }
         if (collections[i].value === 'webaudio') {
           this.enableWebAudio = true;
           this.log('attempt to enable webaudio');
-        }
-        if (collections[i].value === 'unifiedplan') {
-          this.enableUnifiedPlanForChromiumBasedBrowsers = true;
-          this.log('attempt to enable unified plan');
         }
       }
     });

--- a/docs/classes/finishgatheringicecandidatestask.html
+++ b/docs/classes/finishgatheringicecandidatestask.html
@@ -359,7 +359,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L62">src/task/FinishGatheringICECandidatesTask.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L61">src/task/FinishGatheringICECandidatesTask.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/meetingsessionconfiguration.html
+++ b/docs/classes/meetingsessionconfiguration.html
@@ -267,7 +267,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="enableunifiedplanforchromiumbasedbrowsers" class="tsd-anchor"></a>
 					<h3>enable<wbr>Unified<wbr>Plan<wbr>For<wbr>Chromium<wbr>Based<wbr>Browsers</h3>
-					<div class="tsd-signature tsd-kind-icon">enable<wbr>Unified<wbr>Plan<wbr>For<wbr>Chromium<wbr>Based<wbr>Browsers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
+					<div class="tsd-signature tsd-kind-icon">enable<wbr>Unified<wbr>Plan<wbr>For<wbr>Chromium<wbr>Based<wbr>Browsers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L74">src/meetingsession/MeetingSessionConfiguration.ts:74</a></li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/meetingsession/MeetingSessionConfiguration.ts
+++ b/src/meetingsession/MeetingSessionConfiguration.ts
@@ -71,7 +71,7 @@ export default class MeetingSessionConfiguration {
   /**
    * Feature flag to enable Chromium-based browsers
    */
-  enableUnifiedPlanForChromiumBasedBrowsers: boolean = false;
+  enableUnifiedPlanForChromiumBasedBrowsers: boolean = true;
 
   /**
    * Feature flag to enable Simulcast

--- a/src/task/FinishGatheringICECandidatesTask.ts
+++ b/src/task/FinishGatheringICECandidatesTask.ts
@@ -39,7 +39,6 @@ export default class FinishGatheringICECandidatesTask extends BaseTask {
 
   cancel(): void {
     let error = new Error(`canceling ${this.name()}`);
-
     // TODO: Remove when the Chrome VPN reconnect bug is fixed.
     // In Chrome, SDK may fail to establish TURN session after VPN reconnect.
     // https://bugs.chromium.org/p/webrtc/issues/detail?id=9097

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.16.1';
+    return '1.16.2';
   }
 
   /**

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -585,6 +585,7 @@ describe('DefaultAudioVideoController', () => {
   describe('update', () => {
     it('can be started and then start and stop a local video tile for plan-b', async () => {
       setUserAgent('Chrome/77.0.3865.75');
+      configuration.enableUnifiedPlanForChromiumBasedBrowsers = false;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -890,6 +891,7 @@ describe('DefaultAudioVideoController', () => {
 
     it('replaces audio track for Plan-B', async () => {
       setUserAgent('Chrome/77.0.3865.75');
+      configuration.enableUnifiedPlanForChromiumBasedBrowsers = false;
       class TestDeviceController extends NoOpDeviceController {
         async acquireAudioInputStream(): Promise<MediaStream> {
           const mediaStream = new MediaStream();
@@ -1016,7 +1018,7 @@ describe('DefaultAudioVideoController', () => {
 
     it('can reconnect in Plan B', async () => {
       setUserAgent('Chrome/77.0.3865.75');
-
+      configuration.enableUnifiedPlanForChromiumBasedBrowsers = false;
       let startConnectingCalled = 0;
       let startCalled = 0;
       let stopCalled = 0;
@@ -1057,9 +1059,10 @@ describe('DefaultAudioVideoController', () => {
     // FinishGatheringICECandidatesTask does not throw the ICEGatheringTimeoutWorkaround error if
     // the session connection timeout is less than 5000ms.
     it('reconnects when the start operation fails with a non-Terminal meeting status such as ICEGatheringTimeoutWorkaround', function(done) {
-      this.timeout(10000);
+      this.timeout(20000);
 
-      setUserAgent('Chrome/77.0.3865.75');
+      domMockBehavior.browserName = 'chrome';
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
 
       configuration.connectionTimeoutMs = 6000;
       const logger = new NoOpDebugLogger();
@@ -1083,9 +1086,10 @@ describe('DefaultAudioVideoController', () => {
           done();
         }
       }
+
       audioVideoController.addObserver(new TestObserver());
       audioVideoController.start();
-      delay().then(() => {
+      delay(200).then(() => {
         // Finish JoinAndReceiveIndexTask and then wait for the ICE event in FinishGatheringICECandidatesTask.
         webSocketAdapter.send(makeIndexFrame());
       });
@@ -1099,8 +1103,9 @@ describe('DefaultAudioVideoController', () => {
         // At this point, the start operation failed so attempted to connect the session again.
         // Finish the start operation by sending required frames and events.
         webSocketAdapter.send(makeIndexFrame());
+        await delay(100);
         await sendICEEventAndSubscribeAckFrame();
-        await delay();
+        await delay(100);
         await sendAudioStreamIdInfoFrame();
         await delay(300);
         // Finally, stop this test.


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Making Unified Plan default for capable Chromium-based browsers 

**Testing**

1. Have you successfully run `npm run build:release` locally?

yes

2. How did you test these changes?

Tested with
- [x] Chrome 84 on MacOS, Win10, Ubuntu 18, 
- [x] Chromium on Ubuntu 18
- [x] Android Chrome
- [x] interop with Firefox, Safari, iOS Safari


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
