### PR TITLE
Fix tone does not stop when calling MeetingReadinessChecker.checkAudioOutput multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed bug related to unbinding a video element
+- Fix tone does not stop when calling MeetingReadinessChecker.checkAudioOutput multiple times
 
 ## [1.17.2] - 2020-09-08
 ### Added

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L184">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L190">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioconnectivity">checkAudioConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L250">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:250</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L256">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:256</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -402,7 +402,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcameraresolution">checkCameraResolution</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L152">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:152</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L158">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:158</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -432,7 +432,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcontentshareconnectivity">checkContentShareConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L203">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L209">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:209</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L383">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:383</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L389">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:389</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworktcpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkTCPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -468,7 +468,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L341">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:341</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L347">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:347</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworkudpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkUDPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -486,7 +486,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L296">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L302">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:302</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -510,7 +510,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoinput">checkVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L132">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L138">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -533,7 +533,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L459">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:459</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L465">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:465</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +597,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L427">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L433">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:433</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -614,7 +614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L443">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:443</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L449">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:449</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -631,7 +631,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L117">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:117</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L120">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
+++ b/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
@@ -94,6 +94,9 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
     const rampSec = 0.1;
     const maxGainValue = 0.1;
 
+    if (this.oscillatorNode) {
+      this.stopTone();
+    }
     this.audioContext = DefaultDeviceController.getAudioContext();
     this.gainNode = this.audioContext.createGain();
     this.gainNode.gain.value = 0;
@@ -127,6 +130,9 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
     this.oscillatorNode.stop();
     this.oscillatorNode.disconnect(this.gainNode);
     this.gainNode.disconnect(this.destinationStream);
+    this.oscillatorNode = null;
+    this.gainNode = null;
+    this.destinationStream = null;
   }
 
   async checkVideoInput(videoInputDeviceInfo: MediaDeviceInfo): Promise<CheckVideoInputFeedback> {


### PR DESCRIPTION

**Issue:** 
Calling MeetingReadinessChecker multiple times will cause the test tone to not stop.

**Description of changes:**
Before playing the test tone, make sure to stop any tone played previously.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the meeting readiness checker demo and call the checkAudioOutput API multiple times and verify that the test tone stops.
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
