### PR TITLE
Update browser demo app with new regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added auth-token based npm login and logout scripts for npm package publishing
+- Update demo app with new regions CPT, MXP, BOM and ICN
 
 ### Changed
 - Update the dependency version for the singlejs demo

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -29,6 +29,10 @@
               <option value="us-east-1" selected>United States (N. Virginia)</option>
               <option value="ap-northeast-1">Japan (Tokyo)</option>
               <option value="ap-southeast-1">Singapore</option>
+              <option value="af-south-1">South Africa (Cape Town)</option>
+              <option value="eu-south-1">Italy (Milan)</option>
+              <option value="ap-south-1">India (Mumbai)</option>
+              <option value="ap-northeast-2">South Korea (Seoul)</option>
               <option value="ap-southeast-2">Australia (Sydney)</option>
               <option value="ca-central-1">Canada</option>
               <option value="eu-central-1">Germany (Frankfurt)</option>

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -29,6 +29,10 @@
           <option value="us-east-1" selected>United States (N. Virginia)</option>
           <option value="ap-northeast-1">Japan (Tokyo)</option>
           <option value="ap-southeast-1">Singapore</option>
+          <option value="af-south-1">South Africa (Cape Town)</option>
+          <option value="eu-south-1">Italy (Milan)</option>
+          <option value="ap-south-1">India (Mumbai)</option>
+          <option value="ap-northeast-2">South Korea (Seoul)</option>
           <option value="ap-southeast-2">Australia (Sydney)</option>
           <option value="ca-central-1">Canada</option>
           <option value="eu-central-1">Germany (Frankfurt)</option>

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.726.0",
+    "aws-sdk": "^2.738.0",
     "bootstrap": "4.5.0",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.16.0';
+    return '1.16.1';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
	•	Update the browser demo app with new regions Cape Town (CPT), Milan (MXP), Mumbai (BOM) and Seoul (ICN)

**Testing**
1. Have you successfully run `npm run build:release` locally?
    Yes
2. How did you test these changes?
    Verified that the new regions are available in demo app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
