### PR TITLE
Add meeting readiness checker integration tests to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,13 @@ jobs:
         - source script/travis-awscli-installation
         - integration/js/script/install-kite
       script: npm run test:integration-data-message
+    - stage: integ_meeting_readiness_checker
+      if: (type = pull_request) OR (type = push AND branch != master)
+      before_install: script/needs-integration-test || travis_terminate 0
+      install:
+        - source script/travis-awscli-installation
+        - integration/js/script/install-kite
+      script: npm run test:integration-meeting-readiness-checker
     #Deploy
     - stage: deploy
       script: skip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add meeting readiness checker integ tests to travis config
 
 ### Changed
 - Use pip to install aws sam cli for deployment script

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.8';
+    return '1.17.9';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Add meeting readiness checker integration tests to travis config

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Ran the integration tests manually and they succeeded.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
