### PR TITLE
Add tags when creating a meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use pip to install aws sam cli for deployment script
+- Added meetings tags to serverless demo
 
 ### Removed
 

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -31,7 +31,7 @@ function ensureBucket() {
     console.log(`Creating S3 bucket ${bucket}`);
     const s3 = spawnSync('aws', ['s3', 'mb', `s3://${bucket}`, '--region', `${region}`]);
     if (s3.status !== 0) {
-      console.log(`Failed to create bucket: ${JSON.stringify(s3)}`);
+      console.log(`Failed to create bucket: ${s3.status}`);
       console.log((s3.stderr || s3.stdout).toString());
       process.exit(s3.status)
     }

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -58,6 +58,11 @@ exports.join = async(event, context) => {
       // Any meeting ID you wish to associate with the meeting.
       // For simplicity here, we use the meeting title.
       ExternalMeetingId: query.title.substring(0, 64),
+
+      // Tags associated with the meeting. They can be used in cost allocation console
+      Tags: [
+        { Key: 'Department', Value: 'RND'}
+      ]
     };
     console.info('Creating new meeting: ' + JSON.stringify(request));
     meeting = await chime.createMeeting(request).promise();

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -30,6 +30,8 @@ Resources:
           - Effect: Allow
             Action:
               - 'chime:CreateMeeting'
+              - 'chime:TagMeeting'
+              - 'chime:TagResource'
               - 'chime:DeleteMeeting'
               - 'chime:GetMeeting'
               - 'chime:ListMeetings'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.3';
+    return '1.17.4';
   }
 
   /**


### PR DESCRIPTION
 Add tags when creating a meeting to show cost explorer
 integration.

**Issue #:** 
N/A

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Ran a test serverless meeting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
