### PR TITLE
Add npm login and logout as part of publish script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Change WebRTC semantics to Unified Plan by default for Chromium-based browsers
+- Add npm login and logout as part of publish script
 
 ## [1.16.0] - 2020-08-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/postpublish
+++ b/script/postpublish
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 require 'json'
 
+def verbose command
+  puts("--> #{command}") || system(command) || fail("Failed: #{command}")
+end
+
+verbose("npm run logout")
+
 Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..')))
 
 puts
@@ -17,10 +23,6 @@ puts "Type 'yes' to continue"
 x = STDIN.gets
 exit(1) unless x.strip == 'yes'
 puts
-
-def verbose command
-  puts("--> #{command}") || system(command) || fail("Failed: #{command}")
-end
 
 verbose('git fetch origin')
 verbose('git reset --hard origin/master')

--- a/script/publish
+++ b/script/publish
@@ -96,3 +96,5 @@ puts
 
 verbose("git push origin")
 verbose("git push origin -f #{tag}")
+
+verbose("npm run login")

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.16.2';
+    return '1.16.3';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 
The `git clean` command [as part of the post publish script](https://github.com/aws/amazon-chime-sdk-js/blob/master/script/postpublish#L27) deletes all the untracked files. So running `npm run logout` after the `npm publish` threw an error saying that the `.npmrc` file that stored the auth token is already deleted.

**Description of changes:**
We moved the `npm run login` at the end of the pre-publish command and `npm run logout` at the beginning of the post-publish script, so that the npm login / logout can be incorporated as part of the `npm publish` script

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Tested locally - npm login and logout after publish was successful

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
