### PR TITLE
Add --no-fail-on-empty-changeset flag for serverless deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle timing issue of receiving index during resubscribe
 - Mitigate Brew Sam installation issue
 - Remove set command in travis awscli installation script
+- Add `--no-fail-on-empty-changeset` flag in deploy script to not fail for empty changeset
 
 ## [1.16.0] - 2020-08-20
 

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -158,7 +158,7 @@ spawnOrFail('sam', ['package', '--s3-bucket', `${bucket}`,
 console.log('Deploying serverless application');
 spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--stack-name', `${stack}`,
                     '--parameter-overrides', `UseEventBridge=${useEventBridge}`,
-                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`]);
+                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`, '--no-fail-on-empty-changeset']);
 console.log("Amazon Chime SDK Meeting Demo URL: ");
 const output=spawnOrFail('aws', ['cloudformation', 'describe-stacks', '--stack-name', `${stack}`,
                     '--query', 'Stacks[0].Outputs[0].OutputValue', '--output', 'text', '--region', `${region}`]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.16.9",
+  "version": "1.16.10",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.16.9';
+    return '1.16.10';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Updated the serverless application deploy script to add `--no-fail-on-empty-changeset` parameter to specify if the CLI should return a non-zero exit code if there are no changes to be made to the stack.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manually deployed the same app twice. 2nd time, it did not error out. Below is the output for the 2nd deploy command.

```
Waiting for changeset to be created..
No changes to deploy. Stack meeting-rediness-checker-master is up to date

Amazon Chime SDK Meeting Demo URL: 
https://abcdefij.execute-api.us-east-1.amazonaws.com/Prod/
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
