### PR TITLE
Add optional param sourceId to content share connectivity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add meeting readiness checker integ tests to travis config
+- Add optional parameter `sourceId` to checkContentShareConnectivity API
 
 ### Changed
 - Use pip to install aws sam cli for deployment script

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioconnectivity">checkAudioConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L256">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L258">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -425,7 +425,7 @@
 					<a name="checkcontentshareconnectivity" class="tsd-anchor"></a>
 					<h3>check<wbr>Content<wbr>Share<wbr>Connectivity</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">check<wbr>Content<wbr>Share<wbr>Connectivity<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">check<wbr>Content<wbr>Share<wbr>Connectivity<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -435,6 +435,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L209">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:209</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> sourceId: <span class="tsd-signature-type">string</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -450,7 +456,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L389">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:389</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L391">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:391</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworktcpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkTCPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -468,7 +474,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L347">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:347</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L349">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:349</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworkudpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkUDPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -486,7 +492,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L302">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L304">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -533,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L465">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:465</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L467">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:467</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L433">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:433</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L435">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:435</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -614,7 +620,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L449">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:449</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L451">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:451</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/interfaces/meetingreadinesschecker.html
+++ b/docs/interfaces/meetingreadinesschecker.html
@@ -243,7 +243,7 @@
 					<a name="checkcontentshareconnectivity" class="tsd-anchor"></a>
 					<h3>check<wbr>Content<wbr>Share<wbr>Connectivity</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">check<wbr>Content<wbr>Share<wbr>Connectivity<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">check<wbr>Content<wbr>Share<wbr>Connectivity<span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -258,6 +258,12 @@
 									Tests content share connectivity</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> sourceId: <span class="tsd-signature-type">string</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checkcontentshareconnectivityfeedback.html" class="tsd-signature-type">CheckContentShareConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.9",
+  "version": "1.17.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.9",
+  "version": "1.17.10",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
+++ b/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
@@ -206,7 +206,9 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
     return trackConstraints;
   }
 
-  async checkContentShareConnectivity(): Promise<CheckContentShareConnectivityFeedback> {
+  async checkContentShareConnectivity(
+    sourceId?: string
+  ): Promise<CheckContentShareConnectivityFeedback> {
     let isContentShareStarted = false;
     let isAudioVideoStarted = false;
 
@@ -226,7 +228,7 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
       this.meetingSession.audioVideo.start();
 
       this.meetingSession.audioVideo.addContentShareObserver(contentShareObserver);
-      await this.meetingSession.audioVideo.startContentShareFromScreenCapture();
+      await this.meetingSession.audioVideo.startContentShareFromScreenCapture(sourceId);
 
       await this.executeTimeoutTask(async () => {
         return isAudioVideoStarted && isContentShareStarted;

--- a/src/meetingreadinesschecker/MeetingReadinessChecker.ts
+++ b/src/meetingreadinesschecker/MeetingReadinessChecker.ts
@@ -44,7 +44,7 @@ export default interface MeetingReadinessChecker {
   /*
    * Tests content share connectivity
    */
-  checkContentShareConnectivity(): Promise<CheckContentShareConnectivityFeedback>;
+  checkContentShareConnectivity(sourceId?: string): Promise<CheckContentShareConnectivityFeedback>;
 
   /**
    * Tests audio connection

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.9';
+    return '1.17.10';
   }
 
   /**

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -7,6 +7,7 @@ import UserMediaState from './UserMediaState';
 export default class DOMMockBehavior {
   asyncWaitMs: number = 10;
   getDisplayMediaResult: DisplayMediaState = DisplayMediaState.Success;
+  triggeredEndedEventForStopStreamTrack: boolean = true;
   getUserMediaResult: UserMediaState = UserMediaState.Success;
   getUserMediaSucceeds: boolean = true;
   getUserMediaAudioLabel: string = 'Default';

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -175,7 +175,10 @@ export default class DOMMockBuilder {
       stop(): void {
         if (this.readyState === 'live') {
           this.readyState = 'ended';
-          if (this.listeners.hasOwnProperty('ended')) {
+          if (
+            this.listeners.hasOwnProperty('ended') &&
+            mockBehavior.triggeredEndedEventForStopStreamTrack
+          ) {
             this.listeners.ended.forEach((listener: MockListener) =>
               listener({
                 ...Substitute.for(),

--- a/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
+++ b/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
@@ -492,6 +492,15 @@ describe('DefaultMeetingReadinessChecker', () => {
       expect(result).to.equal(CheckContentShareConnectivityFeedback.Succeeded);
     }).timeout(10000);
 
+    it('start content share success with source id', async () => {
+      domMockBehavior.getDisplayMediaResult = DisplayMediaState.Success;
+      domMockBehavior.triggeredEndedEventForStopStreamTrack = false;
+      const result: CheckContentShareConnectivityFeedback = await meetingReadinessCheckerController.checkContentShareConnectivity(
+        'sourceId'
+      );
+      expect(result).to.equal(CheckContentShareConnectivityFeedback.Succeeded);
+    }).timeout(10000);
+
     it('connection failure', async () => {
       attendeeAudioVideoController.skipStart = true;
       const result: CheckContentShareConnectivityFeedback = await meetingReadinessCheckerController.checkContentShareConnectivity();


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Add optional param sourceId to content share connectivity check for electron apps

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tested manually and ran integration tests successfully.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
Yes

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
