### PR TITLE
Fix css bug to account for 4.5.1 bootstrap update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug related to unbinding a video element
 - Fix tone does not stop when calling MeetingReadinessChecker.checkAudioOutput multiple times
+- Fixed demo css format issue from updating to bootstrap 4.5.1
 
 ## [1.17.2] - 2020-09-08
 ### Added

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -213,7 +213,7 @@
     <div id="flow-meeting" class="flow" style="position:absolute;left:15px;top:0;bottom:15px;right:15px">
       <audio id="meeting-audio" style="display:none"></audio>
       <div id="meeting-container" class="container-fluid h-100" style="display:flex; flex-flow:column">
-        <div class="row mb-3 mb-lg-0">
+        <div class="row mb-3 mb-lg-0" style="flex: unset;">
           <div class="col-12 col-lg-3 text-center text-lg-left">
             <div id="meeting-id" class="navbar-brand text-muted m-2"></div>
           </div>
@@ -270,7 +270,7 @@
             </button>
           </div>
         </div>
-        <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100">
+        <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100" style="flex: unset;">
           <div id="roster-container" class="d-flex flex-column col-12 col-sm-6 col-md-5 col-lg-4 h-100">
             <div class="bs-component" style="flex: 1 1 auto; overflow-y: scroll; height: 50%;">
               <ul id="roster" class="list-group"></ul>

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -226,7 +226,7 @@
   </div>
   <audio id="meeting-audio" style="display:none"></audio>
   <div id="meeting-container" class="container-fluid h-100" style="display:flex; flex-flow:column">
-    <div class="row mb-3 mb-lg-0">
+    <div class="row mb-3 mb-lg-0" style="flex-basis: auto;">
       <div class="col-12 col-lg-3 order-1 order-lg-1 text-center text-lg-left">
         <div id="meeting-id" class="navbar-brand text-muted m-0 m-lg-2"></div>
         <div id="mobile-chime-meeting-id" class="text-muted d-block d-sm-none" style="font-size:0.65rem;"></div>
@@ -292,7 +292,7 @@
         </button>
       </div>
     </div>
-    <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100">
+    <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100" style="flex: unset;">
       <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-6 col-md-5 col-lg-4 h-100">
         <div class="bs-component" style="flex: 1 1 auto; overflow-y: scroll; height: 50%;">
           <ul id="roster" class="list-group"></ul>

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4879,9 +4879,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.751.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.751.0.tgz",
-      "integrity": "sha512-0lo7YKTfjEwoP+2vK7F7WGNigvwFxqiM96PzBaseOpOelfhFHPKEJpk2Poa12JI89c8dGoc1PhTQ1TSTJK3ZqQ==",
+      "version": "2.755.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.755.0.tgz",
+      "integrity": "sha512-APei6/d3ki6wi9pp6XvQ7QTiOhDBCo1qCOQZ5n8POUE1yrB7/6SNWami9OTj2TavFvnz7OuPr5YZ2/Ra45N49A==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -5043,9 +5043,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
-      "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.1.tgz",
+      "integrity": "sha512-bxUooHBSbvefnIZfjD0LE8nfdPKrtiFy2sgrxQwUZ0UpFzpjVbVMUxaGIoo9XWT4B2LG1HX6UQg0UMOakT0prQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.751.0",
-    "bootstrap": "4.5.0",
+    "aws-sdk": "^2.755.0",
+    "bootstrap": "^4.5.1",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.17.10';
+    return '1.17.11';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Bootstrap introduced a code change  in 4.5.1. (https://github.com/twbs/bootstrap/pull/30940) that breaks the css format in our demo app.  We just need to override the flex property to make sure the flex-basis property isnt 100%.

Also, bump bootstrap to 4.5.1.

**Testing**
Visual testing in the demo app.

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? visually verified on the demo app
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
