### PR TITLE
Fix unbinding video tile bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fixed bug related to unbinding a video element
 
 ## [1.17.2] - 2020-09-08
 ### Added

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.740.0",
+    "aws-sdk": "^2.750.0",
     "bootstrap": "4.5.0",
     "compression": "^1.7.4",
     "jquery": "^3.4.1",

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -273,7 +273,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L238">src/videotile/DefaultVideoTile.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L245">src/videotile/DefaultVideoTile.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ImageData</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L220">src/videotile/DefaultVideoTile.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L227">src/videotile/DefaultVideoTile.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L206">src/videotile/DefaultVideoTile.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L213">src/videotile/DefaultVideoTile.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L251">src/videotile/DefaultVideoTile.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L258">src/videotile/DefaultVideoTile.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L229">src/videotile/DefaultVideoTile.ts:229</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L236">src/videotile/DefaultVideoTile.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L213">src/videotile/DefaultVideoTile.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L220">src/videotile/DefaultVideoTile.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L258">src/videotile/DefaultVideoTile.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L265">src/videotile/DefaultVideoTile.ts:265</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -492,7 +492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L268">src/videotile/DefaultVideoTile.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L275">src/videotile/DefaultVideoTile.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -509,7 +509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L283">src/videotile/DefaultVideoTile.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L290">src/videotile/DefaultVideoTile.ts:290</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L298">src/videotile/DefaultVideoTile.ts:298</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L305">src/videotile/DefaultVideoTile.ts:305</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.5';
+    return '1.17.6';
   }
 
   /**

--- a/src/videotile/DefaultVideoTile.ts
+++ b/src/videotile/DefaultVideoTile.ts
@@ -181,7 +181,14 @@ export default class DefaultVideoTile implements DevicePixelRatioObserver, Video
 
   bindVideoElement(videoElement: HTMLVideoElement | null): void {
     let tileUpdated = false;
+    // If videoElement is null, we are doing an unbinding
     if (this.tileState.boundVideoElement !== videoElement) {
+      if (videoElement === null) {
+        DefaultVideoTile.disconnectVideoStreamFromVideoElement(
+          this.tileState.boundVideoElement,
+          false
+        );
+      }
       this.tileState.boundVideoElement = videoElement;
       tileUpdated = true;
     }


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/627
**Description of changes:**
Fix bug related to unbinding a video tile from a video element

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? Tested locally on a local instance of the meeting demo. 
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
