### PR TITLE
Revert "Create log stream before logging begins"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add MeetingReadinessCheckerConfiguration to allow custom configuration for meeting readiness checker
-- Create log stream before logging begins
 
 ### Changed
 - Update Travis config to improve PR build speed
-- Disable configs in saucelab capabilities
+- Disable saucelab capabilities
 - Use credentials sent via signaling connection JOIN_ACK to improve audio-video startup time.
 - [Demo] Adjust demo css to prevent unecessary scrollbars on windows and stretching in video grid
 - Update dependencies to TypeScript 4, `ts-loader`, and modern linting
@@ -21,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unnecessary startAudioPreview in meeting demo
 
 ### Removed
+- Revert the "Create log stream before logging begins" commit
 
 ### Fixed
 - Fix Maven installation script

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -671,24 +671,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     }
   }
 
-  async createLogStream(): Promise<void> {
-    const body = JSON.stringify({
-      meetingId: this.meetingSession.configuration.meetingId,
-      attendeeId: this.meetingSession.configuration.credentials.attendeeId,
-    });
-    try {
-      const response = await fetch(`${DemoMeetingApp.BASE_URL}create_log_stream`, {
-        method: 'POST',
-        body
-      });
-      if (response.status === 200) {
-        console.log('Log stream created');
-      }
-    } catch (error) {
-      console.error(error.message);
-    }
-  }
-
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
     let logger: Logger;
     const logLevel = LogLevel.INFO;
@@ -696,7 +678,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
       logger = consoleLogger;
     } else {
-      await this.createLogStream();
       logger = new MultiLogger(
         consoleLogger,
         new MeetingSessionPOSTLogger(

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -136,7 +136,7 @@ exports.logs = async (event, context) => {
     await cloudWatchClient.putLogEvents(putLogEventsInput).promise();
   } catch (error) {
     const errorMessage = `Failed to put CloudWatch log events with error ${error} and params ${JSON.stringify(putLogEventsInput)}`;
-    if (error.code === 'DataAlreadyAcceptedException' || error.code === 'InvalidSequenceToken') {
+    if (error.code === 'DataAlreadyAcceptedException') {
       console.warn(errorMessage);
     } else {
       console.error(errorMessage);
@@ -201,20 +201,6 @@ async function ensureLogStream(cloudWatchClient, logStreamName) {
     logStreamName: logStreamName,
   }).promise();
   return null;
-}
-
-exports.create_log_stream = async (event, context, callback) => {
-  const body = JSON.parse(event.body);
-  if (!body.meetingId || !body.attendeeId) {
-    return response(400, 'application/json', JSON.stringify({error: 'Need properties: meetingId, attendeeId'}));
-  }
-  const logStreamName = `ChimeSDKMeeting_${body.meetingId.toString()}_${body.attendeeId.toString()}`;
-  const cloudWatchClient = new AWS.CloudWatchLogs({ apiVersion: '2014-03-28' });
-  await cloudWatchClient.createLogStream({
-    logGroupName: logGroupName,
-    logStreamName: logStreamName,
-  }).promise();
-  return response(200, 'application/json', JSON.stringify({}));
 }
 
 function response(statusCode, contentType, body) {

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -59,7 +59,6 @@ Resources:
             Resource: '*'
       Roles:
         - Ref: ChimeSdkBrowserLogsLambdaRole
-        - Ref: ChimeSdkBrowserCreateLogStreamLambdaRole
   Meetings:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -175,17 +174,6 @@ Resources:
           Type: Api
           Properties:
             Path: /logs
-            Method: POST
-  ChimeSdkBrowserCreateLogStreamLambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: handlers.create_log_stream
-      CodeUri: src/
-      Events:
-        Api1:
-          Type: Api
-          Properties:
-            Path: /create_log_stream
             Method: POST
   ChimeNotificationsQueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.18.5';
+    return '1.18.6';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
#715 is causing the serverless demo to fail in the device selection page

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Deployed the serverless demo and ensure that I can join a meeting
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
