### PR TITLE
Change error to warn for logging Cloudwatch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update PR template to add question about protocol and API change
 - Add demos/browser package-lock to git, update webpack and jquery versions
 - Update integration-watchlist to include demos/browser with no exception for package.json
+- Change error to warn for logging Cloudwatch errors
 
 ### Removed
 

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -135,7 +135,12 @@ exports.logs = async (event, context) => {
   try {
     await cloudWatchClient.putLogEvents(putLogEventsInput).promise();
   } catch (error) {
-    console.error(`Failed to put CloudWatch log events with error ${error.message} and params ${JSON.stringify(putLogEventsInput)}`);
+    const errorMessage = `Failed to put CloudWatch log events with error ${error} and params ${JSON.stringify(putLogEventsInput)}`;
+    if (error.code === 'DataAlreadyAcceptedException') {
+      console.warn(errorMessage);
+    } else {
+      console.error(errorMessage);
+    }
   }
   return response(200, 'application/json', JSON.stringify({}));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.7';
+    return '1.17.8';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
We were logging errors generated from the cloudwatch logs if any as error. We just need it to warn us instead.

**Description of changes:**
Changing error logging to warn logging on the handler

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Yes

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
