### PR TITLE
Remove set in travis awscli installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed removeLocalVideoTile so that the video tile is removed correctly for the user and attendees
 - Handle timing issue of receiving index during resubscribe
 - Mitigate Brew Sam installation issue
+- Remove set command in travis awscli installation script
 
 ## [1.16.0] - 2020-08-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/travis-awscli-installation
+++ b/script/travis-awscli-installation
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x -e
 
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)" LNK POP
 test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.16.8';
+    return '1.16.9';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Remove `set -x -e` command in travis awscli installation script as it generates a lot of log from travis and make it hard to read the log.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? I only do npm run build:release


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
