### PR TITLE
Disable saucelab capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update Travis config to improve PR build speed
+- Disable saucelab capabilities
 
 ### Removed
 

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -95,12 +95,7 @@ const getSauceLabsConfig = (capabilities) => {
     name: capabilities.name,
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
-    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
-      extendedDebugging: true,
-      capturePerformance: true,
-      crmuxdriverVersion: 'beta'
-    })
+    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
   }
 };
 


### PR DESCRIPTION
**Issue #:**
Firefox:
“Unable to connect”  issue was primarily observed only on Firefox in Saucelabs - where the FF v75 browser was not able to connect to the meeting app. It eventually times out and session fails to test the last step in the canary execution to validate if the monitor_window has VIDEO_OFF. Thus it gets marked as failure in Saucelabs.

Chrome:
We observed that meeting sessions dont end even after the meeting end button is clicked. For such meeting sessions, the meeting logs indicates that the meeting ended successfully but was marked as failed on saucelabs


**Description of changes:**
In order to mitigate the errors we are disabling the capabilities on Saucelabs

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manually on Saucelabs - tests are running fine with the capabilities disabled.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
