### PR TITLE
Add Seleniunm session initialization metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add a Travis check to make sure version update
+- Add metrics for Selenium initialization metrics for integration tests
 
 ### Changed
+- Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests
 
 ### Removed
 
 ### Fixed
+- Make sure integration test returns FAILED if there is error
 
 ## [1.19.0] - 2020-09-29
 ### Added

--- a/integration/js/steps/GetSipUriForCallStep.js
+++ b/integration/js/steps/GetSipUriForCallStep.js
@@ -25,7 +25,7 @@ class GetSipUriForCallStep extends AppTestStep {
     await this.page.authenticateSipCall(this.meetingId, this.test.payload.voiceConnectorId);
     let authState = await this.page.waitForSipAuthentication();
     if (authState === 'failed') {
-      throw new KiteTestError(Status.ERROR, 'Timeout while getting sip call uri');
+      throw new KiteTestError(Status.BROKEN, 'Timeout while getting sip call uri');
     }
     let sipUri = await this.page.getSipUri();
     this.test.sipUri = sipUri;

--- a/integration/js/steps/JoinMeetingStep.js
+++ b/integration/js/steps/JoinMeetingStep.js
@@ -28,7 +28,7 @@ class JoinMeetingStep extends AppTestStep {
     await this.page.joinMeeting();
     let joinState = await this.page.waitToJoinTheMeeting();
     if (joinState === 'failed') {
-      throw new KiteTestError(Status.ERROR, 'Timeout while joining the meeting');
+      throw new KiteTestError(Status.BROKEN, 'Timeout while joining the meeting');
     }
   }
 }

--- a/integration/js/steps/SetTestBrokenStep.js
+++ b/integration/js/steps/SetTestBrokenStep.js
@@ -1,0 +1,30 @@
+const {KiteTestError, Status} = require('kite-common');
+const AppTestStep = require('../utils/AppTestStep');
+
+class SetTestBrokenStep extends AppTestStep {
+  constructor(kiteBaseTest, errorMessage) {
+    super(kiteBaseTest);
+    this.errorMessage = errorMessage;
+  }
+
+  stepDescription() {
+    return 'Setting test to broken';
+  }
+
+  static async executeStep(KiteBaseTest, errorMessage) {
+    const step = new SetTestBrokenStep(KiteBaseTest, errorMessage);
+    await step.execute(KiteBaseTest);
+  }
+
+  async step() {
+    throw new KiteTestError(Status.BROKEN, this.errorMessage);
+  }
+
+  async finish() {
+    this.report.setName(this.stepDescription());
+    this.report.setDescription(this.stepDescription());
+    this.report.setStopTimestamp();
+  }
+}
+
+module.exports = SetTestBrokenStep;

--- a/integration/js/steps/index.js
+++ b/integration/js/steps/index.js
@@ -31,3 +31,4 @@ exports.StartMeetingReadinessCheckerStep = require('./StartMeetingReadinessCheck
 exports.StartContentShareConnectivityCheckStep = require('./StartContentShareConnectivityCheckStep');
 exports.WaitForContentShareTestToBeReady = require('./WaitForContentShareTestToBeReady');
 exports.WaitForStartMeetingReadinessCheckerButtonToBeEnabled = require('./WaitForStartMeetingReadinessCheckerButtonToBeEnabled');
+exports.SetTestBrokenStep = require('./SetTestBrokenStep');

--- a/integration/js/utils/AppTestStep.js
+++ b/integration/js/utils/AppTestStep.js
@@ -12,9 +12,11 @@ class AppTestStep extends TestStep {
     this.testReporter = kiteBaseTest.reporter;
 
     // this is different if we have multiple sessions
-    this.logger = sessionInfo.logger;
-    this.page = sessionInfo.page;
-    this.driver = sessionInfo.driver;
+    if (sessionInfo) {
+      this.logger = sessionInfo.logger;
+      this.page = sessionInfo.page;
+      this.driver = sessionInfo.driver;
+    }
   }
 
   async step() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.1';
+    return '1.19.2';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
- Add metrics for Selenium initialization metrics for integration tests
- Make sure integration test returns FAILED if there is error
- Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
Manually run integ tests and verify the changes.
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
