### PR TITLE
Add messaging for getUserMedia error on HTTP site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update integration-watchlist to include demos/browser with no exception for package.json
 - Change error to warn for logging Cloudwatch errors
 - Update README with use case to handle `realtimeSubscribeToVolumeIndicator` updates efficiently
+- Change error messaging for getUserMedia error
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -211,11 +211,12 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           try {
             chimeMeetingId = await this.authenticate();
           } catch (error) {
+            const httpErrorMessage = 'UserMedia is not allowed in HTTP sites. Either use HTTPS or enable media capture on insecure sites.';
             (document.getElementById(
               'failed-meeting'
             ) as HTMLDivElement).innerText = `Meeting ID: ${this.meeting}`;
             (document.getElementById('failed-meeting-error') as HTMLDivElement).innerText =
-              error.message;
+              window.location.protocol === 'http:' ? httpErrorMessage : error.message;
             this.switchToFlow('flow-failed-meeting');
             return;
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.14",
+  "version": "1.17.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.14",
+  "version": "1.17.15",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.14';
+    return '1.17.15';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
#456
**Description of changes:**
Added improved messaging for getUserMedia error when on HTTP sites. 
**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
I loaded the app via `http:` and `https:` in Chrome, Safari, and Firefox. The new error message is only shown when joining a meeting fails and the client is using `http:`. 

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
