### PR TITLE
Fix meeting readiness checker integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Maven installation script
 - Fix SIP integration test
 - Fixed v1 meeting bug related to bootstrap row class
+- Fix meeting readiness checker integration test
 
 ## [1.18.0] - 2020-09-22
 ### Added

--- a/integration/js/pages/MeetingReadinessCheckerPage.js
+++ b/integration/js/pages/MeetingReadinessCheckerPage.js
@@ -57,12 +57,16 @@ class MeetingReadinessCheckerPage {
   }
 
   async checkSpeakerTestSucceed() {
+    const sleep = (milliseconds) => {
+      return new Promise(resolve => setTimeout(resolve, milliseconds))
+    };
     let audioFrequencyCheckResult = await this.audioFrequencyCheck();
     if(audioFrequencyCheckResult) {
       await this.speakerCheckFeedbackYes();
     } else {
       await this.speakerCheckFeedbackNo();
     }
+    await sleep(3000);
     let checkSpeakerFeedback = await this.driver.findElement(elements.speakerTest).getAttribute('class');
     return checkSpeakerFeedback.includes(badgeSuccessLabel);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.4",
+  "version": "1.18.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.18.4';
+    return '1.18.5';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Fix meeting readiness checker integration test by adding a sleep of 3 seconds between the audio output check succeeding and checking for the `succeed` label on the UI.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
By running the integration tests locally.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
