### PR TITLE
Use pip to install aws sam cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+- Use pip to install aws sam cli for deployment script
+
+### Removed
+
+### Fixed
+
 ## [1.17.2] - 2020-09-08
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/travis-awscli-installation
+++ b/script/travis-awscli-installation
@@ -5,8 +5,7 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
 echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 
-pip install --user awscli
-brew tap aws/tap
-brew install aws-sam-cli || true
-brew install aws-sam-cli || true
+brew install python
+pip3 install --user awscli
+pip3 install aws-sam-cli
 sam --version

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.2';
+    return '1.17.3';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Switch to using pip to install aws sam cli to workaround recent bug with sam installation using brew that cause Travis job to fail (See https://github.com/CircleCI-Public/aws-sam-serverless-orb/issues/20).

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the script and make sure we get the latest sam version 1.12.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
