### PR TITLE
Change default encode resolution to 960x540

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- Change default encode resolution back to 960x540
+
 ## [1.17.0] - 2020-09-04
 ### Added
 - Add npm login and logout as part of publish script

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -177,8 +177,8 @@
         <div class="col-12 col-sm-8">
           <select id="video-input-quality" class="custom-select" style="width:100%">
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
-            <option value="540p">540p (qHD) @ 15 fps (1.4 Mbps max)</option>
-            <option value="720p" selected>720p (HD) @ 15 fps (1.4 Mbps max)</option>
+            <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
+            <option value="720p">720p (HD) @ 15 fps (1.4 Mbps max)</option>
           </select>
         </div>
       </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -329,6 +329,8 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         if (collections[i].value === 'simulcast') {
           this.enableSimulcast = true;
           this.log('attempt to enable simulcast');
+          const videoInputQuality = document.getElementById('video-input-quality') as HTMLSelectElement;
+          videoInputQuality.value = '720p';
         }
         if (collections[i].value === 'webaudio') {
           this.enableWebAudio = true;

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -428,7 +428,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-static">
 					<a name="defaultvideoheight" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> <span class="tsd-flag ts-flagPrivate">Private</span> default<wbr>Video<wbr>Height</h3>
-					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 720</span></div>
+					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 540</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L22">src/devicecontroller/DefaultDeviceController.ts:22</a></li>
@@ -448,7 +448,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private tsd-is-static">
 					<a name="defaultvideowidth" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> <span class="tsd-flag ts-flagPrivate">Private</span> default<wbr>Video<wbr>Width</h3>
-					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1280</span></div>
+					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 960</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L21">src/devicecontroller/DefaultDeviceController.ts:21</a></li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -18,8 +18,8 @@ import DeviceSelection from './DeviceSelection';
 export default class DefaultDeviceController implements DeviceControllerBasedMediaStreamBroker {
   private static permissionGrantedOriginDetectionThresholdMs = 1000;
   private static permissionDeniedOriginDetectionThresholdMs = 500;
-  private static defaultVideoWidth = 1280;
-  private static defaultVideoHeight = 720;
+  private static defaultVideoWidth = 960;
+  private static defaultVideoHeight = 540;
   private static defaultVideoFrameRate = 15;
   private static defaultVideoMaxBandwidthKbps = 1400;
   private static defaultSampleRate = 48000;

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.0';
+    return '1.17.1';
   }
 
   /**


### PR DESCRIPTION

**Description of changes:**
Change the default encode resolution back from 1280x720 to 960x540

**Testing**
Verified correct encode attributes both with and without simulcast.
Verified correct encode attributes without simulcast using all the demo drop down options

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Ran above test both against a local server and against serverless demo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
