### PR TITLE
Fix bootstrap bug in V1 meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 ### Added
 - Add MeetingReadinessCheckerConfiguration to allow custom configuration for meeting readiness checker
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix Maven installation script
 - Fix SIP integration test
+- Fixed v1 meeting bug related to bootstrap row class
 
 ## [1.18.0] - 2020-09-22
 ### Added

--- a/demos/browser/app/meeting/meeting.html
+++ b/demos/browser/app/meeting/meeting.html
@@ -367,7 +367,7 @@
             </div>
           </div>
         </div>
-        <div class="row">
+        <div class="row" style="flex: unset;">
           <div class="text-muted text-left col-sm-12 col-md-6 col-lg-4" id="video-uplink-bandwidth"></div>
           <div class="text-muted text-sm-left text-md-right text-lg-center col-sm-12 col-md-6 col-lg-4" id="chime-meeting-id"></div>
           <div class="text-muted text-sm-left text-md-left text-lg-right col-sm-12 col-md-6 col-lg-4" id="video-downlink-bandwidth"></div>

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -226,7 +226,7 @@
   </div>
   <audio id="meeting-audio" style="display:none"></audio>
   <div id="meeting-container" class="container-fluid h-100" style="display:flex; flex-flow:column">
-    <div class="row mb-3 mb-lg-0" style="flex-basis: auto;">
+    <div class="row mb-3 mb-lg-0" style="flex: unset;">
       <div class="col-12 col-lg-3 order-1 order-lg-1 text-center text-lg-left">
         <div id="meeting-id" class="navbar-brand text-muted m-0 m-lg-2"></div>
         <div id="mobile-chime-meeting-id" class="text-muted d-block d-sm-none" style="font-size:0.65rem;"></div>

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4879,9 +4879,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.755.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.755.0.tgz",
-      "integrity": "sha512-APei6/d3ki6wi9pp6XvQ7QTiOhDBCo1qCOQZ5n8POUE1yrB7/6SNWami9OTj2TavFvnz7OuPr5YZ2/Ra45N49A==",
+      "version": "2.759.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.759.0.tgz",
+      "integrity": "sha512-XTmt6b8NfluqmixO18Bu9ZttZMW9rwEDVO+XITsIQ5dZvLectwrjlbEn2refudJI1Y2pxLguw+tABvXi1wtbbQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.755.0",
+    "aws-sdk": "^2.759.0",
     "bootstrap": "^4.5.1",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Adjust for bootstrap 4.5.1 addition to row class. Need to unset the flex property that was introduced in 4.5.1.

**Testing**
Ran meeting V1 and meeting V2 and visually verified.

1. Have you successfully run `npm run build:release` locally? 
yes

2. How did you test these changes? 
 Ran meeting V1 and meeting V2 and visually verified.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n/a
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
