### PR TITLE
Create log stream before logging begins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional parameter `sourceId` to checkContentShareConnectivity API
 - Add getVideoInputQualitySettings to retrieve the current video settings
 - Add documentation for DefaultActiveSpeakerPolicy constructor
+- Create log stream before logging begins
 
 ### Changed
 - Use pip to install aws sam cli for deployment script

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -674,6 +674,24 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     }
   }
 
+  async createLogStream(): Promise<void> {
+    const body = JSON.stringify({
+      meetingId: this.meetingSession.configuration.meetingId,
+      attendeeId: this.meetingSession.configuration.credentials.attendeeId,
+    });
+    try {
+      const response = await fetch(`${DemoMeetingApp.BASE_URL}create_log_stream`, {
+        method: 'POST',
+        body
+      });
+      if (response.status === 200) {
+        console.log('Log stream created');
+      }
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
     let logger: Logger;
     const logLevel = LogLevel.INFO;
@@ -681,6 +699,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
       logger = consoleLogger;
     } else {
+      await this.createLogStream();
       logger = new MultiLogger(
         consoleLogger,
         new MeetingSessionPOSTLogger(

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4879,9 +4879,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.755.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.755.0.tgz",
-      "integrity": "sha512-APei6/d3ki6wi9pp6XvQ7QTiOhDBCo1qCOQZ5n8POUE1yrB7/6SNWami9OTj2TavFvnz7OuPr5YZ2/Ra45N49A==",
+      "version": "2.756.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.756.0.tgz",
+      "integrity": "sha512-Hk6DzcsXq1WRg+UVHDH56iQz31kDtg/NRqtJL1A0BrZ/PtNSLTHsQQllpcAi09UxLDMzBoDXymZ8kYg0Migq8w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.755.0",
+    "aws-sdk": "^2.756.0",
     "bootstrap": "^4.5.1",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -59,6 +59,7 @@ Resources:
             Resource: '*'
       Roles:
         - Ref: ChimeSdkBrowserLogsLambdaRole
+        - Ref: ChimeSdkBrowserCreateLogStreamLambdaRole
   Meetings:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -174,6 +175,17 @@ Resources:
           Type: Api
           Properties:
             Path: /logs
+            Method: POST
+  ChimeSdkBrowserCreateLogStreamLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.create_log_stream
+      CodeUri: src/
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /create_log_stream
             Method: POST
   ChimeNotificationsQueuePolicy:
     Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
**Issue #:**
We recently observed ResourceAlreadyExistsException on Log stream - we already have a mechanism to check if a log stream exists - and if it exists we re-use that or else we create a new log stream. 
A race condition is taking place, two or more processes reach the createLogStream() in ensureLogStream at the same time. While one gets the priority and creates a logStream, the other process fails to create a LogStream with the same logStream name. So this process fails for the first time and is retried at the CW end. Upon retry the previously failed process executes without error on the LogStream returned by ensureLogStream - thus there is no data loss but we see ERROR entry due to the failed execution.

**Description of changes:**
We are creating a log stream at the beginning of the meeting itself. So there should be no race condition when multiple process start writing to a log.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Tested by removing the endpoint logs and running the serverless demo app to see that the application is creating a new Log Stream

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
