### PR TITLE
Make the demo not calling chooseVideoInputQuality under default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Make demo not calling chooseVideoInputQuality by default
 - Change default encode resolution back to 960x540
 
 ## [1.17.0] - 2020-09-04

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -176,6 +176,7 @@
       <div class="row mt-3">
         <div class="col-12 col-sm-8">
           <select id="video-input-quality" class="custom-select" style="width:100%">
+            <option value="default">SDK Default (540p @ 15 fps 1.Mbps)</option>
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
             <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
             <option value="720p">720p (HD) @ 15 fps (1.4 Mbps max)</option>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -343,6 +343,8 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     videoInputQuality.addEventListener('change', async (_ev: Event) => {
       this.log('Video input quality is changed');
       switch (videoInputQuality.value) {
+        case 'default':
+          break;
         case '360p':
           this.audioVideo.chooseVideoInputQuality(640, 360, 15, 600);
           break;

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.740.0",
+    "aws-sdk": "^2.747.0",
     "bootstrap": "4.5.0",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.1';
+    return '1.17.2';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** 

**Description of changes:**

Add an additional option for  video quality in demo to not call chooseVideoInputQuality.

**Testing**

1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
yes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
