### PR TITLE
Reintroduce defined-in links to GitHub.

### DIFF
--- a/docs/classes/allhighestvideobandwidthpolicy.html
+++ b/docs/classes/allhighestvideobandwidthpolicy.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L17">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">optimal<wbr>Receive<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L16">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">self<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L19">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribed<wbr>Receive<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L17">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L41">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L36">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -234,7 +234,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatecalculatedoptimalreceiveset">updateCalculatedOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L30">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -252,7 +252,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L24">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L28">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts#L32">src/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/asyncscheduler.html
+++ b/docs/classes/asyncscheduler.html
@@ -126,7 +126,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="timeoutscheduler.html">TimeoutScheduler</a>.<a href="timeoutscheduler.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/scheduler/AsyncScheduler.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/AsyncScheduler.ts#L10">src/scheduler/AsyncScheduler.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="asyncscheduler.html" class="tsd-signature-type">AsyncScheduler</a></h4>
@@ -147,7 +147,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="timeoutscheduler.html">TimeoutScheduler</a>.<a href="timeoutscheduler.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/scheduler/TimeoutScheduler.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L14">src/scheduler/TimeoutScheduler.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -184,7 +184,7 @@
 								<p>Implementation of <a href="../interfaces/scheduler.html">Scheduler</a>.<a href="../interfaces/scheduler.html#stop">stop</a></p>
 								<p>Inherited from <a href="timeoutscheduler.html">TimeoutScheduler</a>.<a href="timeoutscheduler.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/scheduler/TimeoutScheduler.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L22">src/scheduler/TimeoutScheduler.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/attachmediainputtask.html
+++ b/docs/classes/attachmediainputtask.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/AttachMediaInputTask.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/AttachMediaInputTask.ts#L12">src/task/AttachMediaInputTask.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/AttachMediaInputTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/AttachMediaInputTask.ts#L14">src/task/AttachMediaInputTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/AttachMediaInputTask.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/AttachMediaInputTask.ts#L12">src/task/AttachMediaInputTask.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -254,7 +254,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -273,7 +273,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/AttachMediaInputTask.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/AttachMediaInputTask.ts#L18">src/task/AttachMediaInputTask.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -292,7 +292,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/audiovideocontrollerstate.html
+++ b/docs/classes/audiovideocontrollerstate.html
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Audio<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:58</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L58">src/audiovideocontroller/AudioVideoControllerState.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Video<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:60</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L60">src/audiovideocontroller/AudioVideoControllerState.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Device<wbr>Information<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:112</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L112">src/audiovideocontroller/AudioVideoControllerState.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Mix<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:56</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L56">src/audiovideocontroller/AudioVideoControllerState.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:48</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L48">src/audiovideocontroller/AudioVideoControllerState.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L36">src/audiovideocontroller/AudioVideoControllerState.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Monitor<span class="tsd-signature-symbol">:</span> <a href="../interfaces/connectionmonitor.html" class="tsd-signature-type">ConnectionMonitor</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:108</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L108">src/audiovideocontroller/AudioVideoControllerState.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Simulcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:116</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L116">src/audiovideocontroller/AudioVideoControllerState.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">ice<wbr>Candidate<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RTCPeerConnectionIceEvent</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:68</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L68">src/audiovideocontroller/AudioVideoControllerState.ts:68</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">ice<wbr>Candidates<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCIceCandidate</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:66</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L66">src/audiovideocontroller/AudioVideoControllerState.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">ice<wbr>Gathering<wbr>State<wbr>Event<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:70</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L70">src/audiovideocontroller/AudioVideoControllerState.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">index<wbr>Frame<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkIndexFrame</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:64</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L64">src/audiovideocontroller/AudioVideoControllerState.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Known<wbr>Video<wbr>Availability<span class="tsd-signature-symbol">:</span> <a href="meetingsessionvideoavailability.html" class="tsd-signature-type">MeetingSessionVideoAvailability</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:88</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L88">src/audiovideocontroller/AudioVideoControllerState.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -317,7 +317,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Audio<wbr>Sender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCRtpSender</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:92</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L92">src/audiovideocontroller/AudioVideoControllerState.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Video<wbr>Sender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCRtpSender</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:90</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L90">src/audiovideocontroller/AudioVideoControllerState.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -337,7 +337,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L34">src/audiovideocontroller/AudioVideoControllerState.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -347,7 +347,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:54</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L54">src/audiovideocontroller/AudioVideoControllerState.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -357,7 +357,7 @@
 					<div class="tsd-signature tsd-kind-icon">meeting<wbr>Session<wbr>Configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L40">src/audiovideocontroller/AudioVideoControllerState.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -367,7 +367,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCPeerConnection</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L42">src/audiovideocontroller/AudioVideoControllerState.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -377,7 +377,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Sdp<wbr>Offer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/sdp.html" class="tsd-signature-type">SDP</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L44">src/audiovideocontroller/AudioVideoControllerState.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -387,7 +387,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:50</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L50">src/audiovideocontroller/AudioVideoControllerState.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -397,7 +397,7 @@
 					<div class="tsd-signature tsd-kind-icon">reconnect<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/reconnectcontroller.html" class="tsd-signature-type">ReconnectController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:78</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L78">src/audiovideocontroller/AudioVideoControllerState.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -407,7 +407,7 @@
 					<div class="tsd-signature tsd-kind-icon">removable<wbr>Observers<span class="tsd-signature-symbol">:</span> <a href="../interfaces/removableobserver.html" class="tsd-signature-type">RemovableObserver</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:80</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L80">src/audiovideocontroller/AudioVideoControllerState.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -417,7 +417,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Sharing<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingsession.html" class="tsd-signature-type">ScreenSharingSession</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:72</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L72">src/audiovideocontroller/AudioVideoControllerState.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -427,7 +427,7 @@
 					<div class="tsd-signature tsd-kind-icon">sdp<wbr>Answer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:74</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L74">src/audiovideocontroller/AudioVideoControllerState.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -437,7 +437,7 @@
 					<div class="tsd-signature tsd-kind-icon">sdp<wbr>Offer<wbr>Init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCSessionDescriptionInit</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L46">src/audiovideocontroller/AudioVideoControllerState.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -447,7 +447,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/signalingclient.html" class="tsd-signature-type">SignalingClient</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L38">src/audiovideocontroller/AudioVideoControllerState.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -457,7 +457,7 @@
 					<div class="tsd-signature tsd-kind-icon">stats<wbr>Collector<span class="tsd-signature-symbol">:</span> <a href="../interfaces/statscollector.html" class="tsd-signature-type">StatsCollector</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:106</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L106">src/audiovideocontroller/AudioVideoControllerState.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -467,7 +467,7 @@
 					<div class="tsd-signature tsd-kind-icon">transceiver<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/transceivercontroller.html" class="tsd-signature-type">TransceiverController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:62</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L62">src/audiovideocontroller/AudioVideoControllerState.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -477,7 +477,7 @@
 					<div class="tsd-signature tsd-kind-icon">turn<wbr>Credentials<span class="tsd-signature-symbol">:</span> <a href="meetingsessionturncredentials.html" class="tsd-signature-type">MeetingSessionTURNCredentials</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:76</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L76">src/audiovideocontroller/AudioVideoControllerState.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -487,7 +487,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Capture<wbr>And<wbr>Encode<wbr>Parameter<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videocaptureandencodeparameter.html" class="tsd-signature-type">VideoCaptureAndEncodeParameter</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:94</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L94">src/audiovideocontroller/AudioVideoControllerState.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -497,7 +497,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Device<wbr>Information<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:114</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L114">src/audiovideocontroller/AudioVideoControllerState.ts:114</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -515,7 +515,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Downlink<wbr>Bandwidth<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videodownlinkbandwidthpolicy.html" class="tsd-signature-type">VideoDownlinkBandwidthPolicy</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:84</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L84">src/audiovideocontroller/AudioVideoControllerState.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -525,7 +525,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Duplex<wbr>Mode<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkStreamServiceType</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:102</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L102">src/audiovideocontroller/AudioVideoControllerState.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -535,7 +535,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Input<wbr>Attached<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:110</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L110">src/audiovideocontroller/AudioVideoControllerState.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -545,7 +545,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Index<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:82</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L82">src/audiovideocontroller/AudioVideoControllerState.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -555,7 +555,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:98</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L98">src/audiovideocontroller/AudioVideoControllerState.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -565,7 +565,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:52</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L52">src/audiovideocontroller/AudioVideoControllerState.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -575,7 +575,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Uplink<wbr>Bandwidth<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videouplinkbandwidthpolicy.html" class="tsd-signature-type">VideoUplinkBandwidthPolicy</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:86</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L86">src/audiovideocontroller/AudioVideoControllerState.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -585,7 +585,7 @@
 					<div class="tsd-signature tsd-kind-icon">videos<wbr>Paused<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:100</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L100">src/audiovideocontroller/AudioVideoControllerState.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -595,7 +595,7 @@
 					<div class="tsd-signature tsd-kind-icon">videos<wbr>ToReceive<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:96</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L96">src/audiovideocontroller/AudioVideoControllerState.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -605,7 +605,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<wbr>Indicator<wbr>Adapter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VolumeIndicatorAdapter</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoControllerState.ts:104</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerState.ts#L104">src/audiovideocontroller/AudioVideoControllerState.ts:104</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/baseconnectionhealthpolicy.html
+++ b/docs/classes/baseconnectionhealthpolicy.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Data<span class="tsd-signature-symbol">:</span> <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L9">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L11">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L10">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L37">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></h4>
@@ -224,7 +224,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#health">health</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L29">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthifchanged">healthIfChanged</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L45">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -260,7 +260,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthy">healthy</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L41">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -278,7 +278,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#maximumhealth">maximumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L25">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -296,7 +296,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#minimumhealth">minimumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L21">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -314,7 +314,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#update">update</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L33">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/basetask.html
+++ b/docs/classes/basetask.html
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L17">src/task/BaseTask.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">parent<wbr>Task<span class="tsd-signature-symbol">:</span> <a href="../interfaces/task.html" class="tsd-signature-type">Task</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L14">src/task/BaseTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a><span class="tsd-signature-symbol"> = TaskStatus.IDLE</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L15">src/task/BaseTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;BaseTask&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L12">src/task/BaseTask.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L69">src/task/BaseTask.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L43">src/task/BaseTask.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -350,7 +350,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -384,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -408,7 +408,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -426,7 +426,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L17">src/task/BaseTask.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -444,7 +444,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/bitrateparameters.html
+++ b/docs/classes/bitrateparameters.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/BitrateParameters.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/BitrateParameters.ts#L6">src/videouplinkbandwidthpolicy/BitrateParameters.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/BitrateParameters.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/BitrateParameters.ts#L5">src/videouplinkbandwidthpolicy/BitrateParameters.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/cleanrestartedsessiontask.html
+++ b/docs/classes/cleanrestartedsessiontask.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/CleanRestartedSessionTask.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanRestartedSessionTask.ts#L8">src/task/CleanRestartedSessionTask.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CleanRestartedSessionTask.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanRestartedSessionTask.ts#L10">src/task/CleanRestartedSessionTask.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/CleanRestartedSessionTask.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanRestartedSessionTask.ts#L8">src/task/CleanRestartedSessionTask.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -254,7 +254,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -273,7 +273,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/CleanRestartedSessionTask.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanRestartedSessionTask.ts#L14">src/task/CleanRestartedSessionTask.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -292,7 +292,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cleanstoppedsessiontask.html
+++ b/docs/classes/cleanstoppedsessiontask.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/CleanStoppedSessionTask.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L14">src/task/CleanStoppedSessionTask.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CleanStoppedSessionTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L16">src/task/CleanStoppedSessionTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Canceler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/taskcanceler.html" class="tsd-signature-type">TaskCanceler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CleanStoppedSessionTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L14">src/task/CleanStoppedSessionTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/CleanStoppedSessionTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L13">src/task/CleanStoppedSessionTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/CleanStoppedSessionTask.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L20">src/task/CleanStoppedSessionTask.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -241,7 +241,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -266,7 +266,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CleanStoppedSessionTask.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L72">src/task/CleanStoppedSessionTask.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -302,7 +302,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/CleanStoppedSessionTask.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CleanStoppedSessionTask.ts#L27">src/task/CleanStoppedSessionTask.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -321,7 +321,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/clientvideostreamreceivingreport.html
+++ b/docs/classes/clientvideostreamreceivingreport.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientVideoStreamReceivingReport.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientVideoStreamReceivingReport.ts#L5">src/clientmetricreport/ClientVideoStreamReceivingReport.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">expected<wbr>Average<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientVideoStreamReceivingReport.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientVideoStreamReceivingReport.ts#L7">src/clientmetricreport/ClientVideoStreamReceivingReport.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">received<wbr>Average<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientVideoStreamReceivingReport.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientVideoStreamReceivingReport.ts#L6">src/clientmetricreport/ClientVideoStreamReceivingReport.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/connectionhealthdata.html
+++ b/docs/classes/connectionhealthdata.html
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L14">src/connectionhealthpolicy/ConnectionHealthData.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></h4>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Speaker<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L14">src/connectionhealthpolicy/ConnectionHealthData.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Start<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L5">src/connectionhealthpolicy/ConnectionHealthData.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">consecutive<wbr>Missed<wbr>Pongs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L11">src/connectionhealthpolicy/ConnectionHealthData.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">consecutive<wbr>Stats<wbr>With<wbr>NoPackets<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L6">src/connectionhealthpolicy/ConnectionHealthData.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">fraction<wbr>Packets<wbr>Lost<wbr>Inbound<wbr>InLast<wbr>Minute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L13">src/connectionhealthpolicy/ConnectionHealthData.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Good<wbr>Signal<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L8">src/connectionhealthpolicy/ConnectionHealthData.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>NoSignal<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L10">src/connectionhealthpolicy/ConnectionHealthData.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Packet<wbr>Loss<wbr>Inbound<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L7">src/connectionhealthpolicy/ConnectionHealthData.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Weak<wbr>Signal<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L9">src/connectionhealthpolicy/ConnectionHealthData.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">packets<wbr>Received<wbr>InLast<wbr>Minute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L12">src/connectionhealthpolicy/ConnectionHealthData.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L65">src/connectionhealthpolicy/ConnectionHealthData.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></h4>
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L44">src/connectionhealthpolicy/ConnectionHealthData.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L56">src/connectionhealthpolicy/ConnectionHealthData.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L50">src/connectionhealthpolicy/ConnectionHealthData.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -344,7 +344,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L62">src/connectionhealthpolicy/ConnectionHealthData.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L59">src/connectionhealthpolicy/ConnectionHealthData.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -390,7 +390,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L29">src/connectionhealthpolicy/ConnectionHealthData.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L99">src/connectionhealthpolicy/ConnectionHealthData.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -430,7 +430,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L24">src/connectionhealthpolicy/ConnectionHealthData.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -447,7 +447,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:81</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L81">src/connectionhealthpolicy/ConnectionHealthData.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L84">src/connectionhealthpolicy/ConnectionHealthData.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -493,7 +493,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L96">src/connectionhealthpolicy/ConnectionHealthData.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -516,7 +516,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L90">src/connectionhealthpolicy/ConnectionHealthData.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L87">src/connectionhealthpolicy/ConnectionHealthData.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L93">src/connectionhealthpolicy/ConnectionHealthData.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -585,7 +585,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthData.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthData.ts#L20">src/connectionhealthpolicy/ConnectionHealthData.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/connectionhealthpolicyconfiguration.html
+++ b/docs/classes/connectionhealthpolicyconfiguration.html
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Unhealthy<wbr>Threshold<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 25</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L8">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Wait<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L10">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">cooldown<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 60000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L17">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">five<wbr>Bars<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 60000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L16">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">four<wbr>Bars<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 20000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L15">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">fractional<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0.5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L20">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">good<wbr>Signal<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 15000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L19">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">initial<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L7">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L6">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Audio<wbr>Delay<wbr>Data<wbr>Points<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L26">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Audio<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 60000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L25">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Times<wbr>ToWarn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L22">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Health<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L5">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">missed<wbr>Pongs<wbr>Lower<wbr>Threshold<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L23">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">missed<wbr>Pongs<wbr>Upper<wbr>Threshold<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L24">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">no<wbr>Signal<wbr>Threshold<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L9">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">one<wbr>Bar<wbr>Weak<wbr>Signal<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L12">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">packets<wbr>Expected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 50</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L21">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 					<div class="tsd-signature tsd-kind-icon">past<wbr>Samples<wbr>ToConsider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L18">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 					<div class="tsd-signature tsd-kind-icon">three<wbr>Bars<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L14">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">two<wbr>Bars<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L13">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">zero<wbr>Bars<wbr>NoSignal<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts#L11">src/connectionhealthpolicy/ConnectionHealthPolicyConfiguration.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/consolelogger.html
+++ b/docs/classes/consolelogger.html
@@ -144,7 +144,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L28">src/logger/ConsoleLogger.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">level<span class="tsd-signature-symbol">:</span> <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/ConsoleLogger.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L28">src/logger/ConsoleLogger.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/ConsoleLogger.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L27">src/logger/ConsoleLogger.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L47">src/logger/ConsoleLogger.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -232,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#error">error</a></p>
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L43">src/logger/ConsoleLogger.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L58">src/logger/ConsoleLogger.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -274,7 +274,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#info">info</a></p>
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L35">src/logger/ConsoleLogger.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L62">src/logger/ConsoleLogger.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L54">src/logger/ConsoleLogger.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -348,7 +348,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#warn">warn</a></p>
 								<ul>
-									<li>Defined in src/logger/ConsoleLogger.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L39">src/logger/ConsoleLogger.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/contentsharemediastreambroker.html
+++ b/docs/classes/contentsharemediastreambroker.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L12">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">_media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L12">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L14">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L11">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L16">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -201,7 +201,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L20">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L24">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L40">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -269,7 +269,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L61">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -296,7 +296,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L31">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -314,7 +314,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:57</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L57">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L109">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -355,7 +355,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#releasemediastream">releaseMediaStream</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L35">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L70">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:70</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareMediaStreamBroker.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareMediaStreamBroker.ts#L96">src/contentsharecontroller/ContentShareMediaStreamBroker.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/createpeerconnectiontask.html
+++ b/docs/classes/createpeerconnectiontask.html
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L27">src/task/CreatePeerConnectionTask.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L29">src/task/CreatePeerConnectionTask.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">remove<wbr>Track<wbr>Added<wbr>Event<wbr>Listener<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L15">src/task/CreatePeerConnectionTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">remove<wbr>Track<wbr>Removed<wbr>Event<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L16">src/task/CreatePeerConnectionTask.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">remove<wbr>Video<wbr>Track<wbr>Event<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L25">src/task/CreatePeerConnectionTask.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L13">src/task/CreatePeerConnectionTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,7 +254,7 @@
 					<div class="tsd-signature tsd-kind-icon">track<wbr>Events<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&#x27;ended&#x27;,&#x27;mute&#x27;,&#x27;unmute&#x27;,&#x27;isolationchange&#x27;,&#x27;overconstrained&#x27;,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L18">src/task/CreatePeerConnectionTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -264,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">REMOVE_<wbr>HANDLER_<wbr>INTERVAL_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreatePeerConnectionTask.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L27">src/task/CreatePeerConnectionTask.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L40">src/task/CreatePeerConnectionTask.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:159</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L159">src/task/CreatePeerConnectionTask.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -326,7 +326,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -362,7 +362,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -387,7 +387,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L33">src/task/CreatePeerConnectionTask.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:241</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L241">src/task/CreatePeerConnectionTask.ts:241</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -450,7 +450,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L65">src/task/CreatePeerConnectionTask.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -469,7 +469,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -492,7 +492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:117</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L117">src/task/CreatePeerConnectionTask.ts:117</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -515,7 +515,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreatePeerConnectionTask.ts:140</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreatePeerConnectionTask.ts#L140">src/task/CreatePeerConnectionTask.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/createsdptask.html
+++ b/docs/classes/createsdptask.html
@@ -133,7 +133,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/CreateSDPTask.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L15">src/task/CreateSDPTask.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreateSDPTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L15">src/task/CreateSDPTask.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/CreateSDPTask.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L17">src/task/CreateSDPTask.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/CreateSDPTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L13">src/task/CreateSDPTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/CreateSDPTask.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L21">src/task/CreateSDPTask.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -245,7 +245,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -263,7 +263,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -288,7 +288,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -307,7 +307,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/CreateSDPTask.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L46">src/task/CreateSDPTask.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -324,7 +324,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreateSDPTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L26">src/task/CreateSDPTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/CreateSDPTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/CreateSDPTask.ts#L30">src/task/CreateSDPTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -360,7 +360,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/datamessage.html
+++ b/docs/classes/datamessage.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/datamessage/DataMessage.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L35">src/datamessage/DataMessage.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Uint8Array</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L19">src/datamessage/DataMessage.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L24">src/datamessage/DataMessage.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">sender<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L29">src/datamessage/DataMessage.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">throttled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L35">src/datamessage/DataMessage.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L9">src/datamessage/DataMessage.ts:9</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">topic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/datamessage/DataMessage.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L14">src/datamessage/DataMessage.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/datamessage/DataMessage.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L63">src/datamessage/DataMessage.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/datamessage/DataMessage.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/datamessage/DataMessage.ts#L56">src/datamessage/DataMessage.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/defaultactivespeakerdetector.html
+++ b/docs/classes/defaultactivespeakerdetector.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L34">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Speakers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L19">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">detector<wbr>Callback<wbr>ToActivity<wbr>Timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#detectorcallback" class="tsd-signature-type">DetectorCallback</a><span class="tsd-signature-symbol">, </span><a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;DetectorCallback,IntervalScheduler&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L28">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">detector<wbr>Callback<wbr>ToHandler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#detectorcallback" class="tsd-signature-type">DetectorCallback</a><span class="tsd-signature-symbol">, </span><a href="../globals.html#detectorhandler" class="tsd-signature-type">DetectorHandler</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;DetectorCallback,DetectorHandler&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L20">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">detector<wbr>Callback<wbr>ToScores<wbr>Timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#detectorcallback" class="tsd-signature-type">DetectorCallback</a><span class="tsd-signature-symbol">, </span><a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;DetectorCallback,IntervalScheduler&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L24">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Bandwidth<wbr>Priority<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L32">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Bandwidth<wbr>Priority<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>hasBandwidthPriority<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L39">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:39</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">most<wbr>Recent<wbr>Update<wbr>Timestamp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L34">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -284,7 +284,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L37">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -294,7 +294,7 @@
 					<div class="tsd-signature tsd-kind-icon">self<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L38">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">speaker<wbr>Mute<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L17">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -322,7 +322,7 @@
 					<div class="tsd-signature tsd-kind-icon">speaker<wbr>Scores<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L16">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -340,7 +340,7 @@
 					<div class="tsd-signature tsd-kind-icon">update<wbr>Interval<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L41">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -350,7 +350,7 @@
 					<div class="tsd-signature tsd-kind-icon">wait<wbr>Interval<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L40">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L44">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -390,7 +390,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:106</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L106">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:106</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -445,7 +445,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:157</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L157">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:157</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -468,7 +468,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L54">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -497,7 +497,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L91">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultactivespeakerpolicy.html
+++ b/docs/classes/defaultactivespeakerpolicy.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L10">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 					<div class="tsd-signature tsd-kind-icon">cutoff<wbr>Threshold<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L44">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 					<div class="tsd-signature tsd-kind-icon">silence<wbr>Threshold<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:45</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L45">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:45</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 					<div class="tsd-signature tsd-kind-icon">speaker<wbr>Weight<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:43</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L43">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 					<div class="tsd-signature tsd-kind-icon">takeover<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L46">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 					<div class="tsd-signature tsd-kind-icon">volumes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L10">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:10</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/activespeakerpolicy.html">ActiveSpeakerPolicy</a>.<a href="../interfaces/activespeakerpolicy.html#calculatescore">calculateScore</a></p>
 								<ul>
-									<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L49">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -323,7 +323,7 @@ updatedCurrentAttendeeScore = currentAttendeeExistingScore * speakerWeight + cur
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/activespeakerpolicy.html">ActiveSpeakerPolicy</a>.<a href="../interfaces/activespeakerpolicy.html#prioritizevideosendbandwidthforactivespeaker">prioritizeVideoSendBandwidthForActiveSpeaker</a></p>
 								<ul>
-									<li>Defined in src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts#L77">src/activespeakerpolicy/DefaultActiveSpeakerPolicy.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/defaultaudiomixcontroller.html
+++ b/docs/classes/defaultaudiomixcontroller.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Device<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L9">src/audiomixcontroller/DefaultAudioMixController.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLAudioElement</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L10">src/audiomixcontroller/DefaultAudioMixController.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L11">src/audiomixcontroller/DefaultAudioMixController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a><span class="tsd-signature-symbol"> = new DefaultBrowserBehavior()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L12">src/audiomixcontroller/DefaultAudioMixController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudiodevice">bindAudioDevice</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L38">src/audiomixcontroller/DefaultAudioMixController.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -186,7 +186,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L14">src/audiomixcontroller/DefaultAudioMixController.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L46">src/audiomixcontroller/DefaultAudioMixController.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#bindaudiostream">bindAudioStream</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L30">src/audiomixcontroller/DefaultAudioMixController.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiomixcontroller.html">AudioMixController</a>.<a href="../interfaces/audiomixcontroller.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/DefaultAudioMixController.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/DefaultAudioMixController.ts#L23">src/audiomixcontroller/DefaultAudioMixController.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L93">src/audiovideocontroller/DefaultAudioVideoController.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">_active<wbr>Speaker<wbr>Detector<span class="tsd-signature-symbol">:</span> <a href="../interfaces/activespeakerdetector.html" class="tsd-signature-type">ActiveSpeakerDetector</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:78</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L78">src/audiovideocontroller/DefaultAudioVideoController.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">_audio<wbr>Mix<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:82</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L82">src/audiovideocontroller/DefaultAudioVideoController.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">_configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:75</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L75">src/audiovideocontroller/DefaultAudioVideoController.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">_logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:74</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L74">src/audiovideocontroller/DefaultAudioVideoController.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">_media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:80</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L80">src/audiovideocontroller/DefaultAudioVideoController.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">_realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:77</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L77">src/audiovideocontroller/DefaultAudioVideoController.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">_reconnect<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/reconnectcontroller.html" class="tsd-signature-type">ReconnectController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:81</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L81">src/audiovideocontroller/DefaultAudioVideoController.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">_video<wbr>Tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:79</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L79">src/audiovideocontroller/DefaultAudioVideoController.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">_web<wbr>Socket<wbr>Adapter<span class="tsd-signature-symbol">:</span> <a href="../interfaces/websocketadapter.html" class="tsd-signature-type">WebSocketAdapter</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:76</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L76">src/audiovideocontroller/DefaultAudioVideoController.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Health<wbr>Data<span class="tsd-signature-symbol">:</span> <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a><span class="tsd-signature-symbol"> = new ConnectionHealthData()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:84</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L84">src/audiovideocontroller/DefaultAudioVideoController.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Simulcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:93</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L93">src/audiovideocontroller/DefaultAudioVideoController.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">meeting<wbr>Session<wbr>Context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a><span class="tsd-signature-symbol"> = new AudioVideoControllerState()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:86</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L86">src/audiovideocontroller/DefaultAudioVideoController.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -328,7 +328,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/audiovideoobserver.html" class="tsd-signature-type">AudioVideoObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;AudioVideoObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:85</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L85">src/audiovideocontroller/DefaultAudioVideoController.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">session<wbr>State<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/sessionstatecontroller.html" class="tsd-signature-type">SessionStateController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:87</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L87">src/audiovideocontroller/DefaultAudioVideoController.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -348,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAX_<wbr>VOLUME_<wbr>DECIBELS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = -14</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:90</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L90">src/audiovideocontroller/DefaultAudioVideoController.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -358,7 +358,7 @@
 					<div class="tsd-signature tsd-kind-icon">MIN_<wbr>VOLUME_<wbr>DECIBELS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = -42</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:89</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L89">src/audiovideocontroller/DefaultAudioVideoController.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -368,7 +368,7 @@
 					<div class="tsd-signature tsd-kind-icon">PING_<wbr>PONG_<wbr>INTERVAL_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:91</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L91">src/audiovideocontroller/DefaultAudioVideoController.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -385,7 +385,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:142</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L142">src/audiovideocontroller/DefaultAudioVideoController.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/activespeakerdetector.html" class="tsd-signature-type">ActiveSpeakerDetector</a></h4>
@@ -402,7 +402,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L150">src/audiovideocontroller/DefaultAudioVideoController.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a></h4>
@@ -419,7 +419,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L134">src/audiovideocontroller/DefaultAudioVideoController.ts:134</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></h4>
@@ -436,7 +436,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:154</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L154">src/audiovideocontroller/DefaultAudioVideoController.ts:154</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h4>
@@ -453,7 +453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:162</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L162">src/audiovideocontroller/DefaultAudioVideoController.ts:162</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></h4>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L138">src/audiovideocontroller/DefaultAudioVideoController.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></h4>
@@ -487,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:158</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L158">src/audiovideocontroller/DefaultAudioVideoController.ts:158</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCPeerConnection</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -504,7 +504,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:146</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L146">src/audiovideocontroller/DefaultAudioVideoController.ts:146</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></h4>
@@ -524,7 +524,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:199</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L199">src/audiovideocontroller/DefaultAudioVideoController.ts:199</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -547,7 +547,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:390</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L390">src/audiovideocontroller/DefaultAudioVideoController.ts:390</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -573,7 +573,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:370</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L370">src/audiovideocontroller/DefaultAudioVideoController.ts:370</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -590,7 +590,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:534</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L534">src/audiovideocontroller/DefaultAudioVideoController.ts:534</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -607,7 +607,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:569</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L569">src/audiovideocontroller/DefaultAudioVideoController.ts:569</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -624,7 +624,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:498</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L498">src/audiovideocontroller/DefaultAudioVideoController.ts:498</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -648,7 +648,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:173</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L173">src/audiovideocontroller/DefaultAudioVideoController.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -671,7 +671,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:638</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L638">src/audiovideocontroller/DefaultAudioVideoController.ts:638</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -694,7 +694,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:183</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L183">src/audiovideocontroller/DefaultAudioVideoController.ts:183</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -735,7 +735,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:629</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L629">src/audiovideocontroller/DefaultAudioVideoController.ts:629</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -759,7 +759,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:166</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L166">src/audiovideocontroller/DefaultAudioVideoController.ts:166</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -782,7 +782,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:709</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L709">src/audiovideocontroller/DefaultAudioVideoController.ts:709</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -806,7 +806,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:652</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L652">src/audiovideocontroller/DefaultAudioVideoController.ts:652</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -833,7 +833,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:731</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L731">src/audiovideocontroller/DefaultAudioVideoController.ts:731</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -857,7 +857,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:543</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L543">src/audiovideocontroller/DefaultAudioVideoController.ts:543</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -881,7 +881,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:178</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L178">src/audiovideocontroller/DefaultAudioVideoController.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:459</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L459">src/audiovideocontroller/DefaultAudioVideoController.ts:459</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -939,7 +939,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:436</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L436">src/audiovideocontroller/DefaultAudioVideoController.ts:436</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -975,7 +975,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:737</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L737">src/audiovideocontroller/DefaultAudioVideoController.ts:737</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -999,7 +999,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:700</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L700">src/audiovideocontroller/DefaultAudioVideoController.ts:700</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1023,7 +1023,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:193</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L193">src/audiovideocontroller/DefaultAudioVideoController.ts:193</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1041,7 +1041,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:384</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L384">src/audiovideocontroller/DefaultAudioVideoController.ts:384</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1059,7 +1059,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#update">update</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:426</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L426">src/audiovideocontroller/DefaultAudioVideoController.ts:426</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1076,7 +1076,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:625</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L625">src/audiovideocontroller/DefaultAudioVideoController.ts:625</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultaudiovideofacade.html
+++ b/docs/classes/defaultaudiovideofacade.html
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L21">src/audiovideofacade/DefaultAudioVideoFacade.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Mix<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L26">src/audiovideofacade/DefaultAudioVideoFacade.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L23">src/audiovideofacade/DefaultAudioVideoFacade.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Share<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/contentsharecontroller.html" class="tsd-signature-type">ContentShareController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L28">src/audiovideofacade/DefaultAudioVideoFacade.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicecontroller.html" class="tsd-signature-type">DeviceController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L27">src/audiovideofacade/DefaultAudioVideoFacade.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L25">src/audiovideofacade/DefaultAudioVideoFacade.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L24">src/audiovideofacade/DefaultAudioVideoFacade.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:439</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L439">src/audiovideofacade/DefaultAudioVideoFacade.ts:439</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -320,7 +320,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:346</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L346">src/audiovideofacade/DefaultAudioVideoFacade.ts:346</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L31">src/audiovideofacade/DefaultAudioVideoFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -368,7 +368,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addvideotile">addVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:133</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L133">src/audiovideofacade/DefaultAudioVideoFacade.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a></h4>
@@ -386,7 +386,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L56">src/audiovideofacade/DefaultAudioVideoFacade.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L67">src/audiovideofacade/DefaultAudioVideoFacade.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -437,7 +437,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:155</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L155">src/audiovideofacade/DefaultAudioVideoFacade.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -461,7 +461,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:328</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L328">src/audiovideofacade/DefaultAudioVideoFacade.ts:328</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -485,7 +485,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:340</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L340">src/audiovideofacade/DefaultAudioVideoFacade.ts:340</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -509,7 +509,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:334</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L334">src/audiovideofacade/DefaultAudioVideoFacade.ts:334</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -533,7 +533,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:383</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L383">src/audiovideofacade/DefaultAudioVideoFacade.ts:383</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:356</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L356">src/audiovideofacade/DefaultAudioVideoFacade.ts:356</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AnalyserNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -584,7 +584,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:404</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L404">src/audiovideofacade/DefaultAudioVideoFacade.ts:404</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -608,7 +608,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L121">src/audiovideofacade/DefaultAudioVideoFacade.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -626,7 +626,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L127">src/audiovideofacade/DefaultAudioVideoFacade.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -644,7 +644,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L99">src/audiovideofacade/DefaultAudioVideoFacade.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -662,7 +662,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L51">src/audiovideofacade/DefaultAudioVideoFacade.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -686,7 +686,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:398</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L398">src/audiovideofacade/DefaultAudioVideoFacade.ts:398</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -704,7 +704,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:115</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L115">src/audiovideofacade/DefaultAudioVideoFacade.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -728,7 +728,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#hasstartedlocalvideotile">hasStartedLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L88">src/audiovideofacade/DefaultAudioVideoFacade.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -746,7 +746,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:310</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L310">src/audiovideofacade/DefaultAudioVideoFacade.ts:310</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -764,7 +764,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:322</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L322">src/audiovideofacade/DefaultAudioVideoFacade.ts:322</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -782,7 +782,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:316</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L316">src/audiovideofacade/DefaultAudioVideoFacade.ts:316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -800,7 +800,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:377</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L377">src/audiovideofacade/DefaultAudioVideoFacade.ts:377</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -824,7 +824,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:424</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L424">src/audiovideofacade/DefaultAudioVideoFacade.ts:424</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -842,7 +842,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:105</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L105">src/audiovideofacade/DefaultAudioVideoFacade.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -866,7 +866,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:199</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L199">src/audiovideofacade/DefaultAudioVideoFacade.ts:199</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -884,7 +884,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:225</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L225">src/audiovideofacade/DefaultAudioVideoFacade.ts:225</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -902,7 +902,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:205</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L205">src/audiovideofacade/DefaultAudioVideoFacade.ts:205</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -920,7 +920,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:260</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L260">src/audiovideofacade/DefaultAudioVideoFacade.ts:260</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -950,7 +950,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L185">src/audiovideofacade/DefaultAudioVideoFacade.ts:185</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -973,7 +973,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:161</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L161">src/audiovideofacade/DefaultAudioVideoFacade.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1023,7 +1023,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:282</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L282">src/audiovideofacade/DefaultAudioVideoFacade.ts:282</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1064,7 +1064,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:250</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L250">src/audiovideofacade/DefaultAudioVideoFacade.ts:250</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1105,7 +1105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:216</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L216">src/audiovideofacade/DefaultAudioVideoFacade.ts:216</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1146,7 +1146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:269</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L269">src/audiovideofacade/DefaultAudioVideoFacade.ts:269</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1190,7 +1190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:190</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L190">src/audiovideofacade/DefaultAudioVideoFacade.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1231,7 +1231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:231</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L231">src/audiovideofacade/DefaultAudioVideoFacade.ts:231</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1288,7 +1288,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:210</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L210">src/audiovideofacade/DefaultAudioVideoFacade.ts:210</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1306,7 +1306,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:277</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L277">src/audiovideofacade/DefaultAudioVideoFacade.ts:277</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1330,7 +1330,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:245</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L245">src/audiovideofacade/DefaultAudioVideoFacade.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1353,7 +1353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:173</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L173">src/audiovideofacade/DefaultAudioVideoFacade.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1403,7 +1403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:286</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L286">src/audiovideofacade/DefaultAudioVideoFacade.ts:286</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1444,7 +1444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:255</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L255">src/audiovideofacade/DefaultAudioVideoFacade.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1485,7 +1485,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:221</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L221">src/audiovideofacade/DefaultAudioVideoFacade.ts:221</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1526,7 +1526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:195</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L195">src/audiovideofacade/DefaultAudioVideoFacade.ts:195</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1568,7 +1568,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L150">src/audiovideofacade/DefaultAudioVideoFacade.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1586,7 +1586,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:444</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L444">src/audiovideofacade/DefaultAudioVideoFacade.ts:444</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1610,7 +1610,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:351</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L351">src/audiovideofacade/DefaultAudioVideoFacade.ts:351</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1634,7 +1634,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removelocalvideotile">removeLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L94">src/audiovideofacade/DefaultAudioVideoFacade.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1652,7 +1652,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L36">src/audiovideofacade/DefaultAudioVideoFacade.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1676,7 +1676,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:139</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L139">src/audiovideofacade/DefaultAudioVideoFacade.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1700,7 +1700,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:144</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L144">src/audiovideofacade/DefaultAudioVideoFacade.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1723,7 +1723,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:372</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L372">src/audiovideofacade/DefaultAudioVideoFacade.ts:372</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1759,7 +1759,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L41">src/audiovideofacade/DefaultAudioVideoFacade.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1777,7 +1777,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:409</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L409">src/audiovideofacade/DefaultAudioVideoFacade.ts:409</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1801,7 +1801,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:415</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L415">src/audiovideofacade/DefaultAudioVideoFacade.ts:415</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1828,7 +1828,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startlocalvideotile">startLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L77">src/audiovideofacade/DefaultAudioVideoFacade.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -1846,7 +1846,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:362</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L362">src/audiovideofacade/DefaultAudioVideoFacade.ts:362</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1870,7 +1870,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L46">src/audiovideofacade/DefaultAudioVideoFacade.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1888,7 +1888,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:434</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L434">src/audiovideofacade/DefaultAudioVideoFacade.ts:434</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1906,7 +1906,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stoplocalvideotile">stopLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L83">src/audiovideofacade/DefaultAudioVideoFacade.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1924,7 +1924,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:367</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L367">src/audiovideofacade/DefaultAudioVideoFacade.ts:367</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1947,7 +1947,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:290</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L290">src/audiovideofacade/DefaultAudioVideoFacade.ts:290</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2020,7 +2020,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:450</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L450">src/audiovideofacade/DefaultAudioVideoFacade.ts:450</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2050,7 +2050,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L62">src/audiovideofacade/DefaultAudioVideoFacade.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2068,7 +2068,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unbindvideoelement">unbindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L72">src/audiovideofacade/DefaultAudioVideoFacade.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2092,7 +2092,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:429</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L429">src/audiovideofacade/DefaultAudioVideoFacade.ts:429</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2110,7 +2110,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:110</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L110">src/audiovideofacade/DefaultAudioVideoFacade.ts:110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2133,7 +2133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideofacade/DefaultAudioVideoFacade.ts:305</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L305">src/audiovideofacade/DefaultAudioVideoFacade.ts:305</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultbrowserbehavior.html
+++ b/docs/classes/defaultbrowserbehavior.html
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L32">src/browserbehavior/DefaultBrowserBehavior.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BrowserInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">SearchBotDeviceInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">BotInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">NodeInfo</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">ReactNativeInfo</span><span class="tsd-signature-symbol"> = detect()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L9">src/browserbehavior/DefaultBrowserBehavior.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">chrome<wbr>Like<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&#x27;chrome&#x27;, &#x27;edge-chromium&#x27;, &#x27;chromium-webview&#x27;, &#x27;opera&#x27;]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L31">src/browserbehavior/DefaultBrowserBehavior.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Unified<wbr>Plan<wbr>For<wbr>Chromium<wbr>Based<wbr>Browsers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L32">src/browserbehavior/DefaultBrowserBehavior.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:124</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L124">src/browserbehavior/DefaultBrowserBehavior.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -237,7 +237,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#haschromiumwebrtc">hasChromiumWebRTC</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L52">src/browserbehavior/DefaultBrowserBehavior.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -255,7 +255,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#hasfirefoxwebrtc">hasFirefoxWebRTC</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L61">src/browserbehavior/DefaultBrowserBehavior.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:200</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L200">src/browserbehavior/DefaultBrowserBehavior.ts:200</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -289,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L192">src/browserbehavior/DefaultBrowserBehavior.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -306,7 +306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:196</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L196">src/browserbehavior/DefaultBrowserBehavior.ts:196</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:188</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L188">src/browserbehavior/DefaultBrowserBehavior.ts:188</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -340,7 +340,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:180</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L180">src/browserbehavior/DefaultBrowserBehavior.ts:180</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:204</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L204">src/browserbehavior/DefaultBrowserBehavior.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:184</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L184">src/browserbehavior/DefaultBrowserBehavior.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -392,7 +392,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#issupported">isSupported</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L135">src/browserbehavior/DefaultBrowserBehavior.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:208</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L208">src/browserbehavior/DefaultBrowserBehavior.ts:208</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -427,7 +427,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#majorversion">majorVersion</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L44">src/browserbehavior/DefaultBrowserBehavior.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -445,7 +445,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L48">src/browserbehavior/DefaultBrowserBehavior.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -463,7 +463,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiresbundlepolicy">requiresBundlePolicy</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L108">src/browserbehavior/DefaultBrowserBehavior.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCBundlePolicy</span></h4>
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requirescheckforsdpconnectionattributes">requiresCheckForSdpConnectionAttributes</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L84">src/browserbehavior/DefaultBrowserBehavior.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -499,7 +499,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiresicecandidategatheringtimeoutworkaround">requiresIceCandidateGatheringTimeoutWorkaround</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L88">src/browserbehavior/DefaultBrowserBehavior.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -517,7 +517,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiresnoexactmediastreamconstraints">requiresNoExactMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:120</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L120">src/browserbehavior/DefaultBrowserBehavior.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -535,7 +535,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requirespromisebasedwebrtcgetstats">requiresPromiseBasedWebRTCGetStats</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:112</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L112">src/browserbehavior/DefaultBrowserBehavior.ts:112</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -552,7 +552,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L77">src/browserbehavior/DefaultBrowserBehavior.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -579,7 +579,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiressimulcastmunging">requiresSimulcastMunging</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L104">src/browserbehavior/DefaultBrowserBehavior.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -597,7 +597,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiressortcodecpreferencesforsdpanswer">requiresSortCodecPreferencesForSdpAnswer</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L100">src/browserbehavior/DefaultBrowserBehavior.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -615,7 +615,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiresunifiedplan">requiresUnifiedPlan</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L69">src/browserbehavior/DefaultBrowserBehavior.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -633,7 +633,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#requiresunifiedplanmunging">requiresUnifiedPlanMunging</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L92">src/browserbehavior/DefaultBrowserBehavior.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -650,7 +650,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L116">src/browserbehavior/DefaultBrowserBehavior.ts:116</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -668,7 +668,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#screensharesendsonlykeyframes">screenShareSendsOnlyKeyframes</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L65">src/browserbehavior/DefaultBrowserBehavior.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -686,7 +686,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#screenshareunsupported">screenShareUnsupported</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L128">src/browserbehavior/DefaultBrowserBehavior.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -704,7 +704,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#supportstring">supportString</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:148</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L148">src/browserbehavior/DefaultBrowserBehavior.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -722,7 +722,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#supportedvideocodecs">supportedVideoCodecs</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:159</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L159">src/browserbehavior/DefaultBrowserBehavior.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -740,7 +740,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/browserbehavior.html">BrowserBehavior</a>.<a href="../interfaces/browserbehavior.html#version">version</a></p>
 								<ul>
-									<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L40">src/browserbehavior/DefaultBrowserBehavior.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -756,7 +756,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L21">src/browserbehavior/DefaultBrowserBehavior.ts:21</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -765,7 +765,7 @@
 						<div class="tsd-signature tsd-kind-icon">chrome<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Google Chrome&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:22</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L22">src/browserbehavior/DefaultBrowserBehavior.ts:22</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -775,7 +775,7 @@
 						<div class="tsd-signature tsd-kind-icon">edge-<wbr>chromium<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Microsoft Edge&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:23</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L23">src/browserbehavior/DefaultBrowserBehavior.ts:23</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -785,7 +785,7 @@
 						<div class="tsd-signature tsd-kind-icon">electron<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Electron&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:24</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L24">src/browserbehavior/DefaultBrowserBehavior.ts:24</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -795,7 +795,7 @@
 						<div class="tsd-signature tsd-kind-icon">firefox<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Mozilla Firefox&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:25</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L25">src/browserbehavior/DefaultBrowserBehavior.ts:25</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -805,7 +805,7 @@
 						<div class="tsd-signature tsd-kind-icon">ios<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Safari iOS&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:26</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L26">src/browserbehavior/DefaultBrowserBehavior.ts:26</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -815,7 +815,7 @@
 						<div class="tsd-signature tsd-kind-icon">opera<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Opera&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:28</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L28">src/browserbehavior/DefaultBrowserBehavior.ts:28</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -825,7 +825,7 @@
 						<div class="tsd-signature tsd-kind-icon">safari<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;Safari&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:27</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L27">src/browserbehavior/DefaultBrowserBehavior.ts:27</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -836,7 +836,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Support<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L11">src/browserbehavior/DefaultBrowserBehavior.ts:11</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -845,7 +845,7 @@
 						<div class="tsd-signature tsd-kind-icon">chrome<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 78</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:12</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L12">src/browserbehavior/DefaultBrowserBehavior.ts:12</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -855,7 +855,7 @@
 						<div class="tsd-signature tsd-kind-icon">edge-<wbr>chromium<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 79</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:13</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L13">src/browserbehavior/DefaultBrowserBehavior.ts:13</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -865,7 +865,7 @@
 						<div class="tsd-signature tsd-kind-icon">electron<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 7</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:14</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L14">src/browserbehavior/DefaultBrowserBehavior.ts:14</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -875,7 +875,7 @@
 						<div class="tsd-signature tsd-kind-icon">firefox<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 60</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:15</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L15">src/browserbehavior/DefaultBrowserBehavior.ts:15</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -885,7 +885,7 @@
 						<div class="tsd-signature tsd-kind-icon">ios<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 12</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:16</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L16">src/browserbehavior/DefaultBrowserBehavior.ts:16</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -895,7 +895,7 @@
 						<div class="tsd-signature tsd-kind-icon">opera<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 66</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:18</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L18">src/browserbehavior/DefaultBrowserBehavior.ts:18</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -905,7 +905,7 @@
 						<div class="tsd-signature tsd-kind-icon">safari<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 12</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/browserbehavior/DefaultBrowserBehavior.ts:17</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L17">src/browserbehavior/DefaultBrowserBehavior.ts:17</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/classes/defaultclientmetricreport.html
+++ b/docs/classes/defaultclientmetricreport.html
@@ -144,7 +144,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L17">src/clientmetricreport/DefaultClientMetricReport.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Ssrcs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L17">src/clientmetricreport/DefaultClientMetricReport.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L15">src/clientmetricreport/DefaultClientMetricReport.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">:</span> <a href="globalmetricreport.html" class="tsd-signature-type">GlobalMetricReport</a><span class="tsd-signature-symbol"> = new GlobalMetricReport()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L13">src/clientmetricreport/DefaultClientMetricReport.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L19">src/clientmetricreport/DefaultClientMetricReport.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L16">src/clientmetricreport/DefaultClientMetricReport.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -224,7 +224,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>Metric<wbr>Reports<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L14">src/clientmetricreport/DefaultClientMetricReport.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L80">src/clientmetricreport/DefaultClientMetricReport.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:420</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L420">src/clientmetricreport/DefaultClientMetricReport.ts:420</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L63">src/clientmetricreport/DefaultClientMetricReport.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L30">src/clientmetricreport/DefaultClientMetricReport.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:297</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L297">src/clientmetricreport/DefaultClientMetricReport.ts:297</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -412,7 +412,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:383</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L383">src/clientmetricreport/DefaultClientMetricReport.ts:383</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -436,7 +436,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/clientmetricreport.html">ClientMetricReport</a>.<a href="../interfaces/clientmetricreport.html#getobservablemetrics">getObservableMetrics</a></p>
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:408</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L408">src/clientmetricreport/DefaultClientMetricReport.ts:408</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{}</span></h4>
@@ -458,7 +458,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L25">src/clientmetricreport/DefaultClientMetricReport.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -489,7 +489,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L48">src/clientmetricreport/DefaultClientMetricReport.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -515,7 +515,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:429</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L429">src/clientmetricreport/DefaultClientMetricReport.ts:429</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -532,7 +532,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:441</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L441">src/clientmetricreport/DefaultClientMetricReport.ts:441</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -549,7 +549,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:98</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L98">src/clientmetricreport/DefaultClientMetricReport.ts:98</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -574,7 +574,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Downstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:171</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L171">src/clientmetricreport/DefaultClientMetricReport.ts:171</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -583,7 +583,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:192</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -592,7 +592,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -602,7 +602,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -613,7 +613,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Current<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:193</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L193">src/clientmetricreport/DefaultClientMetricReport.ts:193</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -622,7 +622,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:194</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L194">src/clientmetricreport/DefaultClientMetricReport.ts:194</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -632,7 +632,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_CURRENT_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_CURRENT_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:195</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L195">src/clientmetricreport/DefaultClientMetricReport.ts:195</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -643,7 +643,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>DecodingCTN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:186</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L186">src/clientmetricreport/DefaultClientMetricReport.ts:186</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -652,7 +652,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:186</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L186">src/clientmetricreport/DefaultClientMetricReport.ts:186</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -663,7 +663,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Decoding<wbr>Normal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:187</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L187">src/clientmetricreport/DefaultClientMetricReport.ts:187</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -672,7 +672,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googDecodingCTN&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:190</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -682,7 +682,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.decoderLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:188</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L188">src/clientmetricreport/DefaultClientMetricReport.ts:188</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -692,7 +692,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_FRACTION_DECODER_LOSS_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_FRACTION_DECODER_LOSS_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:189</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L189">src/clientmetricreport/DefaultClientMetricReport.ts:189</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -703,7 +703,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Buffer<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:197</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L197">src/clientmetricreport/DefaultClientMetricReport.ts:197</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -712,7 +712,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:198</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L198">src/clientmetricreport/DefaultClientMetricReport.ts:198</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -722,7 +722,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_BUFFER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_BUFFER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:199</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L199">src/clientmetricreport/DefaultClientMetricReport.ts:199</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -733,7 +733,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:184</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -742,7 +742,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:184</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -752,7 +752,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:184</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -763,7 +763,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:185</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L185">src/clientmetricreport/DefaultClientMetricReport.ts:185</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -772,7 +772,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L185">src/clientmetricreport/DefaultClientMetricReport.ts:185</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -782,7 +782,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L185">src/clientmetricreport/DefaultClientMetricReport.ts:185</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -793,7 +793,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:179</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L179">src/clientmetricreport/DefaultClientMetricReport.ts:179</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -802,7 +802,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:182</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L182">src/clientmetricreport/DefaultClientMetricReport.ts:182</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -812,7 +812,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:180</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L180">src/clientmetricreport/DefaultClientMetricReport.ts:180</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -822,7 +822,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:181</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L181">src/clientmetricreport/DefaultClientMetricReport.ts:181</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -833,7 +833,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:178</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L178">src/clientmetricreport/DefaultClientMetricReport.ts:178</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -842,7 +842,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:178</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L178">src/clientmetricreport/DefaultClientMetricReport.ts:178</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -852,7 +852,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:178</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L178">src/clientmetricreport/DefaultClientMetricReport.ts:178</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -864,7 +864,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Upstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:152</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L152">src/clientmetricreport/DefaultClientMetricReport.ts:152</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -873,7 +873,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:162</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L162">src/clientmetricreport/DefaultClientMetricReport.ts:162</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -882,7 +882,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:162</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L162">src/clientmetricreport/DefaultClientMetricReport.ts:162</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -892,7 +892,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:162</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L162">src/clientmetricreport/DefaultClientMetricReport.ts:162</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -903,7 +903,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:159</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L159">src/clientmetricreport/DefaultClientMetricReport.ts:159</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -912,7 +912,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:159</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L159">src/clientmetricreport/DefaultClientMetricReport.ts:159</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -922,7 +922,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:159</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L159">src/clientmetricreport/DefaultClientMetricReport.ts:159</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -933,7 +933,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:163</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L163">src/clientmetricreport/DefaultClientMetricReport.ts:163</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -942,7 +942,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:163</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L163">src/clientmetricreport/DefaultClientMetricReport.ts:163</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -952,7 +952,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:163</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L163">src/clientmetricreport/DefaultClientMetricReport.ts:163</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -963,7 +963,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:160</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L160">src/clientmetricreport/DefaultClientMetricReport.ts:160</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -972,7 +972,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:160</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L160">src/clientmetricreport/DefaultClientMetricReport.ts:160</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -982,7 +982,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:160</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L160">src/clientmetricreport/DefaultClientMetricReport.ts:160</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -993,7 +993,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:164</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L164">src/clientmetricreport/DefaultClientMetricReport.ts:164</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1002,7 +1002,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:167</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1012,7 +1012,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:165</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1022,7 +1022,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:166</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1033,7 +1033,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:161</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L161">src/clientmetricreport/DefaultClientMetricReport.ts:161</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1042,7 +1042,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:161</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L161">src/clientmetricreport/DefaultClientMetricReport.ts:161</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1052,7 +1052,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:161</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L161">src/clientmetricreport/DefaultClientMetricReport.ts:161</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1064,7 +1064,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:107</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L107">src/clientmetricreport/DefaultClientMetricReport.ts:107</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1078,7 +1078,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Incoming<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:141</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L141">src/clientmetricreport/DefaultClientMetricReport.ts:141</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1087,7 +1087,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:142</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L142">src/clientmetricreport/DefaultClientMetricReport.ts:142</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1097,7 +1097,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L143">src/clientmetricreport/DefaultClientMetricReport.ts:143</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1108,7 +1108,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Outgoing<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:145</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L145">src/clientmetricreport/DefaultClientMetricReport.ts:145</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1117,7 +1117,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:146</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L146">src/clientmetricreport/DefaultClientMetricReport.ts:146</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1127,7 +1127,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_SEND_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_SEND_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:147</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L147">src/clientmetricreport/DefaultClientMetricReport.ts:147</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1138,7 +1138,7 @@
 						<div class="tsd-signature tsd-kind-icon">current<wbr>Round<wbr>Trip<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:149</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L149">src/clientmetricreport/DefaultClientMetricReport.ts:149</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1147,7 +1147,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:149</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L149">src/clientmetricreport/DefaultClientMetricReport.ts:149</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1157,7 +1157,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">STUN_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.STUN_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:149</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L149">src/clientmetricreport/DefaultClientMetricReport.ts:149</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1168,7 +1168,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Actual<wbr>Enc<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:114</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L114">src/clientmetricreport/DefaultClientMetricReport.ts:114</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1177,7 +1177,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:115</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L115">src/clientmetricreport/DefaultClientMetricReport.ts:115</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1187,7 +1187,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ACTUAL_ENCODER_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ACTUAL_ENCODER_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L116">src/clientmetricreport/DefaultClientMetricReport.ts:116</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1198,7 +1198,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Available<wbr>Receive<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:126</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L126">src/clientmetricreport/DefaultClientMetricReport.ts:126</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1207,7 +1207,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L127">src/clientmetricreport/DefaultClientMetricReport.ts:127</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1217,7 +1217,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L128">src/clientmetricreport/DefaultClientMetricReport.ts:128</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1228,7 +1228,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Available<wbr>Send<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:118</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L118">src/clientmetricreport/DefaultClientMetricReport.ts:118</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1237,7 +1237,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L119">src/clientmetricreport/DefaultClientMetricReport.ts:119</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1247,7 +1247,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_SEND_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_SEND_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:120</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L120">src/clientmetricreport/DefaultClientMetricReport.ts:120</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1258,7 +1258,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Bucket<wbr>Delay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:134</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L134">src/clientmetricreport/DefaultClientMetricReport.ts:134</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1267,7 +1267,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L134">src/clientmetricreport/DefaultClientMetricReport.ts:134</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1277,7 +1277,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_BUCKET_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_BUCKET_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L134">src/clientmetricreport/DefaultClientMetricReport.ts:134</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1288,7 +1288,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Retransmit<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:122</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L122">src/clientmetricreport/DefaultClientMetricReport.ts:122</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1297,7 +1297,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L123">src/clientmetricreport/DefaultClientMetricReport.ts:123</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1307,7 +1307,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RETRANSMIT_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RETRANSMIT_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:124</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L124">src/clientmetricreport/DefaultClientMetricReport.ts:124</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1318,7 +1318,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:135</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L135">src/clientmetricreport/DefaultClientMetricReport.ts:135</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1327,7 +1327,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L135">src/clientmetricreport/DefaultClientMetricReport.ts:135</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1337,7 +1337,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">STUN_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.STUN_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L135">src/clientmetricreport/DefaultClientMetricReport.ts:135</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1348,7 +1348,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Target<wbr>Enc<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:130</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L130">src/clientmetricreport/DefaultClientMetricReport.ts:130</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1357,7 +1357,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:131</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L131">src/clientmetricreport/DefaultClientMetricReport.ts:131</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1367,7 +1367,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_TARGET_ENCODER_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_TARGET_ENCODER_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:132</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L132">src/clientmetricreport/DefaultClientMetricReport.ts:132</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1378,7 +1378,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Discarded<wbr>OnSend<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:136</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L136">src/clientmetricreport/DefaultClientMetricReport.ts:136</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1387,7 +1387,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:137</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L137">src/clientmetricreport/DefaultClientMetricReport.ts:137</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1397,7 +1397,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SOCKET_DISCARDED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.SOCKET_DISCARDED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L138">src/clientmetricreport/DefaultClientMetricReport.ts:138</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1409,7 +1409,7 @@
 					<div class="tsd-signature tsd-kind-icon">observable<wbr>Metric<wbr>Spec<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:331</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L331">src/clientmetricreport/DefaultClientMetricReport.ts:331</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1423,7 +1423,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Decoder<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:348</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L348">src/clientmetricreport/DefaultClientMetricReport.ts:348</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1432,7 +1432,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:351</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L351">src/clientmetricreport/DefaultClientMetricReport.ts:351</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1442,7 +1442,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:350</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L350">src/clientmetricreport/DefaultClientMetricReport.ts:350</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1452,7 +1452,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googDecodingNormal&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:349</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L349">src/clientmetricreport/DefaultClientMetricReport.ts:349</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1463,7 +1463,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:338</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L338">src/clientmetricreport/DefaultClientMetricReport.ts:338</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1472,7 +1472,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:341</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L341">src/clientmetricreport/DefaultClientMetricReport.ts:341</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1482,7 +1482,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:340</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L340">src/clientmetricreport/DefaultClientMetricReport.ts:340</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1492,7 +1492,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:339</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L339">src/clientmetricreport/DefaultClientMetricReport.ts:339</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1503,7 +1503,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packets<wbr>Received<wbr>Fraction<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:343</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L343">src/clientmetricreport/DefaultClientMetricReport.ts:343</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1512,7 +1512,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:346</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L346">src/clientmetricreport/DefaultClientMetricReport.ts:346</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1522,7 +1522,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:345</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L345">src/clientmetricreport/DefaultClientMetricReport.ts:345</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1532,7 +1532,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsLost&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:344</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L344">src/clientmetricreport/DefaultClientMetricReport.ts:344</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1543,7 +1543,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Speaker<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:361</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L361">src/clientmetricreport/DefaultClientMetricReport.ts:361</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1552,7 +1552,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:364</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L364">src/clientmetricreport/DefaultClientMetricReport.ts:364</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1562,7 +1562,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:363</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L363">src/clientmetricreport/DefaultClientMetricReport.ts:363</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1572,7 +1572,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googCurrentDelayMs&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:362</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L362">src/clientmetricreport/DefaultClientMetricReport.ts:362</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1583,7 +1583,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Incoming<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:368</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L368">src/clientmetricreport/DefaultClientMetricReport.ts:368</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1592,7 +1592,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;availableIncomingBitrate&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:368</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L368">src/clientmetricreport/DefaultClientMetricReport.ts:368</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1603,7 +1603,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Outgoing<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:369</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L369">src/clientmetricreport/DefaultClientMetricReport.ts:369</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1612,7 +1612,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;availableOutgoingBitrate&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:369</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L369">src/clientmetricreport/DefaultClientMetricReport.ts:369</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1623,7 +1623,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Receive<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:360</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L360">src/clientmetricreport/DefaultClientMetricReport.ts:360</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1632,7 +1632,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googAvailableReceiveBandwidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:360</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L360">src/clientmetricreport/DefaultClientMetricReport.ts:360</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1643,7 +1643,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Send<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:359</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L359">src/clientmetricreport/DefaultClientMetricReport.ts:359</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1652,7 +1652,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googAvailableSendBandwidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:359</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L359">src/clientmetricreport/DefaultClientMetricReport.ts:359</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1663,7 +1663,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nack<wbr>Count<wbr>Received<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:376</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L376">src/clientmetricreport/DefaultClientMetricReport.ts:376</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1672,7 +1672,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:379</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L379">src/clientmetricreport/DefaultClientMetricReport.ts:379</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1682,7 +1682,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:378</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L378">src/clientmetricreport/DefaultClientMetricReport.ts:378</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1692,7 +1692,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googNacksReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:377</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L377">src/clientmetricreport/DefaultClientMetricReport.ts:377</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1703,7 +1703,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<wbr>Received<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:371</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L371">src/clientmetricreport/DefaultClientMetricReport.ts:371</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1712,7 +1712,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:374</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L374">src/clientmetricreport/DefaultClientMetricReport.ts:374</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1722,7 +1722,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:373</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L373">src/clientmetricreport/DefaultClientMetricReport.ts:373</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1732,7 +1732,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;nackCount&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:372</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L372">src/clientmetricreport/DefaultClientMetricReport.ts:372</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1743,7 +1743,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Packet<wbr>Sent<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:354</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L354">src/clientmetricreport/DefaultClientMetricReport.ts:354</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1752,7 +1752,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:357</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L357">src/clientmetricreport/DefaultClientMetricReport.ts:357</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1762,7 +1762,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:356</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L356">src/clientmetricreport/DefaultClientMetricReport.ts:356</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1772,7 +1772,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:355</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L355">src/clientmetricreport/DefaultClientMetricReport.ts:355</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1783,7 +1783,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:353</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L353">src/clientmetricreport/DefaultClientMetricReport.ts:353</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1792,7 +1792,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:353</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L353">src/clientmetricreport/DefaultClientMetricReport.ts:353</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1802,7 +1802,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:353</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L353">src/clientmetricreport/DefaultClientMetricReport.ts:353</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1812,7 +1812,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;bytesSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:353</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L353">src/clientmetricreport/DefaultClientMetricReport.ts:353</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1824,7 +1824,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:242</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L242">src/clientmetricreport/DefaultClientMetricReport.ts:242</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -1833,7 +1833,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:277</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L277">src/clientmetricreport/DefaultClientMetricReport.ts:277</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1842,7 +1842,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:277</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L277">src/clientmetricreport/DefaultClientMetricReport.ts:277</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1852,7 +1852,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:277</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L277">src/clientmetricreport/DefaultClientMetricReport.ts:277</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1863,7 +1863,7 @@
 						<div class="tsd-signature tsd-kind-icon">discarded<wbr>Packets<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:286</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1872,7 +1872,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:286</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1882,7 +1882,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DISCARDED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DISCARDED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:286</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1893,7 +1893,7 @@
 						<div class="tsd-signature tsd-kind-icon">fir<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:274</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L274">src/clientmetricreport/DefaultClientMetricReport.ts:274</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1902,7 +1902,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:274</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L274">src/clientmetricreport/DefaultClientMetricReport.ts:274</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1912,7 +1912,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:274</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L274">src/clientmetricreport/DefaultClientMetricReport.ts:274</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1923,7 +1923,7 @@
 						<div class="tsd-signature tsd-kind-icon">framerate<wbr>Mean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:269</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1932,7 +1932,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:269</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1942,7 +1942,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:269</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1953,7 +1953,7 @@
 						<div class="tsd-signature tsd-kind-icon">frames<wbr>Decoded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:270</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L270">src/clientmetricreport/DefaultClientMetricReport.ts:270</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1962,7 +1962,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:270</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L270">src/clientmetricreport/DefaultClientMetricReport.ts:270</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1972,7 +1972,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:270</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L270">src/clientmetricreport/DefaultClientMetricReport.ts:270</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1983,7 +1983,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Current<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:278</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L278">src/clientmetricreport/DefaultClientMetricReport.ts:278</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1992,7 +1992,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:279</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L279">src/clientmetricreport/DefaultClientMetricReport.ts:279</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2002,7 +2002,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_CURRENT_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_CURRENT_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:280</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L280">src/clientmetricreport/DefaultClientMetricReport.ts:280</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2013,7 +2013,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Decode<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:253</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2022,7 +2022,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:253</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2032,7 +2032,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:253</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2043,7 +2043,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Firs<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:273</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L273">src/clientmetricreport/DefaultClientMetricReport.ts:273</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2052,7 +2052,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:273</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L273">src/clientmetricreport/DefaultClientMetricReport.ts:273</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2062,7 +2062,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:273</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L273">src/clientmetricreport/DefaultClientMetricReport.ts:273</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2073,7 +2073,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Output<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:254</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L254">src/clientmetricreport/DefaultClientMetricReport.ts:254</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2082,7 +2082,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:254</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L254">src/clientmetricreport/DefaultClientMetricReport.ts:254</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2092,7 +2092,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_OUTPUT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_OUTPUT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:254</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L254">src/clientmetricreport/DefaultClientMetricReport.ts:254</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2103,7 +2103,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:265</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L265">src/clientmetricreport/DefaultClientMetricReport.ts:265</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2112,7 +2112,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:266</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L266">src/clientmetricreport/DefaultClientMetricReport.ts:266</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2122,7 +2122,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:267</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2133,7 +2133,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Buffer<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:282</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L282">src/clientmetricreport/DefaultClientMetricReport.ts:282</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2142,7 +2142,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:283</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2152,7 +2152,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_JITTER_BUFFER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_JITTER_BUFFER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:284</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2163,7 +2163,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:287</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2172,7 +2172,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:288</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2182,7 +2182,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:289</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2193,7 +2193,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nacks<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:271</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L271">src/clientmetricreport/DefaultClientMetricReport.ts:271</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2202,7 +2202,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:271</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L271">src/clientmetricreport/DefaultClientMetricReport.ts:271</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2212,7 +2212,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:271</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L271">src/clientmetricreport/DefaultClientMetricReport.ts:271</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2223,7 +2223,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Plis<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:275</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L275">src/clientmetricreport/DefaultClientMetricReport.ts:275</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2232,7 +2232,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:275</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L275">src/clientmetricreport/DefaultClientMetricReport.ts:275</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2242,7 +2242,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:275</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L275">src/clientmetricreport/DefaultClientMetricReport.ts:275</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2253,7 +2253,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Render<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:261</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L261">src/clientmetricreport/DefaultClientMetricReport.ts:261</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2262,7 +2262,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:262</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L262">src/clientmetricreport/DefaultClientMetricReport.ts:262</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2272,7 +2272,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RENDER_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RENDER_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:263</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L263">src/clientmetricreport/DefaultClientMetricReport.ts:263</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2283,7 +2283,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Target<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:249</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L249">src/clientmetricreport/DefaultClientMetricReport.ts:249</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2292,7 +2292,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:250</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L250">src/clientmetricreport/DefaultClientMetricReport.ts:250</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2302,7 +2302,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_TARGET_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_TARGET_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:251</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2313,7 +2313,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:291</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L291">src/clientmetricreport/DefaultClientMetricReport.ts:291</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2322,7 +2322,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:292</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L292">src/clientmetricreport/DefaultClientMetricReport.ts:292</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2332,7 +2332,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:293</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L293">src/clientmetricreport/DefaultClientMetricReport.ts:293</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2343,7 +2343,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:272</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L272">src/clientmetricreport/DefaultClientMetricReport.ts:272</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2352,7 +2352,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:272</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L272">src/clientmetricreport/DefaultClientMetricReport.ts:272</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2362,7 +2362,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:272</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L272">src/clientmetricreport/DefaultClientMetricReport.ts:272</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2373,7 +2373,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:256</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L256">src/clientmetricreport/DefaultClientMetricReport.ts:256</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2382,7 +2382,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:259</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L259">src/clientmetricreport/DefaultClientMetricReport.ts:259</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2392,7 +2392,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:257</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L257">src/clientmetricreport/DefaultClientMetricReport.ts:257</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2402,7 +2402,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:258</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L258">src/clientmetricreport/DefaultClientMetricReport.ts:258</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2413,7 +2413,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:255</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L255">src/clientmetricreport/DefaultClientMetricReport.ts:255</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2422,7 +2422,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:255</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L255">src/clientmetricreport/DefaultClientMetricReport.ts:255</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2432,7 +2432,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:255</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L255">src/clientmetricreport/DefaultClientMetricReport.ts:255</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2443,7 +2443,7 @@
 						<div class="tsd-signature tsd-kind-icon">pli<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:276</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L276">src/clientmetricreport/DefaultClientMetricReport.ts:276</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2452,7 +2452,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:276</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L276">src/clientmetricreport/DefaultClientMetricReport.ts:276</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2462,7 +2462,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:276</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L276">src/clientmetricreport/DefaultClientMetricReport.ts:276</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2474,7 +2474,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:203</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L203">src/clientmetricreport/DefaultClientMetricReport.ts:203</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -2483,7 +2483,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:238</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2492,7 +2492,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:238</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2502,7 +2502,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:238</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2513,7 +2513,7 @@
 						<div class="tsd-signature tsd-kind-icon">dropped<wbr>Frames<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:239</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L239">src/clientmetricreport/DefaultClientMetricReport.ts:239</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2522,7 +2522,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:239</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L239">src/clientmetricreport/DefaultClientMetricReport.ts:239</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2532,7 +2532,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DROPPED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DROPPED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:239</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L239">src/clientmetricreport/DefaultClientMetricReport.ts:239</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2543,7 +2543,7 @@
 						<div class="tsd-signature tsd-kind-icon">fir<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:223</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L223">src/clientmetricreport/DefaultClientMetricReport.ts:223</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2552,7 +2552,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:223</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L223">src/clientmetricreport/DefaultClientMetricReport.ts:223</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2562,7 +2562,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:223</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L223">src/clientmetricreport/DefaultClientMetricReport.ts:223</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2573,7 +2573,7 @@
 						<div class="tsd-signature tsd-kind-icon">framerate<wbr>Mean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:231</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L231">src/clientmetricreport/DefaultClientMetricReport.ts:231</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2582,7 +2582,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:231</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L231">src/clientmetricreport/DefaultClientMetricReport.ts:231</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2592,7 +2592,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:231</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L231">src/clientmetricreport/DefaultClientMetricReport.ts:231</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2603,7 +2603,7 @@
 						<div class="tsd-signature tsd-kind-icon">frames<wbr>Encoded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:229</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2612,7 +2612,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:229</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2622,7 +2622,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:229</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2633,7 +2633,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Avg<wbr>Encode<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:224</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L224">src/clientmetricreport/DefaultClientMetricReport.ts:224</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2642,7 +2642,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:225</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2652,7 +2652,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVERAGE_ENCODE_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVERAGE_ENCODE_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:226</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2663,7 +2663,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Encode<wbr>Usage<wbr>Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:211</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L211">src/clientmetricreport/DefaultClientMetricReport.ts:211</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2672,7 +2672,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:212</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L212">src/clientmetricreport/DefaultClientMetricReport.ts:212</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2682,7 +2682,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_USAGE_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_USAGE_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:213</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L213">src/clientmetricreport/DefaultClientMetricReport.ts:213</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2693,7 +2693,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Firs<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:222</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L222">src/clientmetricreport/DefaultClientMetricReport.ts:222</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2702,7 +2702,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:222</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L222">src/clientmetricreport/DefaultClientMetricReport.ts:222</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2712,7 +2712,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:222</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L222">src/clientmetricreport/DefaultClientMetricReport.ts:222</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2723,7 +2723,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:228</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2732,7 +2732,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:228</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2742,7 +2742,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_INPUT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_INPUT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:228</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2753,7 +2753,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:230</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L230">src/clientmetricreport/DefaultClientMetricReport.ts:230</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2762,7 +2762,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:230</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L230">src/clientmetricreport/DefaultClientMetricReport.ts:230</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2772,7 +2772,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:230</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L230">src/clientmetricreport/DefaultClientMetricReport.ts:230</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2783,7 +2783,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nacks<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:215</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L215">src/clientmetricreport/DefaultClientMetricReport.ts:215</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2792,7 +2792,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:216</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L216">src/clientmetricreport/DefaultClientMetricReport.ts:216</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2802,7 +2802,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:217</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L217">src/clientmetricreport/DefaultClientMetricReport.ts:217</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2813,7 +2813,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Plis<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:220</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L220">src/clientmetricreport/DefaultClientMetricReport.ts:220</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2822,7 +2822,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:220</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L220">src/clientmetricreport/DefaultClientMetricReport.ts:220</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2832,7 +2832,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:220</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L220">src/clientmetricreport/DefaultClientMetricReport.ts:220</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2843,7 +2843,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:210</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L210">src/clientmetricreport/DefaultClientMetricReport.ts:210</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2852,7 +2852,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:210</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L210">src/clientmetricreport/DefaultClientMetricReport.ts:210</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2862,7 +2862,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:210</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L210">src/clientmetricreport/DefaultClientMetricReport.ts:210</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2873,7 +2873,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:219</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L219">src/clientmetricreport/DefaultClientMetricReport.ts:219</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2882,7 +2882,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:219</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L219">src/clientmetricreport/DefaultClientMetricReport.ts:219</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2892,7 +2892,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:219</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L219">src/clientmetricreport/DefaultClientMetricReport.ts:219</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2903,7 +2903,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:233</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L233">src/clientmetricreport/DefaultClientMetricReport.ts:233</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2912,7 +2912,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:236</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2922,7 +2922,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:234</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2932,7 +2932,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:235</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2943,7 +2943,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:232</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L232">src/clientmetricreport/DefaultClientMetricReport.ts:232</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2952,7 +2952,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:232</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L232">src/clientmetricreport/DefaultClientMetricReport.ts:232</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2962,7 +2962,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:232</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L232">src/clientmetricreport/DefaultClientMetricReport.ts:232</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2973,7 +2973,7 @@
 						<div class="tsd-signature tsd-kind-icon">pli<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:221</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L221">src/clientmetricreport/DefaultClientMetricReport.ts:221</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2982,7 +2982,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:221</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L221">src/clientmetricreport/DefaultClientMetricReport.ts:221</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2992,7 +2992,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/DefaultClientMetricReport.ts:221</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L221">src/clientmetricreport/DefaultClientMetricReport.ts:221</a></li>
 								</ul>
 							</aside>
 						</section>

--- a/docs/classes/defaultcontentsharecontroller.html
+++ b/docs/classes/defaultcontentsharecontroller.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L36">src/contentsharecontroller/DefaultContentShareController.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Audio<wbr>Video<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L41">src/contentsharecontroller/DefaultContentShareController.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Audio<wbr>Video<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L40">src/contentsharecontroller/DefaultContentShareController.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Share<wbr>Tile<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L36">src/contentsharecontroller/DefaultContentShareController.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="contentsharemediastreambroker.html" class="tsd-signature-type">ContentShareMediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L39">src/contentsharecontroller/DefaultContentShareController.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/contentshareobserver.html" class="tsd-signature-type">ContentShareObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;ContentShareObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L35">src/contentsharecontroller/DefaultContentShareController.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L96">src/contentsharecontroller/DefaultContentShareController.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstop">audioVideoDidStop</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L114">src/contentsharecontroller/DefaultContentShareController.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L104">src/contentsharecontroller/DefaultContentShareController.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -307,7 +307,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:75</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L75">src/contentsharecontroller/DefaultContentShareController.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -325,7 +325,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L100">src/contentsharecontroller/DefaultContentShareController.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -348,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L127">src/contentsharecontroller/DefaultContentShareController.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -366,7 +366,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L47">src/contentsharecontroller/DefaultContentShareController.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -390,7 +390,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L63">src/contentsharecontroller/DefaultContentShareController.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -417,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L91">src/contentsharecontroller/DefaultContentShareController.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -435,7 +435,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L83">src/contentsharecontroller/DefaultContentShareController.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -452,7 +452,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/DefaultContentShareController.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/DefaultContentShareController.ts#L20">src/contentsharecontroller/DefaultContentShareController.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L49">src/devicecontroller/DefaultDeviceController.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">already<wbr>Handling<wbr>Device<wbr>Change<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:462</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L462">src/devicecontroller/DefaultDeviceController.ts:462</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Input<wbr>Destination<wbr>Node<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStreamAudioDestinationNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L39">src/devicecontroller/DefaultDeviceController.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Input<wbr>Source<wbr>Node<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStreamAudioSourceNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L40">src/devicecontroller/DefaultDeviceController.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Output<wbr>Device<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L33">src/devicecontroller/DefaultDeviceController.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">bound<wbr>Audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L35">src/devicecontroller/DefaultDeviceController.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -269,7 +269,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="defaultbrowserbehavior.html" class="tsd-signature-type">DefaultBrowserBehavior</a><span class="tsd-signature-symbol"> = new DefaultBrowserBehavior()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:49</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L49">src/devicecontroller/DefaultDeviceController.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -279,7 +279,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Change<wbr>Observers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/devicechangeobserver.html" class="tsd-signature-type">DeviceChangeObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;DeviceChangeObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L34">src/devicecontroller/DefaultDeviceController.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -289,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Info<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L31">src/devicecontroller/DefaultDeviceController.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -299,7 +299,7 @@
 					<div class="tsd-signature tsd-kind-icon">input<wbr>Device<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L46">src/devicecontroller/DefaultDeviceController.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -309,7 +309,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>NoVideo<wbr>Input<wbr>Device<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L47">src/devicecontroller/DefaultDeviceController.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L51">src/devicecontroller/DefaultDeviceController.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -329,7 +329,7 @@
 					<div class="tsd-signature tsd-kind-icon">use<wbr>Web<wbr>Audio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L44">src/devicecontroller/DefaultDeviceController.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -339,7 +339,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Input<wbr>Quality<wbr>Settings<span class="tsd-signature-symbol">:</span> <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L42">src/devicecontroller/DefaultDeviceController.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -349,7 +349,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Context<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AudioContext</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L29">src/devicecontroller/DefaultDeviceController.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -359,7 +359,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Channel<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L28">src/devicecontroller/DefaultDeviceController.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -369,7 +369,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Sample<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 48000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L26">src/devicecontroller/DefaultDeviceController.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -379,7 +379,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Sample<wbr>Size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 16</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L27">src/devicecontroller/DefaultDeviceController.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -389,7 +389,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L24">src/devicecontroller/DefaultDeviceController.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -399,7 +399,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 540</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L23">src/devicecontroller/DefaultDeviceController.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -409,7 +409,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Max<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1400</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L25">src/devicecontroller/DefaultDeviceController.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -419,7 +419,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 960</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L22">src/devicecontroller/DefaultDeviceController.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -429,7 +429,7 @@
 					<div class="tsd-signature tsd-kind-icon">permission<wbr>Denied<wbr>Origin<wbr>Detection<wbr>Threshold<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 500</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L21">src/devicecontroller/DefaultDeviceController.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -439,7 +439,7 @@
 					<div class="tsd-signature tsd-kind-icon">permission<wbr>Granted<wbr>Origin<wbr>Detection<wbr>Threshold<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L20">src/devicecontroller/DefaultDeviceController.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:223</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L223">src/devicecontroller/DefaultDeviceController.ts:223</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -475,7 +475,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:231</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L231">src/devicecontroller/DefaultDeviceController.ts:231</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -498,7 +498,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:826</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L826">src/devicecontroller/DefaultDeviceController.ts:826</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -522,7 +522,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:227</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L227">src/devicecontroller/DefaultDeviceController.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -540,7 +540,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:126</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L126">src/devicecontroller/DefaultDeviceController.ts:126</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -563,7 +563,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:519</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L519">src/devicecontroller/DefaultDeviceController.ts:519</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -589,7 +589,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:858</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L858">src/devicecontroller/DefaultDeviceController.ts:858</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -612,7 +612,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:727</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L727">src/devicecontroller/DefaultDeviceController.ts:727</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -630,7 +630,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:282</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L282">src/devicecontroller/DefaultDeviceController.ts:282</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -653,7 +653,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:736</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L736">src/devicecontroller/DefaultDeviceController.ts:736</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -680,7 +680,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L101">src/devicecontroller/DefaultDeviceController.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -704,7 +704,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L114">src/devicecontroller/DefaultDeviceController.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -727,7 +727,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:596</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L596">src/devicecontroller/DefaultDeviceController.ts:596</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -757,7 +757,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L107">src/devicecontroller/DefaultDeviceController.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -781,7 +781,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:203</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L203">src/devicecontroller/DefaultDeviceController.ts:203</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -814,7 +814,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L138">src/devicecontroller/DefaultDeviceController.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AnalyserNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -831,7 +831,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:526</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L526">src/devicecontroller/DefaultDeviceController.ts:526</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -854,7 +854,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:811</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L811">src/devicecontroller/DefaultDeviceController.ts:811</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -880,7 +880,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L36">src/devicecontroller/DefaultDeviceController.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -898,7 +898,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L121">src/devicecontroller/DefaultDeviceController.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -921,7 +921,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:508</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L508">src/devicecontroller/DefaultDeviceController.ts:508</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -962,7 +962,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:575</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L575">src/devicecontroller/DefaultDeviceController.ts:575</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -985,7 +985,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:551</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L551">src/devicecontroller/DefaultDeviceController.ts:551</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1008,7 +1008,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:539</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L539">src/devicecontroller/DefaultDeviceController.ts:539</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1034,7 +1034,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:868</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L868">src/devicecontroller/DefaultDeviceController.ts:868</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStreamAudioDestinationNode</span></h4>
@@ -1052,7 +1052,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:219</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L219">src/devicecontroller/DefaultDeviceController.ts:219</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -1069,7 +1069,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:463</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L463">src/devicecontroller/DefaultDeviceController.ts:463</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1086,7 +1086,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:495</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L495">src/devicecontroller/DefaultDeviceController.ts:495</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1112,7 +1112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:531</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L531">src/devicecontroller/DefaultDeviceController.ts:531</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1142,7 +1142,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L83">src/devicecontroller/DefaultDeviceController.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1160,7 +1160,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:95</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L95">src/devicecontroller/DefaultDeviceController.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1177,7 +1177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:452</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L452">src/devicecontroller/DefaultDeviceController.ts:452</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1200,7 +1200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:416</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L416">src/devicecontroller/DefaultDeviceController.ts:416</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1224,7 +1224,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L89">src/devicecontroller/DefaultDeviceController.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1242,7 +1242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:190</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L190">src/devicecontroller/DefaultDeviceController.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1265,7 +1265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:248</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L248">src/devicecontroller/DefaultDeviceController.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1289,7 +1289,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:132</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L132">src/devicecontroller/DefaultDeviceController.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1312,7 +1312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L185">src/devicecontroller/DefaultDeviceController.ts:185</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1348,7 +1348,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:149</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L149">src/devicecontroller/DefaultDeviceController.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1372,7 +1372,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:173</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L173">src/devicecontroller/DefaultDeviceController.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1395,7 +1395,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:904</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L904">src/devicecontroller/DefaultDeviceController.ts:904</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1412,7 +1412,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:896</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L896">src/devicecontroller/DefaultDeviceController.ts:896</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1429,7 +1429,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:900</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L900">src/devicecontroller/DefaultDeviceController.ts:900</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1446,7 +1446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:909</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L909">src/devicecontroller/DefaultDeviceController.ts:909</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1475,7 +1475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:423</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L423">src/devicecontroller/DefaultDeviceController.ts:423</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1492,7 +1492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:408</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L408">src/devicecontroller/DefaultDeviceController.ts:408</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1509,7 +1509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:889</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L889">src/devicecontroller/DefaultDeviceController.ts:889</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1526,7 +1526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:287</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L287">src/devicecontroller/DefaultDeviceController.ts:287</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#device" class="tsd-signature-type">Device</a></h4>
@@ -1543,7 +1543,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:291</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L291">src/devicecontroller/DefaultDeviceController.ts:291</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../globals.html#device" class="tsd-signature-type">Device</a></h4>
@@ -1560,7 +1560,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:365</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L365">src/devicecontroller/DefaultDeviceController.ts:365</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1586,7 +1586,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:875</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L875">src/devicecontroller/DefaultDeviceController.ts:875</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -1603,7 +1603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:295</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L295">src/devicecontroller/DefaultDeviceController.ts:295</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1626,7 +1626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DefaultDeviceController.ts:341</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L341">src/devicecontroller/DefaultDeviceController.ts:341</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1648,7 +1648,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Devices<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DefaultDeviceController.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L32">src/devicecontroller/DefaultDeviceController.ts:32</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1657,7 +1657,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/devicecontroller/DefaultDeviceController.ts:32</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L32">src/devicecontroller/DefaultDeviceController.ts:32</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -1667,7 +1667,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/devicecontroller/DefaultDeviceController.ts:32</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L32">src/devicecontroller/DefaultDeviceController.ts:32</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/classes/defaultdevicepixelratiomonitor.html
+++ b/docs/classes/defaultdevicepixelratiomonitor.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L10">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<wbr>Source<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicepixelratiosource.html" class="tsd-signature-type">DevicePixelRatioSource</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L12">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/devicepixelratioobserver.html" class="tsd-signature-type">DevicePixelRatioObserver</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L10">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L28">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -190,7 +190,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratiomonitor.html">DevicePixelRatioMonitor</a>.<a href="../interfaces/devicepixelratiomonitor.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L34">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -214,7 +214,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratiomonitor.html">DevicePixelRatioMonitor</a>.<a href="../interfaces/devicepixelratiomonitor.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts#L39">src/devicepixelratiomonitor/DefaultDevicePixelRatioMonitor.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultdomwebsocket.html
+++ b/docs/classes/defaultdomwebsocket.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:6</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L6">src/domwebsocket/DefaultDOMWebSocket.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">WebSocket</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L7">src/domwebsocket/DefaultDOMWebSocket.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L29">src/domwebsocket/DefaultDOMWebSocket.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">EventListener</span></h4>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L33">src/domwebsocket/DefaultDOMWebSocket.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L21">src/domwebsocket/DefaultDOMWebSocket.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">EventListener</span></h4>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L25">src/domwebsocket/DefaultDOMWebSocket.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L37">src/domwebsocket/DefaultDOMWebSocket.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">EventListener</span></h4>
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L41">src/domwebsocket/DefaultDOMWebSocket.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L13">src/domwebsocket/DefaultDOMWebSocket.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">EventListener</span></h4>
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L17">src/domwebsocket/DefaultDOMWebSocket.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L9">src/domwebsocket/DefaultDOMWebSocket.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -318,7 +318,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L45">src/domwebsocket/DefaultDOMWebSocket.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -348,7 +348,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/domwebsocket.html">DOMWebSocket</a>.<a href="../interfaces/domwebsocket.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L69">src/domwebsocket/DefaultDOMWebSocket.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/domwebsocket.html">DOMWebSocket</a>.<a href="../interfaces/domwebsocket.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L61">src/domwebsocket/DefaultDOMWebSocket.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L53">src/domwebsocket/DefaultDOMWebSocket.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -428,7 +428,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/domwebsocket.html">DOMWebSocket</a>.<a href="../interfaces/domwebsocket.html#send">send</a></p>
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocket.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocket.ts#L65">src/domwebsocket/DefaultDOMWebSocket.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultdomwebsocketfactory.html
+++ b/docs/classes/defaultdomwebsocketfactory.html
@@ -106,7 +106,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/domwebsocketfactory.html">DOMWebSocketFactory</a>.<a href="../interfaces/domwebsocketfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/domwebsocket/DefaultDOMWebSocketFactory.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DefaultDOMWebSocketFactory.ts#L10">src/domwebsocket/DefaultDOMWebSocketFactory.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultdragobserver.html
+++ b/docs/classes/defaultdragobserver.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L12">src/dragobserver/DefaultDragObserver.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLElement</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DefaultDragObserver.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L16">src/dragobserver/DefaultDragObserver.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">mouse<wbr>Down<wbr>Event<wbr>Listener<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DefaultDragObserver.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L10">src/dragobserver/DefaultDragObserver.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">mouse<wbr>Move<wbr>Event<wbr>Listener<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DefaultDragObserver.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L11">src/dragobserver/DefaultDragObserver.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">mouse<wbr>UpEvent<wbr>Listener<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DefaultDragObserver.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L12">src/dragobserver/DefaultDragObserver.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DefaultDragObserver.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L15">src/dragobserver/DefaultDragObserver.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/dragobserver.html">DragObserver</a>.<a href="../interfaces/dragobserver.html#unobserve">unobserve</a></p>
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L40">src/dragobserver/DefaultDragObserver.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L46">src/dragobserver/DefaultDragObserver.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L53">src/dragobserver/DefaultDragObserver.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L69">src/dragobserver/DefaultDragObserver.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -366,7 +366,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DefaultDragObserver.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DefaultDragObserver.ts#L86">src/dragobserver/DefaultDragObserver.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultjpegdecodercomponentfactory.html
+++ b/docs/classes/defaultjpegdecodercomponentfactory.html
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts#L9">src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts#L10">src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Input<wbr>Bytes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts#L10">src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/jpegdecodercomponentfactory.html">JPEGDecoderComponentFactory</a>.<a href="../interfaces/jpegdecodercomponentfactory.html#newcontroller">newController</a></p>
 								<ul>
-									<li>Defined in src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts#L12">src/jpegdecoder/DefaultJPEGDecoderComponentFactory.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/jpegdecodercontroller.html" class="tsd-signature-type">JPEGDecoderController</a><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/defaultjpegdecodercontroller.html
+++ b/docs/classes/defaultjpegdecodercontroller.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L13">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">decoder<wbr>Input<span class="tsd-signature-symbol">:</span> <a href="jpegdecoderinput.html" class="tsd-signature-type">JPEGDecoderInput</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L12">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Decoder<wbr>Module<span class="tsd-signature-symbol">:</span> <a href="jpegdecodermodule.html" class="tsd-signature-type">JPEGDecoderModule</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L13">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L15">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Input<wbr>Size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L15">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/jpegdecodercontroller.html">JPEGDecoderController</a>.<a href="../interfaces/jpegdecodercontroller.html#createinstance">createInstance</a></p>
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L32">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -226,7 +226,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/jpegdecodercontroller.html">JPEGDecoderController</a>.<a href="../interfaces/jpegdecodercontroller.html#free">free</a></p>
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L25">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L17">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L48">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L52">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L36">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Uint8Array</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/DefaultJPEGDecoderController.ts#L44">src/jpegdecoder/controller/DefaultJPEGDecoderController.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultjpegdecoderinstance.html
+++ b/docs/classes/defaultjpegdecoderinstance.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts#L10">src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">controller<span class="tsd-signature-symbol">:</span> <a href="defaultjpegdecodercontroller.html" class="tsd-signature-type">DefaultJPEGDecoderController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts#L10">src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">decoder<span class="tsd-signature-symbol">:</span> <a href="jpegdecoder.html" class="tsd-signature-type">JPEGDecoder</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts#L9">src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts#L28">src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts#L22">src/jpegdecoder/instance/DefaultJPEGDecoderInstance.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultmediadevicefactory.html
+++ b/docs/classes/defaultmediadevicefactory.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/DefaultMediaDeviceFactory.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/DefaultMediaDeviceFactory.ts#L8">src/mediadevicefactory/DefaultMediaDeviceFactory.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultmediadevicefactory.html" class="tsd-signature-type">DefaultMediaDeviceFactory</a></h4>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Media<wbr>Devices<wbr>Supported<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/DefaultMediaDeviceFactory.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/DefaultMediaDeviceFactory.ts#L8">src/mediadevicefactory/DefaultMediaDeviceFactory.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediadevicefactory.html">MediaDeviceFactory</a>.<a href="../interfaces/mediadevicefactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/mediadevicefactory/DefaultMediaDeviceFactory.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/DefaultMediaDeviceFactory.ts#L14">src/mediadevicefactory/DefaultMediaDeviceFactory.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaDevices</span></h4>

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L39">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Context<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AudioContext</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L33">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="defaultbrowserbehavior.html" class="tsd-signature-type">DefaultBrowserBehavior</a><span class="tsd-signature-symbol"> = new DefaultBrowserBehavior()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L39">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="meetingreadinesscheckerconfiguration.html" class="tsd-signature-type">MeetingReadinessCheckerConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L44">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">destination<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStreamAudioDestinationNode</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L36">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">gain<wbr>Node<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">GainNode</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L34">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L42">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">meeting<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="../interfaces/meetingsession.html" class="tsd-signature-type">MeetingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:43</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L43">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">originalURLRewriter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L37">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -269,7 +269,7 @@
 					<div class="tsd-signature tsd-kind-icon">oscillator<wbr>Node<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">OscillatorNode</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L35">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:193</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L193">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:193</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -316,7 +316,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioconnectivity">checkAudioConnectivity</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:261</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L261">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:261</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -340,7 +340,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioinput">checkAudioInput</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L47">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L67">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcameraresolution">checkCameraResolution</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:161</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L161">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -435,7 +435,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcontentshareconnectivity">checkContentShareConnectivity</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:212</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L212">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -459,7 +459,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:394</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L394">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:394</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworktcpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkTCPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -477,7 +477,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:352</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L352">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:352</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworkudpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkUDPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -495,7 +495,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:307</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L307">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:307</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -519,7 +519,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoinput">checkVideoInput</a></p>
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:141</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L141">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -542,7 +542,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:470</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L470">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:470</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -577,7 +577,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L92">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -606,7 +606,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:438</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L438">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:438</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -623,7 +623,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:454</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L454">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:454</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -640,7 +640,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L123">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -657,7 +657,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L29">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultmeetingsession.html
+++ b/docs/classes/defaultmeetingsession.html
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L38">src/meetingsession/DefaultMeetingSession.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">_configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L26">src/meetingsession/DefaultMeetingSession.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">_device<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicecontroller.html" class="tsd-signature-type">DeviceController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L30">src/meetingsession/DefaultMeetingSession.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">_logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L27">src/meetingsession/DefaultMeetingSession.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L28">src/meetingsession/DefaultMeetingSession.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Facade<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideofacade.html" class="tsd-signature-type">AudioVideoFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L33">src/meetingsession/DefaultMeetingSession.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Share<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/contentsharecontroller.html" class="tsd-signature-type">ContentShareController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L29">src/meetingsession/DefaultMeetingSession.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<wbr>Facade<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharefacade.html" class="tsd-signature-type">ScreenShareFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L31">src/meetingsession/DefaultMeetingSession.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<wbr>View<wbr>Facade<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenshareviewfacade.html" class="tsd-signature-type">ScreenShareViewFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L32">src/meetingsession/DefaultMeetingSession.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECONNECT_<wbr>FIXED_<wbr>WAIT_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L36">src/meetingsession/DefaultMeetingSession.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECONNECT_<wbr>LONG_<wbr>BACKOFF_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5 * 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L38">src/meetingsession/DefaultMeetingSession.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECONNECT_<wbr>SHORT_<wbr>BACKOFF_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1 * 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L37">src/meetingsession/DefaultMeetingSession.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECONNECT_<wbr>TIMEOUT_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 120 * 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/DefaultMeetingSession.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L35">src/meetingsession/DefaultMeetingSession.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -295,7 +295,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:115</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L115">src/meetingsession/DefaultMeetingSession.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/audiovideofacade.html" class="tsd-signature-type">AudioVideoFacade</a></h4>
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L107">src/meetingsession/DefaultMeetingSession.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></h4>
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L119">src/meetingsession/DefaultMeetingSession.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/contentsharecontroller.html" class="tsd-signature-type">ContentShareController</a></h4>
@@ -346,7 +346,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:131</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L131">src/meetingsession/DefaultMeetingSession.ts:131</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/devicecontroller.html" class="tsd-signature-type">DeviceController</a></h4>
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:111</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L111">src/meetingsession/DefaultMeetingSession.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h4>
@@ -380,7 +380,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L123">src/meetingsession/DefaultMeetingSession.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharefacade.html" class="tsd-signature-type">ScreenShareFacade</a></h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L127">src/meetingsession/DefaultMeetingSession.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screenshareviewfacade.html" class="tsd-signature-type">ScreenShareViewFacade</a></h4>
@@ -417,7 +417,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/DefaultMeetingSession.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/DefaultMeetingSession.ts#L135">src/meetingsession/DefaultMeetingSession.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultmodality.html
+++ b/docs/classes/defaultmodality.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L10">src/modality/DefaultModality.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">_id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/modality/DefaultModality.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L12">src/modality/DefaultModality.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">MODALITY_<wbr>CONTENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = ContentShareConstants.Modality.substr(1)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/modality/DefaultModality.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L10">src/modality/DefaultModality.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">MODALITY_<wbr>SEPARATOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = ContentShareConstants.Modality[0]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/modality/DefaultModality.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L8">src/modality/DefaultModality.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/modality.html">Modality</a>.<a href="../interfaces/modality.html#base">base</a></p>
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L18">src/modality/DefaultModality.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -201,7 +201,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/modality.html">Modality</a>.<a href="../interfaces/modality.html#hasmodality">hasModality</a></p>
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L36">src/modality/DefaultModality.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/modality.html">Modality</a>.<a href="../interfaces/modality.html#id">id</a></p>
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L14">src/modality/DefaultModality.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/modality.html">Modality</a>.<a href="../interfaces/modality.html#modality-1">modality</a></p>
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L25">src/modality/DefaultModality.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/modality.html">Modality</a>.<a href="../interfaces/modality.html#withmodality">withModality</a></p>
 								<ul>
-									<li>Defined in src/modality/DefaultModality.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/DefaultModality.ts#L40">src/modality/DefaultModality.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultpingpong.html
+++ b/docs/classes/defaultpingpong.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L28">src/pingpong/DefaultPingPong.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">consecutive<wbr>Pongs<wbr>Unaccounted<wbr>For<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L28">src/pingpong/DefaultPingPong.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L32">src/pingpong/DefaultPingPong.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Scheduler<span class="tsd-signature-symbol">:</span> <a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L25">src/pingpong/DefaultPingPong.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L33">src/pingpong/DefaultPingPong.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/pingpongobserver.html" class="tsd-signature-type">PingPongObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;PingPongObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L24">src/pingpong/DefaultPingPong.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">ping<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L27">src/pingpong/DefaultPingPong.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">ping<wbr>Timestamp<wbr>Local<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L26">src/pingpong/DefaultPingPong.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/signalingclient.html" class="tsd-signature-type">SignalingClient</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/pingpong/DefaultPingPong.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L31">src/pingpong/DefaultPingPong.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/pingpong.html">PingPong</a>.<a href="../interfaces/pingpong.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L39">src/pingpong/DefaultPingPong.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L49">src/pingpong/DefaultPingPong.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -322,7 +322,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:112</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L112">src/pingpong/DefaultPingPong.ts:112</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -345,7 +345,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L85">src/pingpong/DefaultPingPong.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -362,7 +362,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:105</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L105">src/pingpong/DefaultPingPong.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -386,7 +386,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/pingpong.html">PingPong</a>.<a href="../interfaces/pingpong.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L44">src/pingpong/DefaultPingPong.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/pingpong.html">PingPong</a>.<a href="../interfaces/pingpong.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L59">src/pingpong/DefaultPingPong.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -427,7 +427,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L72">src/pingpong/DefaultPingPong.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -445,7 +445,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/pingpong.html">PingPong</a>.<a href="../interfaces/pingpong.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L67">src/pingpong/DefaultPingPong.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/DefaultPingPong.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/DefaultPingPong.ts#L79">src/pingpong/DefaultPingPong.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultpresentation.html
+++ b/docs/classes/defaultpresentation.html
@@ -110,7 +110,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/presentation.html">Presentation</a>.<a href="../interfaces/presentation.html#present">present</a></p>
 								<ul>
-									<li>Defined in src/presentation/DefaultPresentation.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L22">src/presentation/DefaultPresentation.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/DefaultPresentation.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L67">src/presentation/DefaultPresentation.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/DefaultPresentation.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L80">src/presentation/DefaultPresentation.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/DefaultPresentation.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L63">src/presentation/DefaultPresentation.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -223,7 +223,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/DefaultPresentation.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L101">src/presentation/DefaultPresentation.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultpromisedwebsocket.html
+++ b/docs/classes/defaultpromisedwebsocket.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L10">src/promisedwebsocket/DefaultPromisedWebSocket.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Set&lt;EventListener&gt;&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L10">src/promisedwebsocket/DefaultPromisedWebSocket.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/domwebsocket.html" class="tsd-signature-type">DOMWebSocket</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L12">src/promisedwebsocket/DefaultPromisedWebSocket.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L14">src/promisedwebsocket/DefaultPromisedWebSocket.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -201,7 +201,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:74</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L74">src/promisedwebsocket/DefaultPromisedWebSocket.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L38">src/promisedwebsocket/DefaultPromisedWebSocket.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L67">src/promisedwebsocket/DefaultPromisedWebSocket.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L62">src/promisedwebsocket/DefaultPromisedWebSocket.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -322,7 +322,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:57</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L57">src/promisedwebsocket/DefaultPromisedWebSocket.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -364,7 +364,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L18">src/promisedwebsocket/DefaultPromisedWebSocket.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:81</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L81">src/promisedwebsocket/DefaultPromisedWebSocket.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -414,7 +414,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#send">send</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L53">src/promisedwebsocket/DefaultPromisedWebSocket.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -437,7 +437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocket.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocket.ts#L85">src/promisedwebsocket/DefaultPromisedWebSocket.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultpromisedwebsocketfactory.html
+++ b/docs/classes/defaultpromisedwebsocketfactory.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts#L9">src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/domwebsocketfactory.html" class="tsd-signature-type">DOMWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts#L10">src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocketfactory.html">PromisedWebSocketFactory</a>.<a href="../interfaces/promisedwebsocketfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts#L12">src/promisedwebsocket/DefaultPromisedWebSocketFactory.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultrealtimecontroller.html
+++ b/docs/classes/defaultrealtimecontroller.html
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <a href="realtimestate.html" class="tsd-signature-type">RealtimeState</a><span class="tsd-signature-symbol"> = new RealtimeState()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:57</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L57">src/realtimecontroller/DefaultRealtimeController.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:429</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L429">src/realtimecontroller/DefaultRealtimeController.ts:429</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:497</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L497">src/realtimecontroller/DefaultRealtimeController.ts:497</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:156</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L156">src/realtimecontroller/DefaultRealtimeController.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:227</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L227">src/realtimecontroller/DefaultRealtimeController.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:164</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L164">src/realtimecontroller/DefaultRealtimeController.ts:164</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -311,7 +311,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimereceivedatamessage">realtimeReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:388</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L388">src/realtimecontroller/DefaultRealtimeController.ts:388</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -335,7 +335,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:357</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L357">src/realtimecontroller/DefaultRealtimeController.ts:357</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -364,7 +364,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L66">src/realtimecontroller/DefaultRealtimeController.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -400,7 +400,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:129</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L129">src/realtimecontroller/DefaultRealtimeController.ts:129</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -423,7 +423,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L59">src/realtimecontroller/DefaultRealtimeController.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesetlocalaudioinput">realtimeSetLocalAudioInput</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L116">src/realtimecontroller/DefaultRealtimeController.ts:116</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -473,7 +473,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L83">src/realtimecontroller/DefaultRealtimeController.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:400</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L400">src/realtimecontroller/DefaultRealtimeController.ts:400</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -567,7 +567,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:317</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L317">src/realtimecontroller/DefaultRealtimeController.ts:317</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -608,7 +608,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:212</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L212">src/realtimecontroller/DefaultRealtimeController.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -649,7 +649,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:369</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L369">src/realtimecontroller/DefaultRealtimeController.ts:369</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -693,7 +693,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:336</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L336">src/realtimecontroller/DefaultRealtimeController.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -740,7 +740,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:141</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L141">src/realtimecontroller/DefaultRealtimeController.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -781,7 +781,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:237</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L237">src/realtimecontroller/DefaultRealtimeController.ts:237</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -838,7 +838,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:184</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L184">src/realtimecontroller/DefaultRealtimeController.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -856,7 +856,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:382</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L382">src/realtimecontroller/DefaultRealtimeController.ts:382</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -879,7 +879,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:345</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L345">src/realtimecontroller/DefaultRealtimeController.ts:345</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -927,7 +927,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:262</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L262">src/realtimecontroller/DefaultRealtimeController.ts:262</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -950,7 +950,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:97</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L97">src/realtimecontroller/DefaultRealtimeController.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1003,7 +1003,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:406</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L406">src/realtimecontroller/DefaultRealtimeController.ts:406</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1044,7 +1044,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:327</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L327">src/realtimecontroller/DefaultRealtimeController.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1085,7 +1085,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:218</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L218">src/realtimecontroller/DefaultRealtimeController.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1126,7 +1126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:147</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L147">src/realtimecontroller/DefaultRealtimeController.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1167,7 +1167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:268</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L268">src/realtimecontroller/DefaultRealtimeController.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1202,7 +1202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:480</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L480">src/realtimecontroller/DefaultRealtimeController.ts:480</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1228,7 +1228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:444</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L444">src/realtimecontroller/DefaultRealtimeController.ts:444</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1263,7 +1263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:417</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L417">src/realtimecontroller/DefaultRealtimeController.ts:417</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1286,7 +1286,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:504</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L504">src/realtimecontroller/DefaultRealtimeController.ts:504</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1309,7 +1309,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/DefaultRealtimeController.ts:508</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/DefaultRealtimeController.ts#L508">src/realtimecontroller/DefaultRealtimeController.ts:508</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultreconnectcontroller.html
+++ b/docs/classes/defaultreconnectcontroller.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L16">src/reconnectcontroller/DefaultReconnectController.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">_is<wbr>First<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L14">src/reconnectcontroller/DefaultReconnectController.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<wbr>Cancel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L16">src/reconnectcontroller/DefaultReconnectController.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<wbr>Policy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BackoffPolicy</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L18">src/reconnectcontroller/DefaultReconnectController.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<wbr>Timer<span class="tsd-signature-symbol">:</span> <a href="timeoutscheduler.html" class="tsd-signature-type">TimeoutScheduler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L15">src/reconnectcontroller/DefaultReconnectController.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Connection<wbr>Attempt<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L12">src/reconnectcontroller/DefaultReconnectController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">first<wbr>Connection<wbr>Attempted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L11">src/reconnectcontroller/DefaultReconnectController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Active<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = Infinity</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L13">src/reconnectcontroller/DefaultReconnectController.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">only<wbr>Restart<wbr>Peer<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L10">src/reconnectcontroller/DefaultReconnectController.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">reconnect<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L18">src/reconnectcontroller/DefaultReconnectController.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">should<wbr>Reconnect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L9">src/reconnectcontroller/DefaultReconnectController.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:71</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L71">src/reconnectcontroller/DefaultReconnectController.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -304,7 +304,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#clone">clone</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L99">src/reconnectcontroller/DefaultReconnectController.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultreconnectcontroller.html" class="tsd-signature-type">DefaultReconnectController</a></h4>
@@ -322,7 +322,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#disablereconnect">disableReconnect</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L63">src/reconnectcontroller/DefaultReconnectController.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -340,7 +340,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#enablerestartpeerconnection">enableRestartPeerConnection</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L67">src/reconnectcontroller/DefaultReconnectController.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L29">src/reconnectcontroller/DefaultReconnectController.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#hasstartedconnectionattempt">hasStartedConnectionAttempt</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L55">src/reconnectcontroller/DefaultReconnectController.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -393,7 +393,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#isfirstconnection">isFirstConnection</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L59">src/reconnectcontroller/DefaultReconnectController.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -411,7 +411,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L37">src/reconnectcontroller/DefaultReconnectController.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:82</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L82">src/reconnectcontroller/DefaultReconnectController.ts:82</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -479,7 +479,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#setlastactivetimestampms">setLastActiveTimestampMs</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L103">src/reconnectcontroller/DefaultReconnectController.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -503,7 +503,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#shouldonlyrestartpeerconnection">shouldOnlyRestartPeerConnection</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:95</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L95">src/reconnectcontroller/DefaultReconnectController.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -521,7 +521,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/reconnectcontroller.html">ReconnectController</a>.<a href="../interfaces/reconnectcontroller.html#startedconnectionattempt">startedConnectionAttempt</a></p>
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L47">src/reconnectcontroller/DefaultReconnectController.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -544,7 +544,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/DefaultReconnectController.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/DefaultReconnectController.ts#L22">src/reconnectcontroller/DefaultReconnectController.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>

--- a/docs/classes/defaultresizeobserveradapter.html
+++ b/docs/classes/defaultresizeobserveradapter.html
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/DefaultResizeObserverAdapter.ts#L8">src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">resize<wbr>Observer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ResizeObserver</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/DefaultResizeObserverAdapter.ts#L9">src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/resizeobserveradapter.html">ResizeObserverAdapter</a>.<a href="../interfaces/resizeobserveradapter.html#observe">observe</a></p>
 								<ul>
-									<li>Defined in src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/DefaultResizeObserverAdapter.ts#L11">src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/resizeobserveradapter.html">ResizeObserverAdapter</a>.<a href="../interfaces/resizeobserveradapter.html#unobserve">unobserve</a></p>
 								<ul>
-									<li>Defined in src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/DefaultResizeObserverAdapter.ts#L15">src/resizeobserveradapter/DefaultResizeObserverAdapter.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreensharefacade.html
+++ b/docs/classes/defaultscreensharefacade.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L14">src/screensharefacade/DefaultScreenShareFacade.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L17">src/screensharefacade/DefaultScreenShareFacade.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L18">src/screensharefacade/DefaultScreenShareFacade.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L19">src/screensharefacade/DefaultScreenShareFacade.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Sharing<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingsession.html" class="tsd-signature-type">ScreenSharingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L14">src/screensharefacade/DefaultScreenShareFacade.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L49">src/screensharefacade/DefaultScreenShareFacade.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L33">src/screensharefacade/DefaultScreenShareFacade.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L79">src/screensharefacade/DefaultScreenShareFacade.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L99">src/screensharefacade/DefaultScreenShareFacade.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -281,7 +281,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L59">src/screensharefacade/DefaultScreenShareFacade.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L69">src/screensharefacade/DefaultScreenShareFacade.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -323,7 +323,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L89">src/screensharefacade/DefaultScreenShareFacade.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -341,7 +341,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharefacade.html">ScreenShareFacade</a>.<a href="../interfaces/screensharefacade.html#unregisterobserver">unregisterObserver</a></p>
 								<ul>
-									<li>Defined in src/screensharefacade/DefaultScreenShareFacade.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/DefaultScreenShareFacade.ts#L103">src/screensharefacade/DefaultScreenShareFacade.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreenshareviewfacade.html
+++ b/docs/classes/defaultscreenshareviewfacade.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L28">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L30">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L30">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Viewing<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewing.html" class="tsd-signature-type">ScreenViewing</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L23">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L62">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L24">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L52">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#presentdragandzoom">presentDragAndZoom</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L84">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#presentscaletofit">presentScaleToFit</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L80">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L104">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -337,7 +337,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L66">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -361,7 +361,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L76">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -379,7 +379,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#unregisterobserver">unregisterObserver</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L108">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -403,7 +403,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#zoom">zoom</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L96">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -427,7 +427,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#zoomin">zoomIn</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L88">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -451,7 +451,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#zoomout">zoomOut</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L92">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -475,7 +475,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenshareviewfacade.html">ScreenShareViewFacade</a>.<a href="../interfaces/screenshareviewfacade.html#zoomreset">zoomReset</a></p>
 								<ul>
-									<li>Defined in src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/DefaultScreenShareViewFacade.ts#L100">src/screenshareviewfacade/DefaultScreenShareViewFacade.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultscreensharingsession.html
+++ b/docs/classes/defaultscreensharingsession.html
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L24">src/screensharingsession/DefaultScreenSharingSession.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L35">src/screensharingsession/DefaultScreenSharingSession.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">constraints<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>sourceId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">MediaStreamConstraints</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L28">src/screensharingsession/DefaultScreenSharingSession.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L34">src/screensharingsession/DefaultScreenSharingSession.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Recording<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediarecordingfactory.html" class="tsd-signature-type">MediaRecordingFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L33">src/screensharingsession/DefaultScreenSharingSession.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L31">src/screensharingsession/DefaultScreenSharingSession.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L30">src/screensharingsession/DefaultScreenSharingSession.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/screensharingsessionobserver.html" class="tsd-signature-type">ScreenSharingSessionObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;ScreenSharingSessionObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L23">src/screensharingsession/DefaultScreenSharingSession.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<wbr>Stream<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="screensharestreamfactory.html" class="tsd-signature-type">ScreenShareStreamFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L32">src/screensharingsession/DefaultScreenSharingSession.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharestreaming.html" class="tsd-signature-type">ScreenShareStreaming</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L24">src/screensharingsession/DefaultScreenSharingSession.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -317,7 +317,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Slice<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L29">src/screensharingsession/DefaultScreenSharingSession.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocket.html" class="tsd-signature-type">PromisedWebSocket</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L27">src/screensharingsession/DefaultScreenSharingSession.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -345,7 +345,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:78</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L78">src/screensharingsession/DefaultScreenSharingSession.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#deregisterobserver">deregisterObserver</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:220</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L220">src/screensharingsession/DefaultScreenSharingSession.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -392,7 +392,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:269</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L269">src/screensharingsession/DefaultScreenSharingSession.ts:269</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:242</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L242">src/screensharingsession/DefaultScreenSharingSession.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -426,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:249</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L249">src/screensharingsession/DefaultScreenSharingSession.ts:249</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -443,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:225</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L225">src/screensharingsession/DefaultScreenSharingSession.ts:225</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -466,7 +466,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:254</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L254">src/screensharingsession/DefaultScreenSharingSession.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -483,7 +483,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:262</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L262">src/screensharingsession/DefaultScreenSharingSession.ts:262</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -501,7 +501,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L73">src/screensharingsession/DefaultScreenSharingSession.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -525,7 +525,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:158</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L158">src/screensharingsession/DefaultScreenSharingSession.ts:158</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -542,7 +542,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:189</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L189">src/screensharingsession/DefaultScreenSharingSession.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:215</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L215">src/screensharingsession/DefaultScreenSharingSession.ts:215</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -589,7 +589,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:292</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L292">src/screensharingsession/DefaultScreenSharingSession.ts:292</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L87">src/screensharingsession/DefaultScreenSharingSession.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -640,7 +640,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:136</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L136">src/screensharingsession/DefaultScreenSharingSession.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -658,7 +658,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsession.html">ScreenSharingSession</a>.<a href="../interfaces/screensharingsession.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSession.ts:173</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSession.ts#L173">src/screensharingsession/DefaultScreenSharingSession.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/defaultscreensharingsessionfactory.html
+++ b/docs/classes/defaultscreensharingsessionfactory.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L16">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L24">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Constraints<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">MediaStreamConstraints</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L18">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Recording<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediarecordingfactory.html" class="tsd-signature-type">MediaRecordingFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L23">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L21">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L20">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<wbr>Stream<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharestreamingfactory.html" class="tsd-signature-type">ScreenShareStreamingFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L22">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Slice<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L25">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L19">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">Binary<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="defaultscreensharingsessionfactory.html#binarytype" class="tsd-signature-type">BinaryType</a><span class="tsd-signature-symbol"> = &quot;arraybuffer&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L16">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">Session<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;_aws_wt_session&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L15">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -304,7 +304,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingsessionfactory.html">ScreenSharingSessionFactory</a>.<a href="../interfaces/screensharingsessionfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/screensharingsession/DefaultScreenSharingSessionFactory.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/DefaultScreenSharingSessionFactory.ts#L28">src/screensharingsession/DefaultScreenSharingSessionFactory.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreensignalingsession.html
+++ b/docs/classes/defaultscreensignalingsession.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L17">src/screensignalingsession/DefaultScreenSignalingSession.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Set&lt;EventListener&gt;&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L17">src/screensignalingsession/DefaultScreenSignalingSession.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L22">src/screensignalingsession/DefaultScreenSignalingSession.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L21">src/screensignalingsession/DefaultScreenSignalingSession.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocket.html" class="tsd-signature-type">PromisedWebSocket</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L20">src/screensignalingsession/DefaultScreenSignalingSession.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">Session<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;_aws_wt_session&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L15">src/screensignalingsession/DefaultScreenSignalingSession.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L40">src/screensignalingsession/DefaultScreenSignalingSession.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -238,7 +238,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensignalingsession.html">ScreenSignalingSession</a>.<a href="../interfaces/screensignalingsession.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L36">src/screensignalingsession/DefaultScreenSignalingSession.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensignalingsession.html">ScreenSignalingSession</a>.<a href="../interfaces/screensignalingsession.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L47">src/screensignalingsession/DefaultScreenSignalingSession.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L58">src/screensignalingsession/DefaultScreenSignalingSession.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensignalingsession.html">ScreenSignalingSession</a>.<a href="../interfaces/screensignalingsession.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L32">src/screensignalingsession/DefaultScreenSignalingSession.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSession.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSession.ts#L54">src/screensignalingsession/DefaultScreenSignalingSession.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreensignalingsessionfactory.html
+++ b/docs/classes/defaultscreensignalingsessionfactory.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts#L11">src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts#L15">src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts#L14">src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts#L13">src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensignalingsessionfactory.html">ScreenSignalingSessionFactory</a>.<a href="../interfaces/screensignalingsessionfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts#L18">src/screensignalingsession/DefaultScreenSignalingSessionFactory.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreenviewing.html
+++ b/docs/classes/defaultscreenviewing.html
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L12">src/screenviewing/DefaultScreenViewing.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">component<wbr>Context<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingcomponentcontext.html" class="tsd-signature-type">ScreenViewingComponentContext</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/DefaultScreenViewing.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L14">src/screenviewing/DefaultScreenViewing.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">request<span class="tsd-signature-symbol">:</span> <a href="screenviewingsessionconnectionrequest.html" class="tsd-signature-type">ScreenViewingSessionConnectionRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/DefaultScreenViewing.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L12">src/screenviewing/DefaultScreenViewing.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L31">src/screenviewing/DefaultScreenViewing.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L20">src/screenviewing/DefaultScreenViewing.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#presentdragandzoom">presentDragAndZoom</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L62">src/screenviewing/DefaultScreenViewing.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#presentscaletofit">presentScaleToFit</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L56">src/screenviewing/DefaultScreenViewing.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -269,7 +269,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L84">src/screenviewing/DefaultScreenViewing.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L43">src/screenviewing/DefaultScreenViewing.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L51">src/screenviewing/DefaultScreenViewing.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -347,7 +347,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#unregisterobserver">unregisterObserver</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L88">src/screenviewing/DefaultScreenViewing.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -371,7 +371,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#zoom">zoom</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L76">src/screenviewing/DefaultScreenViewing.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#zoomin">zoomIn</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L68">src/screenviewing/DefaultScreenViewing.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -419,7 +419,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#zoomout">zoomOut</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L72">src/screenviewing/DefaultScreenViewing.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -443,7 +443,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewing.html">ScreenViewing</a>.<a href="../interfaces/screenviewing.html#zoomreset">zoomReset</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/DefaultScreenViewing.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/DefaultScreenViewing.ts#L80">src/screenviewing/DefaultScreenViewing.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultscreenviewingcomponentcontext.html
+++ b/docs/classes/defaultscreenviewingcomponentcontext.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L37">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#deltarenderer">deltaRenderer</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L31">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#deltasource">deltaSource</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L32">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#jpegdecodercontroller">jpegDecoderController</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L33">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#messagedispatcher">messageDispatcher</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L34">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#messagehandler">messageHandler</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L35">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#signalingsession">signalingSession</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L36">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#viewer">viewer</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L37">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingcomponentcontext.html">ScreenViewingComponentContext</a>.<a href="../interfaces/screenviewingcomponentcontext.html#viewingsession">viewingSession</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L30">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:118</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L118">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:141</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L141">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:156</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L156">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:172</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L172">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -385,7 +385,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:187</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L187">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:187</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -423,7 +423,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:106</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L106">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:106</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -452,7 +452,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:219</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L219">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:219</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -478,7 +478,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/context/DefaultScreenViewingComponentContext.ts:210</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/DefaultScreenViewingComponentContext.ts#L210">src/screenviewing/context/DefaultScreenViewingComponentContext.ts:210</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreenviewingdeltarenderer.html
+++ b/docs/classes/defaultscreenviewingdeltarenderer.html
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L42">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLCanvasElement</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L39">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">drag<wbr>Observer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/dragobserver.html" class="tsd-signature-type">DragObserver</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L41">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">drag<wbr>Observer<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../globals.html#dragobserverfactory" class="tsd-signature-type">DragObserverFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:49</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L49">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#hasrendered">hasRendered</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L30">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#imagedimensions">imageDimensions</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L32">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -234,7 +234,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#jpegdataarrays">jpegDataArrays</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L28">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Decoder<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/jpegdecodercontroller.html" class="tsd-signature-type">JPEGDecoderController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:45</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L45">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,7 +254,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Decoder<wbr>Instance<span class="tsd-signature-symbol">:</span> <a href="../interfaces/jpegdecoderinstance.html" class="tsd-signature-type">JPEGDecoderInstance</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L42">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -265,7 +265,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#lastresizeandsynctime">lastResizeAndSyncTime</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L34">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L46">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -285,7 +285,7 @@
 					<div class="tsd-signature tsd-kind-icon">policy<span class="tsd-signature-symbol">:</span> <a href="../interfaces/presentationpolicy.html" class="tsd-signature-type">PresentationPolicy</a><span class="tsd-signature-symbol"> = new ScaleToFitPresentationPolicy()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L37">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -295,7 +295,7 @@
 					<div class="tsd-signature tsd-kind-icon">presentation<span class="tsd-signature-symbol">:</span> <a href="../interfaces/presentation.html" class="tsd-signature-type">Presentation</a><span class="tsd-signature-symbol"> = new DefaultPresentation()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L36">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -305,7 +305,7 @@
 					<div class="tsd-signature tsd-kind-icon">resize<wbr>Observer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/resizeobserveradapter.html" class="tsd-signature-type">ResizeObserverAdapter</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L40">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#syncbuffer">syncBuffer</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L26">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewport<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLElement</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L38">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<div class="tsd-signature tsd-kind-icon">window<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L47">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">SYNC_<wbr>TIMEOUT_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 500</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L24">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -364,7 +364,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#buildviewer">buildViewer</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L64">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#changepresentationpolicy">changePresentationPolicy</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:204</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L204">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -412,7 +412,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:151</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L151">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -429,7 +429,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:147</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L147">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">CanvasRenderingContext2D</span></h4>
@@ -446,7 +446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:139</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L139">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -470,7 +470,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#hideviewport">hideViewport</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L192">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -487,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:113</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L113">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -505,7 +505,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#resizeandsync">resizeAndSync</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L89">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -523,7 +523,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#revealviewport">revealViewport</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:198</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L198">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:198</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -541,7 +541,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#setviewport">setViewport</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:161</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L161">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -564,7 +564,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:229</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L229">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -591,7 +591,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#zoomabsolute">zoomAbsolute</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:216</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L216">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:216</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -615,7 +615,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#zoomrelative">zoomRelative</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:209</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L209">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:209</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -639,7 +639,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltarenderer.html">ScreenViewingDeltaRenderer</a>.<a href="../interfaces/screenviewingdeltarenderer.html#zoomreset">zoomReset</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:223</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L223">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:223</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -656,7 +656,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts#L56">src/screenviewing/deltarenderer/DefaultScreenViewingDeltaRenderer.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/defaultscreenviewingdeltasource.html
+++ b/docs/classes/defaultscreenviewingdeltasource.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L14">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Renderer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L16">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L16">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltasource.html">ScreenViewingDeltaSource</a>.<a href="../interfaces/screenviewingdeltasource.html#notshared">notShared</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L10">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltasource.html">ScreenViewingDeltaSource</a>.<a href="../interfaces/screenviewingdeltasource.html#pendingdx">pendingDx</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L12">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/screenviewingdeltasource.html">ScreenViewingDeltaSource</a>.<a href="../interfaces/screenviewingdeltasource.html#pendingdy">pendingDy</a></p>
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L14">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingdeltasource.html">ScreenViewingDeltaSource</a>.<a href="../interfaces/screenviewingdeltasource.html#flushsyncbuffer">flushSyncBuffer</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts#L18">src/screenviewing/deltasource/DefaultScreenViewingDeltaSource.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultscreenviewingmessagehandler.html
+++ b/docs/classes/defaultscreenviewingmessagehandler.html
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L13">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingsession.html" class="tsd-signature-type">ScreenViewingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L15">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Renderer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L16">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Source<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingdeltasource.html" class="tsd-signature-type">ScreenViewingDeltaSource</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L17">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L19">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingviewer.html" class="tsd-signature-type">ScreenViewingViewer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L18">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handledefault">handleDefault</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:97</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L97">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -245,7 +245,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handledelta">handleDelta</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L69">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -269,7 +269,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handleechorequest">handleEchoRequest</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L22">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handleendscreen">handleEndScreen</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L91">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -317,7 +317,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handlenoscreen">handleNoScreen</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L86">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -341,7 +341,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handlesetup">handleSetup</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L33">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingmessagehandler.html">ScreenViewingMessageHandler</a>.<a href="../interfaces/screenviewingmessagehandler.html#handlesync">handleSync</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L77">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L49">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -417,7 +417,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts#L109">src/screenviewing/messagehandler/DefaultScreenViewingMessageHandler.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreenviewingsession.html
+++ b/docs/classes/defaultscreenviewingsession.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L18">src/screenviewing/session/DefaultScreenViewingSession.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L22">src/screenviewing/session/DefaultScreenViewingSession.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingsessionobserver.html" class="tsd-signature-type">ScreenViewingSessionObserver</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L18">src/screenviewing/session/DefaultScreenViewingSession.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocket.html" class="tsd-signature-type">PromisedWebSocket</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L17">src/screenviewing/session/DefaultScreenViewingSession.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="reconnectingpromisedwebsocketfactory.html" class="tsd-signature-type">ReconnectingPromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L21">src/screenviewing/session/DefaultScreenViewingSession.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>TIMEOUT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L16">src/screenviewing/session/DefaultScreenViewingSession.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -214,7 +214,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsession.html">ScreenViewingSession</a>.<a href="../interfaces/screenviewingsession.html#closeconnection">closeConnection</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L56">src/screenviewing/session/DefaultScreenViewingSession.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -232,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsession.html">ScreenViewingSession</a>.<a href="../interfaces/screenviewingsession.html#openconnection">openConnection</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L29">src/screenviewing/session/DefaultScreenViewingSession.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsession.html">ScreenViewingSession</a>.<a href="../interfaces/screenviewingsession.html#send">send</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L66">src/screenviewing/session/DefaultScreenViewingSession.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -280,7 +280,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsession.html">ScreenViewingSession</a>.<a href="../interfaces/screenviewingsession.html#withobserver">withObserver</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/session/DefaultScreenViewingSession.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/DefaultScreenViewingSession.ts#L25">src/screenviewing/session/DefaultScreenViewingSession.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultscreenviewingviewer.html
+++ b/docs/classes/defaultscreenviewingviewer.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L8">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Renderer<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L9">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L9">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingviewer.html">ScreenViewingViewer</a>.<a href="../interfaces/screenviewingviewer.html#resizeandsync">resizeAndSync</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L21">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingviewer.html">ScreenViewingViewer</a>.<a href="../interfaces/screenviewingviewer.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L11">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -215,7 +215,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingviewer.html">ScreenViewingViewer</a>.<a href="../interfaces/screenviewingviewer.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/viewer/DefaultScreenViewingViewer.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/DefaultScreenViewingViewer.ts#L16">src/screenviewing/viewer/DefaultScreenViewingViewer.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/defaultsdp.html
+++ b/docs/classes/defaultsdp.html
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L11">src/sdp/DefaultSDP.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">sdp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/DefaultSDP.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L13">src/sdp/DefaultSDP.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">CRLF<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/DefaultSDP.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L11">src/sdp/DefaultSDP.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#clone">clone</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L15">src/sdp/DefaultSDP.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -218,7 +218,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#copyvideo">copyVideo</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:163</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L163">src/sdp/DefaultSDP.ts:163</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#hascandidates">hasCandidates</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L135">src/sdp/DefaultSDP.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -260,7 +260,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#hascandidatesforallmlines">hasCandidatesForAllMLines</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L143">src/sdp/DefaultSDP.ts:143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:131</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L131">src/sdp/DefaultSDP.ts:131</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#lines">lines</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L127">src/sdp/DefaultSDP.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#preferh264ifexists">preferH264IfExists</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:218</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L218">src/sdp/DefaultSDP.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -331,7 +331,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#ssrcforvideosendingsection">ssrcForVideoSendingSection</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:334</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L334">src/sdp/DefaultSDP.ts:334</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -349,7 +349,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#videosendsectionhasdifferentssrc">videoSendSectionHasDifferentSSRC</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:358</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L358">src/sdp/DefaultSDP.ts:358</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -373,7 +373,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withbandwidthrestriction">withBandwidthRestriction</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:190</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L190">src/sdp/DefaultSDP.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -400,7 +400,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withbundleaudiovideo">withBundleAudioVideo</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:149</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L149">src/sdp/DefaultSDP.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -417,7 +417,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:271</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L271">src/sdp/DefaultSDP.ts:271</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -441,7 +441,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withunifiedplanformat">withUnifiedPlanFormat</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:207</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L207">src/sdp/DefaultSDP.ts:207</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -459,7 +459,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withoutcandidatetype">withoutCandidateType</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:180</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L180">src/sdp/DefaultSDP.ts:180</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -483,7 +483,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withoutserverreflexivecandidates">withoutServerReflexiveCandidates</a></p>
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:186</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L186">src/sdp/DefaultSDP.ts:186</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -500,7 +500,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L45">src/sdp/DefaultSDP.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -523,7 +523,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L31">src/sdp/DefaultSDP.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -546,7 +546,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:113</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L113">src/sdp/DefaultSDP.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -569,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L107">src/sdp/DefaultSDP.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -592,7 +592,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L70">src/sdp/DefaultSDP.ts:70</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -615,7 +615,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L19">src/sdp/DefaultSDP.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -638,7 +638,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L27">src/sdp/DefaultSDP.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -661,7 +661,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L121">src/sdp/DefaultSDP.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -687,7 +687,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L89">src/sdp/DefaultSDP.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -710,7 +710,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L53">src/sdp/DefaultSDP.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -733,7 +733,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/DefaultSDP.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L62">src/sdp/DefaultSDP.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultsessionstatecontroller.html
+++ b/docs/classes/defaultsessionstatecontroller.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L11">src/sessionstatecontroller/DefaultSessionStateController.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>State<span class="tsd-signature-symbol">:</span> <a href="../enums/sessionstatecontrollerstate.html" class="tsd-signature-type">SessionStateControllerState</a><span class="tsd-signature-symbol"> = SessionStateControllerState.NotConnected</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:105</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L105">src/sessionstatecontroller/DefaultSessionStateController.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">deferred<wbr>Action<span class="tsd-signature-symbol">:</span> <a href="../enums/sessionstatecontrolleraction.html" class="tsd-signature-type">SessionStateControllerAction</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:106</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L106">src/sessionstatecontroller/DefaultSessionStateController.ts:106</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">deferred<wbr>Work<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:107</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L107">src/sessionstatecontroller/DefaultSessionStateController.ts:107</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L12">src/sessionstatecontroller/DefaultSessionStateController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:147</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L147">src/sessionstatecontroller/DefaultSessionStateController.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:136</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L136">src/sessionstatecontroller/DefaultSessionStateController.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -271,7 +271,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L121">src/sessionstatecontroller/DefaultSessionStateController.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -294,7 +294,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L14">src/sessionstatecontroller/DefaultSessionStateController.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:155</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L155">src/sessionstatecontroller/DefaultSessionStateController.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/sessionstatecontrollertransitionresult.html" class="tsd-signature-type">SessionStateControllerTransitionResult</a></h4>
@@ -350,7 +350,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sessionstatecontroller.html">SessionStateController</a>.<a href="../interfaces/sessionstatecontroller.html#state">state</a></p>
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L101">src/sessionstatecontroller/DefaultSessionStateController.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/sessionstatecontrollerstate.html" class="tsd-signature-type">SessionStateControllerState</a></h4>
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/DefaultSessionStateController.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/DefaultSessionStateController.ts#L109">src/sessionstatecontroller/DefaultSessionStateController.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultsignalingclient.html
+++ b/docs/classes/defaultsignalingclient.html
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L42">src/signalingclient/DefaultSignalingClient.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Request<wbr>Queue<span class="tsd-signature-symbol">:</span> <a href="signalingclientconnectionrequest.html" class="tsd-signature-type">SignalingClientConnectionRequest</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L41">src/signalingclient/DefaultSignalingClient.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Closing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L40">src/signalingclient/DefaultSignalingClient.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L44">src/signalingclient/DefaultSignalingClient.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/signalingclientobserver.html" class="tsd-signature-type">SignalingClientObserver</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L38">src/signalingclient/DefaultSignalingClient.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">unload<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L42">src/signalingclient/DefaultSignalingClient.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">was<wbr>Opened<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L39">src/signalingclient/DefaultSignalingClient.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,7 +254,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/websocketadapter.html" class="tsd-signature-type">WebSocketAdapter</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L44">src/signalingclient/DefaultSignalingClient.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -264,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">FRAME_<wbr>TYPE_<wbr>RTC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/DefaultSignalingClient.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L37">src/signalingclient/DefaultSignalingClient.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:362</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L362">src/signalingclient/DefaultSignalingClient.ts:362</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#closeconnection">closeConnection</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:164</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L164">src/signalingclient/DefaultSignalingClient.ts:164</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -316,7 +316,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:373</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L373">src/signalingclient/DefaultSignalingClient.ts:373</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -334,7 +334,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#join">join</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L76">src/signalingclient/DefaultSignalingClient.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#leave">leave</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:140</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L140">src/signalingclient/DefaultSignalingClient.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -376,7 +376,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#mute">mute</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:187</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L187">src/signalingclient/DefaultSignalingClient.ts:187</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -400,7 +400,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#openconnection">openConnection</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L61">src/signalingclient/DefaultSignalingClient.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -424,7 +424,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:196</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L196">src/signalingclient/DefaultSignalingClient.ts:196</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -448,7 +448,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pingpong">pingPong</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L67">src/signalingclient/DefaultSignalingClient.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -471,7 +471,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:270</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L270">src/signalingclient/DefaultSignalingClient.ts:270</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -495,7 +495,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#ready">ready</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:181</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L181">src/signalingclient/DefaultSignalingClient.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -512,7 +512,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:238</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L238">src/signalingclient/DefaultSignalingClient.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -536,7 +536,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L51">src/signalingclient/DefaultSignalingClient.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -560,7 +560,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L56">src/signalingclient/DefaultSignalingClient.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -583,7 +583,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:212</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L212">src/signalingclient/DefaultSignalingClient.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -601,7 +601,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#resume">resume</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:204</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L204">src/signalingclient/DefaultSignalingClient.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -625,7 +625,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#sendclientmetrics">sendClientMetrics</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L150">src/signalingclient/DefaultSignalingClient.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -649,7 +649,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#senddatamessage">sendDataMessage</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:157</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L157">src/signalingclient/DefaultSignalingClient.ts:157</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -672,7 +672,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:292</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L292">src/signalingclient/DefaultSignalingClient.ts:292</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -695,7 +695,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:217</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L217">src/signalingclient/DefaultSignalingClient.ts:217</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -718,7 +718,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:277</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L277">src/signalingclient/DefaultSignalingClient.ts:277</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -735,7 +735,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:317</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L317">src/signalingclient/DefaultSignalingClient.ts:317</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -752,7 +752,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:261</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L261">src/signalingclient/DefaultSignalingClient.ts:261</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -776,7 +776,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#subscribe">subscribe</a></p>
 								<ul>
-									<li>Defined in src/signalingclient/DefaultSignalingClient.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/DefaultSignalingClient.ts#L101">src/signalingclient/DefaultSignalingClient.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultsignalingsession.html
+++ b/docs/classes/defaultsignalingsession.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L15">src/screenviewing/signalingsession/DefaultSignalingSession.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>TIMEOUT_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 500</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L13">src/screenviewing/signalingsession/DefaultSignalingSession.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">observers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/screenobserver.html" class="tsd-signature-type">ScreenObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;ScreenObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L15">src/screenviewing/signalingsession/DefaultSignalingSession.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Signaling<wbr>Session<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensignalingsessionfactory.html" class="tsd-signature-type">ScreenSignalingSessionFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L17">src/screenviewing/signalingsession/DefaultSignalingSession.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">session<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensignalingsession.html" class="tsd-signature-type">ScreenSignalingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L14">src/screenviewing/signalingsession/DefaultSignalingSession.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingsession.html">SignalingSession</a>.<a href="../interfaces/signalingsession.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L54">src/screenviewing/signalingsession/DefaultSignalingSession.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingsession.html">SignalingSession</a>.<a href="../interfaces/signalingsession.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L19">src/screenviewing/signalingsession/DefaultSignalingSession.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -235,7 +235,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingsession.html">SignalingSession</a>.<a href="../interfaces/signalingsession.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L63">src/screenviewing/signalingsession/DefaultSignalingSession.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingsession.html">SignalingSession</a>.<a href="../interfaces/signalingsession.html#unregisterobserver">unregisterObserver</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/DefaultSignalingSession.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/DefaultSignalingSession.ts#L67">src/screenviewing/signalingsession/DefaultSignalingSession.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultstatscollector.html
+++ b/docs/classes/defaultstatscollector.html
@@ -158,7 +158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L41">src/statscollector/DefaultStatsCollector.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L44">src/statscollector/DefaultStatsCollector.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L46">src/statscollector/DefaultStatsCollector.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">:</span> <a href="defaultclientmetricreport.html" class="tsd-signature-type">DefaultClientMetricReport</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L41">src/statscollector/DefaultStatsCollector.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L47">src/statscollector/DefaultStatsCollector.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Scheduler<span class="tsd-signature-symbol">:</span> <a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L38">src/statscollector/DefaultStatsCollector.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:45</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L45">src/statscollector/DefaultStatsCollector.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/signalingclient.html" class="tsd-signature-type">SignalingClient</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L39">src/statscollector/DefaultStatsCollector.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Index<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L40">src/statscollector/DefaultStatsCollector.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -269,7 +269,7 @@
 					<div class="tsd-signature tsd-kind-icon">CLIENT_<wbr>TYPE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"amazon-chime-sdk-js"</span><span class="tsd-signature-symbol"> = &quot;amazon-chime-sdk-js&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L36">src/statscollector/DefaultStatsCollector.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -279,7 +279,7 @@
 					<div class="tsd-signature tsd-kind-icon">FIREFOX_<wbr>UPDATED_<wbr>GET_<wbr>STATS_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"66.0.0"</span><span class="tsd-signature-symbol"> = &quot;66.0.0&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L35">src/statscollector/DefaultStatsCollector.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -289,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTERVAL_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">1000</span><span class="tsd-signature-symbol"> = 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L34">src/statscollector/DefaultStatsCollector.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:301</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L301">src/statscollector/DefaultStatsCollector.ts:301</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:273</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L273">src/statscollector/DefaultStatsCollector.ts:273</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:308</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L308">src/statscollector/DefaultStatsCollector.ts:308</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -421,7 +421,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:482</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L482">src/statscollector/DefaultStatsCollector.ts:482</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -444,7 +444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:410</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L410">src/statscollector/DefaultStatsCollector.ts:410</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -467,7 +467,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:350</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L350">src/statscollector/DefaultStatsCollector.ts:350</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:346</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L346">src/statscollector/DefaultStatsCollector.ts:346</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:438</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L438">src/statscollector/DefaultStatsCollector.ts:438</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -535,7 +535,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:420</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L420">src/statscollector/DefaultStatsCollector.ts:420</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -558,7 +558,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:342</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L342">src/statscollector/DefaultStatsCollector.ts:342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -586,7 +586,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:360</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L360">src/statscollector/DefaultStatsCollector.ts:360</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -614,7 +614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:402</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L402">src/statscollector/DefaultStatsCollector.ts:402</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -637,7 +637,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:390</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L390">src/statscollector/DefaultStatsCollector.ts:390</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -660,7 +660,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:371</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L371">src/statscollector/DefaultStatsCollector.ts:371</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -683,7 +683,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L96">src/statscollector/DefaultStatsCollector.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -714,7 +714,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:159</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L159">src/statscollector/DefaultStatsCollector.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -745,7 +745,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:106</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L106">src/statscollector/DefaultStatsCollector.ts:106</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -779,7 +779,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L83">src/statscollector/DefaultStatsCollector.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -814,7 +814,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/statscollector.html">StatsCollector</a>.<a href="../interfaces/statscollector.html#loglifecycleevent">logLifecycleEvent</a></p>
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:144</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L144">src/statscollector/DefaultStatsCollector.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -841,7 +841,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/statscollector.html">StatsCollector</a>.<a href="../interfaces/statscollector.html#logmeetingsessionstatus">logMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L123">src/statscollector/DefaultStatsCollector.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -864,7 +864,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L88">src/statscollector/DefaultStatsCollector.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -895,7 +895,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L101">src/statscollector/DefaultStatsCollector.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -926,7 +926,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:325</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L325">src/statscollector/DefaultStatsCollector.ts:325</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">SdkClientMetricFrame</span></h4>
@@ -943,7 +943,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L76">src/statscollector/DefaultStatsCollector.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -977,7 +977,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:81</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L81">src/statscollector/DefaultStatsCollector.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1008,7 +1008,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:240</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L240">src/statscollector/DefaultStatsCollector.ts:240</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1031,7 +1031,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:334</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L334">src/statscollector/DefaultStatsCollector.ts:334</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1054,7 +1054,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:175</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L175">src/statscollector/DefaultStatsCollector.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1089,7 +1089,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/statscollector.html">StatsCollector</a>.<a href="../interfaces/statscollector.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:199</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L199">src/statscollector/DefaultStatsCollector.ts:199</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1106,7 +1106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L51">src/statscollector/DefaultStatsCollector.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1129,7 +1129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L55">src/statscollector/DefaultStatsCollector.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1152,7 +1152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/DefaultStatsCollector.ts:211</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L211">src/statscollector/DefaultStatsCollector.ts:211</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/defaulttransceivercontroller.html
+++ b/docs/classes/defaulttransceivercontroller.html
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L15">src/transceivercontroller/DefaultTransceiverController.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">_local<wbr>Audio<wbr>Transceiver<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCRtpTransceiver</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L12">src/transceivercontroller/DefaultTransceiverController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">_local<wbr>Camera<wbr>Transceiver<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCRtpTransceiver</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L11">src/transceivercontroller/DefaultTransceiverController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<wbr>Behavior<span class="tsd-signature-symbol">:</span> <a href="../interfaces/browserbehavior.html" class="tsd-signature-type">BrowserBehavior</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L17">src/transceivercontroller/DefaultTransceiverController.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L14">src/transceivercontroller/DefaultTransceiverController.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L17">src/transceivercontroller/DefaultTransceiverController.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">peer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCPeerConnection</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L15">src/transceivercontroller/DefaultTransceiverController.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Subscriptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L13">src/transceivercontroller/DefaultTransceiverController.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:244</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L244">src/transceivercontroller/DefaultTransceiverController.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -267,7 +267,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#hasvideoinput">hasVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L93">src/transceivercontroller/DefaultTransceiverController.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -285,7 +285,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localaudiotransceiver">localAudioTransceiver</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L53">src/transceivercontroller/DefaultTransceiverController.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -303,7 +303,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localvideotransceiver">localVideoTransceiver</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L56">src/transceivercontroller/DefaultTransceiverController.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#replaceaudiotrack">replaceAudioTrack</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L134">src/transceivercontroller/DefaultTransceiverController.ts:134</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -345,7 +345,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L77">src/transceivercontroller/DefaultTransceiverController.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -363,7 +363,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setaudioinput">setAudioInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L143">src/transceivercontroller/DefaultTransceiverController.ts:143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setencodingparameters">setEncodingParameters</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L19">src/transceivercontroller/DefaultTransceiverController.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -411,7 +411,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setpeer">setPeer</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L73">src/transceivercontroller/DefaultTransceiverController.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:258</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L258">src/transceivercontroller/DefaultTransceiverController.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -461,7 +461,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideoinput">setVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:148</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L148">src/transceivercontroller/DefaultTransceiverController.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -485,7 +485,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideosendingbitratekbps">setVideoSendingBitrateKbps</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L60">src/transceivercontroller/DefaultTransceiverController.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -509,7 +509,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setuplocaltransceivers">setupLocalTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:110</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L110">src/transceivercontroller/DefaultTransceiverController.ts:110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -527,7 +527,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#trackisvideoinput">trackIsVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L100">src/transceivercontroller/DefaultTransceiverController.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -550,7 +550,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:235</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L235">src/transceivercontroller/DefaultTransceiverController.ts:235</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -573,7 +573,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:175</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L175">src/transceivercontroller/DefaultTransceiverController.ts:175</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -603,7 +603,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#updatevideotransceivers">updateVideoTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:153</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L153">src/transceivercontroller/DefaultTransceiverController.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -630,7 +630,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#usetransceivers">useTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L85">src/transceivercontroller/DefaultTransceiverController.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -647,7 +647,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L41">src/transceivercontroller/DefaultTransceiverController.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -673,7 +673,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L23">src/transceivercontroller/DefaultTransceiverController.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideocaptureandencodeparameter.html
+++ b/docs/classes/defaultvideocaptureandencodeparameter.html
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L7">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">camera<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L11">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">camera<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L10">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">camera<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L9">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Simulcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L13">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Encode<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L12">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#captureframerate">captureFrameRate</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L59">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -238,7 +238,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#captureheight">captureHeight</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L55">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -256,7 +256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#capturewidth">captureWidth</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L51">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -274,7 +274,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#clone">clone</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L41">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideocaptureandencodeparameter.html" class="tsd-signature-type">DefaultVideoCaptureAndEncodeParameter</a></h4>
@@ -292,7 +292,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#encodebitrates">encodeBitrates</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L63">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -310,7 +310,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#encodeheights">encodeHeights</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L72">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -328,7 +328,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videocaptureandencodeparameter.html">VideoCaptureAndEncodeParameter</a>.<a href="../interfaces/videocaptureandencodeparameter.html#encodewidths">encodeWidths</a></p>
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L68">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -345,7 +345,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts#L16">src/videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideostreamidset.html
+++ b/docs/classes/defaultvideostreamidset.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L10">src/videostreamidset/DefaultVideoStreamIdSet.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L10">src/videostreamidset/DefaultVideoStreamIdSet.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#add">add</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L16">src/videostreamidset/DefaultVideoStreamIdSet.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -196,7 +196,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#array">array</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L20">src/videostreamidset/DefaultVideoStreamIdSet.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -214,7 +214,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#clone">clone</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L54">src/videostreamidset/DefaultVideoStreamIdSet.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -232,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#contain">contain</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L25">src/videostreamidset/DefaultVideoStreamIdSet.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -256,7 +256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#empty">empty</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L29">src/videostreamidset/DefaultVideoStreamIdSet.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L37">src/videostreamidset/DefaultVideoStreamIdSet.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#remove">remove</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L58">src/videostreamidset/DefaultVideoStreamIdSet.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#size">size</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L33">src/videostreamidset/DefaultVideoStreamIdSet.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -339,7 +339,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamidset.html">VideoStreamIdSet</a>.<a href="../interfaces/videostreamidset.html#tojson">toJSON</a></p>
 								<ul>
-									<li>Defined in src/videostreamidset/DefaultVideoStreamIdSet.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/DefaultVideoStreamIdSet.ts#L62">src/videostreamidset/DefaultVideoStreamIdSet.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/defaultvideostreamindex.html
+++ b/docs/classes/defaultvideostreamindex.html
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L35">src/videostreamindex/DefaultVideoStreamIndex.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Index<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkIndexFrame</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L21">src/videostreamindex/DefaultVideoStreamIndex.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Subscribe<wbr>Ack<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkSubscribeAckFrame</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L23">src/videostreamindex/DefaultVideoStreamIndex.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">index<wbr>For<wbr>Subscribe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkIndexFrame</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L22">src/videostreamindex/DefaultVideoStreamIndex.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L36">src/videostreamindex/DefaultVideoStreamIndex.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>ToAttendee<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L32">src/videostreamindex/DefaultVideoStreamIndex.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>ToExternal<wbr>User<wbr>IdMap<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L33">src/videostreamindex/DefaultVideoStreamIndex.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<wbr>Ssrc<wbr>ToStream<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L29">src/videostreamindex/DefaultVideoStreamIndex.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<wbr>Stream<wbr>ToAttendee<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L27">src/videostreamindex/DefaultVideoStreamIndex.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<wbr>Stream<wbr>ToExternal<wbr>User<wbr>IdMap<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L28">src/videostreamindex/DefaultVideoStreamIndex.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<wbr>Track<wbr>ToStream<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L26">src/videostreamindex/DefaultVideoStreamIndex.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Description<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol"> = new VideoStreamDescription()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L35">src/videostreamindex/DefaultVideoStreamIndex.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:275</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L275">src/videostreamindex/DefaultVideoStreamIndex.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +332,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L109">src/videostreamindex/DefaultVideoStreamIndex.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -350,7 +350,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingattendeesexcludingself">allVideoSendingAttendeesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L119">src/videostreamindex/DefaultVideoStreamIndex.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:250</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L250">src/videostreamindex/DefaultVideoStreamIndex.ts:250</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -398,7 +398,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:218</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L218">src/videostreamindex/DefaultVideoStreamIndex.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -421,7 +421,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:380</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L380">src/videostreamindex/DefaultVideoStreamIndex.ts:380</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -444,7 +444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:317</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L317">src/videostreamindex/DefaultVideoStreamIndex.ts:317</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -467,7 +467,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:338</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L338">src/videostreamindex/DefaultVideoStreamIndex.ts:338</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:328</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L328">src/videostreamindex/DefaultVideoStreamIndex.ts:328</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:306</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L306">src/videostreamindex/DefaultVideoStreamIndex.ts:306</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -537,7 +537,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:234</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L234">src/videostreamindex/DefaultVideoStreamIndex.ts:234</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -561,7 +561,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:266</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L266">src/videostreamindex/DefaultVideoStreamIndex.ts:266</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -585,7 +585,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L192">src/videostreamindex/DefaultVideoStreamIndex.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -609,7 +609,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratebitratesframe">integrateBitratesFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L96">src/videostreamindex/DefaultVideoStreamIndex.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -633,7 +633,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integrateindexframe">integrateIndexFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L73">src/videostreamindex/DefaultVideoStreamIndex.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -657,7 +657,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratesubscribeackframe">integrateSubscribeAckFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L84">src/videostreamindex/DefaultVideoStreamIndex.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -681,7 +681,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integrateuplinkpolicydecision">integrateUplinkPolicyDecision</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L65">src/videostreamindex/DefaultVideoStreamIndex.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -705,7 +705,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#localstreamdescriptions">localStreamDescriptions</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L42">src/videostreamindex/DefaultVideoStreamIndex.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -723,7 +723,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:214</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L214">src/videostreamindex/DefaultVideoStreamIndex.ts:214</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -747,7 +747,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#remotestreamdescriptions">remoteStreamDescriptions</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L48">src/videostreamindex/DefaultVideoStreamIndex.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -765,7 +765,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:289</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L289">src/videostreamindex/DefaultVideoStreamIndex.ts:289</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -789,7 +789,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:282</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L282">src/videostreamindex/DefaultVideoStreamIndex.ts:282</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -813,7 +813,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:137</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L137">src/videostreamindex/DefaultVideoStreamIndex.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -846,7 +846,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:296</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L296">src/videostreamindex/DefaultVideoStreamIndex.ts:296</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -864,7 +864,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L79">src/videostreamindex/DefaultVideoStreamIndex.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -881,7 +881,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:350</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L350">src/videostreamindex/DefaultVideoStreamIndex.ts:350</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L92">src/videotile/DefaultVideoTile.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<wbr>Monitor<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicepixelratiomonitor.html" class="tsd-signature-type">DevicePixelRatioMonitor</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/DefaultVideoTile.ts:98</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L98">src/videotile/DefaultVideoTile.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/DefaultVideoTile.ts:97</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L97">src/videotile/DefaultVideoTile.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>State<span class="tsd-signature-symbol">:</span> <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a><span class="tsd-signature-symbol"> = new VideoTileState()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/DefaultVideoTile.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L14">src/videotile/DefaultVideoTile.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:182</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L182">src/videotile/DefaultVideoTile.ts:182</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -231,7 +231,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:136</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L136">src/videotile/DefaultVideoTile.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:245</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L245">src/videotile/DefaultVideoTile.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ImageData</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:105</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L105">src/videotile/DefaultVideoTile.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratioobserver.html">DevicePixelRatioObserver</a>.<a href="../interfaces/devicepixelratioobserver.html#devicepixelratiochanged">devicePixelRatioChanged</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L119">src/videotile/DefaultVideoTile.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#id">id</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:124</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L124">src/videotile/DefaultVideoTile.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:227</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L227">src/videotile/DefaultVideoTile.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:213</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L213">src/videotile/DefaultVideoTile.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:258</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L258">src/videotile/DefaultVideoTile.ts:258</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#state">state</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L128">src/videotile/DefaultVideoTile.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#stateref">stateRef</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:132</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L132">src/videotile/DefaultVideoTile.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:236</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L236">src/videotile/DefaultVideoTile.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:220</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L220">src/videotile/DefaultVideoTile.ts:220</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:265</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L265">src/videotile/DefaultVideoTile.ts:265</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -492,7 +492,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:275</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L275">src/videotile/DefaultVideoTile.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -509,7 +509,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:290</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L290">src/videotile/DefaultVideoTile.ts:290</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -526,7 +526,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L16">src/videotile/DefaultVideoTile.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -555,7 +555,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L52">src/videotile/DefaultVideoTile.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/DefaultVideoTile.ts:305</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L305">src/videotile/DefaultVideoTile.ts:305</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideotilecontroller.html
+++ b/docs/classes/defaultvideotilecontroller.html
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L21">src/videotilecontroller/DefaultVideoTileController.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L25">src/videotilecontroller/DefaultVideoTileController.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Local<wbr>Tile<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L19">src/videotilecontroller/DefaultVideoTileController.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Paused<wbr>Tiles<wbr>ByIds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;number&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L21">src/videotilecontroller/DefaultVideoTileController.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<wbr>Monitor<span class="tsd-signature-symbol">:</span> <a href="../interfaces/devicepixelratiomonitor.html" class="tsd-signature-type">DevicePixelRatioMonitor</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L20">src/videotilecontroller/DefaultVideoTileController.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L26">src/videotilecontroller/DefaultVideoTileController.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -223,7 +223,7 @@
 					<div class="tsd-signature tsd-kind-icon">next<wbr>Tile<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L18">src/videotilecontroller/DefaultVideoTileController.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilefactory.html" class="tsd-signature-type">VideoTileFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L24">src/videotilecontroller/DefaultVideoTileController.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;number, VideoTile&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L17">src/videotilecontroller/DefaultVideoTileController.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:137</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L137">src/videotilecontroller/DefaultVideoTileController.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L34">src/videotilecontroller/DefaultVideoTileController.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -310,7 +310,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:204</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L204">src/videotilecontroller/DefaultVideoTileController.ts:204</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:212</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L212">src/videotilecontroller/DefaultVideoTileController.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L123">src/videotilecontroller/DefaultVideoTileController.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:133</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L133">src/videotilecontroller/DefaultVideoTileController.ts:133</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:82</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L82">src/videotilecontroller/DefaultVideoTileController.ts:82</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L108">src/videotilecontroller/DefaultVideoTileController.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -429,7 +429,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotilearea">getVideoTileArea</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:112</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L112">src/videotilecontroller/DefaultVideoTileController.ts:112</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -453,7 +453,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#hasstartedlocalvideotile">hasStartedLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:71</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L71">src/videotilecontroller/DefaultVideoTileController.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -471,7 +471,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#havevideotileforattendeeid">haveVideoTileForAttendeeId</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:194</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L194">src/videotilecontroller/DefaultVideoTileController.ts:194</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -495,7 +495,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#havevideotileswithstreams">haveVideoTilesWithStreams</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L185">src/videotilecontroller/DefaultVideoTileController.ts:185</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -513,7 +513,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L86">src/videotilecontroller/DefaultVideoTileController.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -537,7 +537,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:172</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L172">src/videotilecontroller/DefaultVideoTileController.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -555,7 +555,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removelocalvideotile">removeLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:75</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L75">src/videotilecontroller/DefaultVideoTileController.ts:75</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -573,7 +573,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:145</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L145">src/videotilecontroller/DefaultVideoTileController.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +597,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:160</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L160">src/videotilecontroller/DefaultVideoTileController.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -621,7 +621,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#sendtilestateupdate">sendTileStateUpdate</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:179</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L179">src/videotilecontroller/DefaultVideoTileController.ts:179</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -645,7 +645,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#startlocalvideotile">startLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L47">src/videotilecontroller/DefaultVideoTileController.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -663,7 +663,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#stoplocalvideotile">stopLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L54">src/videotilecontroller/DefaultVideoTileController.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -681,7 +681,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#unbindvideoelement">unbindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L43">src/videotilecontroller/DefaultVideoTileController.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -705,7 +705,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/DefaultVideoTileController.ts:97</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L97">src/videotilecontroller/DefaultVideoTileController.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideotilefactory.html
+++ b/docs/classes/defaultvideotilefactory.html
@@ -106,7 +106,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilefactory.html">VideoTileFactory</a>.<a href="../interfaces/videotilefactory.html#maketile">makeTile</a></p>
 								<ul>
-									<li>Defined in src/videotilefactory/DefaultVideoTileFactory.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilefactory/DefaultVideoTileFactory.ts#L11">src/videotilefactory/DefaultVideoTileFactory.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvolumeindicatoradapter.html
+++ b/docs/classes/defaultvolumeindicatoradapter.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L19">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L22">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Volume<wbr>Decibels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L25">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">min<wbr>Volume<wbr>Decibels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L24">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L23">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>IdTo<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L14">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>IdTo<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L15">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">warned<wbr>About<wbr>Missing<wbr>Stream<wbr>IdMapping<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L16">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">IMPLICIT_<wbr>SIGNAL_<wbr>STRENGTH<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L19">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">IMPLICIT_<wbr>VOLUME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L18">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAX_<wbr>SIGNAL_<wbr>STRENGTH_<wbr>LEVELS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L17">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,7 +293,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:130</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L130">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:130</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:165</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L165">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:165</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:123</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L123">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:123</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:115</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L115">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L88">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -411,7 +411,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L28">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultwebsocketadapter.html
+++ b/docs/classes/defaultwebsocketadapter.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L10">src/websocketadapter/DefaultWebSocketAdapter.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">WebSocket</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L10">src/websocketadapter/DefaultWebSocketAdapter.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L12">src/websocketadapter/DefaultWebSocketAdapter.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#addeventlistener">addEventListener</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L40">src/websocketadapter/DefaultWebSocketAdapter.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -200,7 +200,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L32">src/websocketadapter/DefaultWebSocketAdapter.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L14">src/websocketadapter/DefaultWebSocketAdapter.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L36">src/websocketadapter/DefaultWebSocketAdapter.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -272,7 +272,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#readystate">readyState</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L44">src/websocketadapter/DefaultWebSocketAdapter.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/websocketreadystate.html" class="tsd-signature-type">WebSocketReadyState</a></h4>
@@ -290,7 +290,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/websocketadapter.html">WebSocketAdapter</a>.<a href="../interfaces/websocketadapter.html#send">send</a></p>
 								<ul>
-									<li>Defined in src/websocketadapter/DefaultWebSocketAdapter.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/DefaultWebSocketAdapter.ts#L19">src/websocketadapter/DefaultWebSocketAdapter.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/devicepixelratiowindowsource.html
+++ b/docs/classes/devicepixelratiowindowsource.html
@@ -106,7 +106,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratiosource.html">DevicePixelRatioSource</a>.<a href="../interfaces/devicepixelratiosource.html#devicepixelratio">devicePixelRatio</a></p>
 								<ul>
-									<li>Defined in src/devicepixelratiosource/DevicePixelRatioWindowSource.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiosource/DevicePixelRatioWindowSource.ts#L7">src/devicepixelratiosource/DevicePixelRatioWindowSource.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>

--- a/docs/classes/deviceselection.html
+++ b/docs/classes/deviceselection.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">constraints<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStreamConstraints</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DeviceSelection.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceSelection.ts#L5">src/devicecontroller/DeviceSelection.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">group<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DeviceSelection.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceSelection.ts#L7">src/devicecontroller/DeviceSelection.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DeviceSelection.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceSelection.ts#L6">src/devicecontroller/DeviceSelection.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceSelection.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceSelection.ts#L9">src/devicecontroller/DeviceSelection.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/dragandzoompresentationpolicy.html
+++ b/docs/classes/dragandzoompresentationpolicy.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/policy/DragAndZoomPresentationPolicy.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/DragAndZoomPresentationPolicy.ts#L14">src/presentation/policy/DragAndZoomPresentationPolicy.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/policy/DragAndZoomPresentationPolicy.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/DragAndZoomPresentationPolicy.ts#L66">src/presentation/policy/DragAndZoomPresentationPolicy.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/policy/DragAndZoomPresentationPolicy.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/DragAndZoomPresentationPolicy.ts#L101">src/presentation/policy/DragAndZoomPresentationPolicy.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/policy/DragAndZoomPresentationPolicy.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/DragAndZoomPresentationPolicy.ts#L88">src/presentation/policy/DragAndZoomPresentationPolicy.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/finishgatheringicecandidatestask.html
+++ b/docs/classes/finishgatheringicecandidatestask.html
@@ -135,7 +135,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L19">src/task/FinishGatheringICECandidatesTask.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L19">src/task/FinishGatheringICECandidatesTask.ts:19</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">chrome<wbr>Vpn<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L23">src/task/FinishGatheringICECandidatesTask.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L22">src/task/FinishGatheringICECandidatesTask.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">start<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L18">src/task/FinishGatheringICECandidatesTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L14">src/task/FinishGatheringICECandidatesTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<div class="tsd-signature tsd-kind-icon">CHROME_<wbr>VPN_<wbr>TIMEOUT_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L16">src/task/FinishGatheringICECandidatesTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L40">src/task/FinishGatheringICECandidatesTask.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -280,7 +280,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -298,7 +298,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -323,7 +323,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -340,7 +340,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L28">src/task/FinishGatheringICECandidatesTask.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -359,7 +359,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/FinishGatheringICECandidatesTask.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/FinishGatheringICECandidatesTask.ts#L61">src/task/FinishGatheringICECandidatesTask.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -378,7 +378,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/fulljitterbackoff.html
+++ b/docs/classes/fulljitterbackoff.html
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoff.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L13">src/backoff/FullJitterBackoff.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Retry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoff.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L13">src/backoff/FullJitterBackoff.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">fixed<wbr>Wait<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoff.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L16">src/backoff/FullJitterBackoff.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">long<wbr>Backoff<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoff.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L18">src/backoff/FullJitterBackoff.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">short<wbr>Backoff<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoff.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L17">src/backoff/FullJitterBackoff.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/backoff.html">Backoff</a>.<a href="../interfaces/backoff.html#nextbackoffamountms">nextBackoffAmountMs</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoff.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L36">src/backoff/FullJitterBackoff.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/backoff.html">Backoff</a>.<a href="../interfaces/backoff.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoff.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L32">src/backoff/FullJitterBackoff.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/fulljitterbackofffactory.html
+++ b/docs/classes/fulljitterbackofffactory.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoffFactory.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L9">src/backoff/FullJitterBackoffFactory.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">fixed<wbr>Wait<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoffFactory.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L11">src/backoff/FullJitterBackoffFactory.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">long<wbr>Backoff<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoffFactory.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L13">src/backoff/FullJitterBackoffFactory.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">short<wbr>Backoff<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterBackoffFactory.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L12">src/backoff/FullJitterBackoffFactory.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/backofffactory.html">BackoffFactory</a>.<a href="../interfaces/backofffactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoffFactory.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L16">src/backoff/FullJitterBackoffFactory.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/backoff.html" class="tsd-signature-type">Backoff</a></h4>
@@ -204,7 +204,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/backofffactory.html">BackoffFactory</a>.<a href="../interfaces/backofffactory.html#createwithlimit">createWithLimit</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoffFactory.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoffFactory.ts#L20">src/backoff/FullJitterBackoffFactory.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/fulljitterlimitedbackoff.html
+++ b/docs/classes/fulljitterlimitedbackoff.html
@@ -125,7 +125,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="fulljitterbackoff.html">FullJitterBackoff</a>.<a href="fulljitterbackoff.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterLimitedBackoff.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterLimitedBackoff.ts#L7">src/backoff/FullJitterLimitedBackoff.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">attempts<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterLimitedBackoff.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterLimitedBackoff.ts#L7">src/backoff/FullJitterLimitedBackoff.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/backoff/FullJitterLimitedBackoff.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterLimitedBackoff.ts#L13">src/backoff/FullJitterLimitedBackoff.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 								<p>Implementation of <a href="../interfaces/backoff.html">Backoff</a>.<a href="../interfaces/backoff.html#nextbackoffamountms">nextBackoffAmountMs</a></p>
 								<p>Overrides <a href="fulljitterbackoff.html">FullJitterBackoff</a>.<a href="fulljitterbackoff.html#nextbackoffamountms">nextBackoffAmountMs</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterLimitedBackoff.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterLimitedBackoff.ts#L18">src/backoff/FullJitterLimitedBackoff.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -204,7 +204,7 @@
 								<p>Implementation of <a href="../interfaces/backoff.html">Backoff</a>.<a href="../interfaces/backoff.html#reset">reset</a></p>
 								<p>Inherited from <a href="fulljitterbackoff.html">FullJitterBackoff</a>.<a href="fulljitterbackoff.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in src/backoff/FullJitterBackoff.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/FullJitterBackoff.ts#L32">src/backoff/FullJitterBackoff.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/globalmetricreport.html
+++ b/docs/classes/globalmetricreport.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Metrics<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/GlobalMetricReport.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/GlobalMetricReport.ts#L6">src/clientmetricreport/GlobalMetricReport.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Metrics<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/GlobalMetricReport.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/GlobalMetricReport.ts#L5">src/clientmetricreport/GlobalMetricReport.ts:5</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/classes/initializedefaultjpegdecodercontrollertask.html
+++ b/docs/classes/initializedefaultjpegdecodercontrollertask.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/InitializeDefaultJPEGDecoderControllerTask.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/InitializeDefaultJPEGDecoderControllerTask.ts#L8">src/task/InitializeDefaultJPEGDecoderControllerTask.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">defaultJPEGDecoder<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="defaultjpegdecodercontroller.html" class="tsd-signature-type">DefaultJPEGDecoderController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/InitializeDefaultJPEGDecoderControllerTask.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/InitializeDefaultJPEGDecoderControllerTask.ts#L10">src/task/InitializeDefaultJPEGDecoderControllerTask.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/InitializeDefaultJPEGDecoderControllerTask.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/InitializeDefaultJPEGDecoderControllerTask.ts#L11">src/task/InitializeDefaultJPEGDecoderControllerTask.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L12">src/task/BaseTask.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -214,7 +214,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -232,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +257,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -276,7 +276,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/InitializeDefaultJPEGDecoderControllerTask.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/InitializeDefaultJPEGDecoderControllerTask.ts#L16">src/task/InitializeDefaultJPEGDecoderControllerTask.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -295,7 +295,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/intervalscheduler.html
+++ b/docs/classes/intervalscheduler.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/IntervalScheduler.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/IntervalScheduler.ts#L11">src/scheduler/IntervalScheduler.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/scheduler/IntervalScheduler.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/IntervalScheduler.ts#L13">src/scheduler/IntervalScheduler.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/scheduler/IntervalScheduler.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/IntervalScheduler.ts#L11">src/scheduler/IntervalScheduler.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/IntervalScheduler.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/IntervalScheduler.ts#L15">src/scheduler/IntervalScheduler.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -211,7 +211,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/scheduler.html">Scheduler</a>.<a href="../interfaces/scheduler.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/scheduler/IntervalScheduler.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/IntervalScheduler.ts#L20">src/scheduler/IntervalScheduler.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/joinandreceiveindextask.html
+++ b/docs/classes/joinandreceiveindextask.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/JoinAndReceiveIndexTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L24">src/task/JoinAndReceiveIndexTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/JoinAndReceiveIndexTask.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L26">src/task/JoinAndReceiveIndexTask.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Videos<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 16</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/JoinAndReceiveIndexTask.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L24">src/task/JoinAndReceiveIndexTask.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Canceler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/taskcanceler.html" class="tsd-signature-type">TaskCanceler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/JoinAndReceiveIndexTask.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L23">src/task/JoinAndReceiveIndexTask.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/JoinAndReceiveIndexTask.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L22">src/task/JoinAndReceiveIndexTask.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/JoinAndReceiveIndexTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L30">src/task/JoinAndReceiveIndexTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -233,7 +233,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -276,7 +276,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -295,7 +295,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/JoinAndReceiveIndexTask.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/JoinAndReceiveIndexTask.ts#L37">src/task/JoinAndReceiveIndexTask.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -314,7 +314,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/jpegdecoder.html
+++ b/docs/classes/jpegdecoder.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L8">src/jpegdecoder/webassembly/JPEGDecoder.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">module<span class="tsd-signature-symbol">:</span> <a href="jpegdecodermodule.html" class="tsd-signature-type">JPEGDecoderModule</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L8">src/jpegdecoder/webassembly/JPEGDecoder.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">pointer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L7">src/jpegdecoder/webassembly/JPEGDecoder.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L25">src/jpegdecoder/webassembly/JPEGDecoder.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L15">src/jpegdecoder/webassembly/JPEGDecoder.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L33">src/jpegdecoder/webassembly/JPEGDecoder.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L21">src/jpegdecoder/webassembly/JPEGDecoder.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoder.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoder.ts#L29">src/jpegdecoder/webassembly/JPEGDecoder.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>

--- a/docs/classes/jpegdecoderinput.html
+++ b/docs/classes/jpegdecoderinput.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderInput.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderInput.ts#L8">src/jpegdecoder/webassembly/JPEGDecoderInput.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">module<span class="tsd-signature-symbol">:</span> <a href="jpegdecodermodule.html" class="tsd-signature-type">JPEGDecoderModule</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderInput.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderInput.ts#L8">src/jpegdecoder/webassembly/JPEGDecoderInput.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">pointer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderInput.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderInput.ts#L7">src/jpegdecoder/webassembly/JPEGDecoderInput.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderInput.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderInput.ts#L15">src/jpegdecoder/webassembly/JPEGDecoderInput.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -182,7 +182,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderInput.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderInput.ts#L21">src/jpegdecoder/webassembly/JPEGDecoderInput.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>

--- a/docs/classes/jpegdecodermodule.html
+++ b/docs/classes/jpegdecodermodule.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:6</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L6">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L7">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">wasm<wbr>Internal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L51">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L46">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L24">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -198,7 +198,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L17">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Uint8Array</span></h4>
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/webassembly/JPEGDecoderModule.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/webassembly/JPEGDecoderModule.ts#L42">src/jpegdecoder/webassembly/JPEGDecoderModule.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>

--- a/docs/classes/leaveandreceiveleaveacktask.html
+++ b/docs/classes/leaveandreceiveleaveacktask.html
@@ -139,7 +139,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L19">src/task/LeaveAndReceiveLeaveAckTask.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L21">src/task/LeaveAndReceiveLeaveAckTask.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Canceler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/taskcanceler.html" class="tsd-signature-type">TaskCanceler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L19">src/task/LeaveAndReceiveLeaveAckTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L18">src/task/LeaveAndReceiveLeaveAckTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L25">src/task/LeaveAndReceiveLeaveAckTask.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -230,7 +230,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -248,7 +248,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L40">src/task/LeaveAndReceiveLeaveAckTask.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -309,7 +309,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/LeaveAndReceiveLeaveAckTask.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/LeaveAndReceiveLeaveAckTask.ts#L32">src/task/LeaveAndReceiveLeaveAckTask.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -328,7 +328,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/linkmediastats.html
+++ b/docs/classes/linkmediastats.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L15">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="linkmediastats.html" class="tsd-signature-type">LinkMediaStats</a></h4>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">bandwidth<wbr>Estimate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L23">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L26">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L25">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">rtt<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L27">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">used<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L24">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/listenforvolumeindicatorstask.html
+++ b/docs/classes/listenforvolumeindicatorstask.html
@@ -135,7 +135,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L18">src/task/ListenForVolumeIndicatorsTask.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L19">src/task/ListenForVolumeIndicatorsTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L18">src/task/ListenForVolumeIndicatorsTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -234,7 +234,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L38">src/task/ListenForVolumeIndicatorsTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -283,7 +283,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L55">src/task/ListenForVolumeIndicatorsTask.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L31">src/task/ListenForVolumeIndicatorsTask.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -343,7 +343,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ListenForVolumeIndicatorsTask.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ListenForVolumeIndicatorsTask.ts#L23">src/task/ListenForVolumeIndicatorsTask.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -362,7 +362,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/log.html
+++ b/docs/classes/log.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Log.ts:4</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L4">src/logger/Log.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">log<wbr>Level<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/Log.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L9">src/logger/Log.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/Log.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L7">src/logger/Log.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">sequence<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/Log.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L6">src/logger/Log.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/Log.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Log.ts#L8">src/logger/Log.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/maybe.html
+++ b/docs/classes/maybe.html
@@ -99,7 +99,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/Maybe.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Maybe.ts#L9">src/maybe/Maybe.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/mediadeviceproxyhandler.html
+++ b/docs/classes/mediadeviceproxyhandler.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Change<wbr>Listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListenerOrEventListenerObject</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L19">src/mediadevicefactory/MediaDeviceProxyHandler.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">devices<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L18">src/mediadevicefactory/MediaDeviceProxyHandler.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">scheduler<span class="tsd-signature-symbol">:</span> <a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L17">src/mediadevicefactory/MediaDeviceProxyHandler.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTERVAL_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L15">src/mediadevicefactory/MediaDeviceProxyHandler.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L22">src/mediadevicefactory/MediaDeviceProxyHandler.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L114">src/mediadevicefactory/MediaDeviceProxyHandler.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L37">src/mediadevicefactory/MediaDeviceProxyHandler.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L61">src/mediadevicefactory/MediaDeviceProxyHandler.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -266,7 +266,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L85">src/mediadevicefactory/MediaDeviceProxyHandler.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L100">src/mediadevicefactory/MediaDeviceProxyHandler.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/meetingreadinesscheckerconfiguration.html
+++ b/docs/classes/meetingreadinesscheckerconfiguration.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts#L12">src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">wait<wbr>Duration<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 3000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts#L18">src/meetingreadinesschecker/MeetingReadinessCheckerConfiguration.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/meetingsessionconfiguration.html
+++ b/docs/classes/meetingsessionconfiguration.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L91">src/meetingsession/MeetingSessionConfiguration.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Presence<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:53</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L53">src/meetingsession/MeetingSessionConfiguration.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Health<wbr>Policy<wbr>Configuration<span class="tsd-signature-symbol">:</span> <a href="connectionhealthpolicyconfiguration.html" class="tsd-signature-type">ConnectionHealthPolicyConfiguration</a><span class="tsd-signature-symbol"> = new ConnectionHealthPolicyConfiguration()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:64</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L64">src/meetingsession/MeetingSessionConfiguration.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 15000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L37">src/meetingsession/MeetingSessionConfiguration.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">credentials<span class="tsd-signature-symbol">:</span> <a href="meetingsessioncredentials.html" class="tsd-signature-type">MeetingSessionCredentials</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L27">src/meetingsession/MeetingSessionConfiguration.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Simulcast<wbr>For<wbr>Unified<wbr>Plan<wbr>Chromium<wbr>Based<wbr>Browsers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:79</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L79">src/meetingsession/MeetingSessionConfiguration.ts:79</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -271,7 +271,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Unified<wbr>Plan<wbr>For<wbr>Chromium<wbr>Based<wbr>Browsers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:74</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L74">src/meetingsession/MeetingSessionConfiguration.ts:74</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">enable<wbr>Web<wbr>Audio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:69</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L69">src/meetingsession/MeetingSessionConfiguration.ts:69</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 					<div class="tsd-signature tsd-kind-icon">meeting<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L22">src/meetingsession/MeetingSessionConfiguration.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Sharing<wbr>Session<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingsessionoptions.html" class="tsd-signature-type">ScreenSharingSessionOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:58</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L58">src/meetingsession/MeetingSessionConfiguration.ts:58</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -331,7 +331,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Sharing<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L42">src/meetingsession/MeetingSessionConfiguration.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Viewing<wbr>Timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L47">src/meetingsession/MeetingSessionConfiguration.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -361,7 +361,7 @@
 					<div class="tsd-signature tsd-kind-icon">urls<span class="tsd-signature-symbol">:</span> <a href="meetingsessionurls.html" class="tsd-signature-type">MeetingSessionURLs</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L32">src/meetingsession/MeetingSessionConfiguration.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Downlink<wbr>Bandwidth<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videodownlinkbandwidthpolicy.html" class="tsd-signature-type">VideoDownlinkBandwidthPolicy</a><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:85</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L85">src/meetingsession/MeetingSessionConfiguration.ts:85</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -392,7 +392,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Uplink<wbr>Bandwidth<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videouplinkbandwidthpolicy.html" class="tsd-signature-type">VideoUplinkBandwidthPolicy</a><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionConfiguration.ts:91</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionConfiguration.ts#L91">src/meetingsession/MeetingSessionConfiguration.ts:91</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/meetingsessioncredentials.html
+++ b/docs/classes/meetingsessioncredentials.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionCredentials.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionCredentials.ts#L12">src/meetingsession/MeetingSessionCredentials.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">external<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionCredentials.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionCredentials.ts#L17">src/meetingsession/MeetingSessionCredentials.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">join<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionCredentials.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionCredentials.ts#L22">src/meetingsession/MeetingSessionCredentials.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionCredentials.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionCredentials.ts#L27">src/meetingsession/MeetingSessionCredentials.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/meetingsessionpostlogger.html
+++ b/docs/classes/meetingsessionpostlogger.html
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L13">src/logger/MeetingSessionPOSTLogger.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">batch<wbr>Size<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L18">src/logger/MeetingSessionPOSTLogger.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L17">src/logger/MeetingSessionPOSTLogger.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L19">src/logger/MeetingSessionPOSTLogger.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Scheduler<span class="tsd-signature-symbol">:</span> <a href="intervalscheduler.html" class="tsd-signature-type">IntervalScheduler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L13">src/logger/MeetingSessionPOSTLogger.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">level<span class="tsd-signature-symbol">:</span> <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L21">src/logger/MeetingSessionPOSTLogger.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">lock<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L12">src/logger/MeetingSessionPOSTLogger.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">log<wbr>Capture<span class="tsd-signature-symbol">:</span> <a href="log.html" class="tsd-signature-type">Log</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L10">src/logger/MeetingSessionPOSTLogger.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L16">src/logger/MeetingSessionPOSTLogger.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">sequence<wbr>Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L11">src/logger/MeetingSessionPOSTLogger.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L20">src/logger/MeetingSessionPOSTLogger.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L33">src/logger/MeetingSessionPOSTLogger.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L48">src/logger/MeetingSessionPOSTLogger.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L60">src/logger/MeetingSessionPOSTLogger.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L56">src/logger/MeetingSessionPOSTLogger.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -366,7 +366,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L40">src/logger/MeetingSessionPOSTLogger.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -389,7 +389,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L103">src/logger/MeetingSessionPOSTLogger.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -415,7 +415,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L94">src/logger/MeetingSessionPOSTLogger.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +438,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L52">src/logger/MeetingSessionPOSTLogger.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -461,7 +461,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L64">src/logger/MeetingSessionPOSTLogger.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -484,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L88">src/logger/MeetingSessionPOSTLogger.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -501,7 +501,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MeetingSessionPOSTLogger.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L44">src/logger/MeetingSessionPOSTLogger.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/meetingsessionstatus.html
+++ b/docs/classes/meetingsessionstatus.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L10">src/meetingsession/MeetingSessionStatus.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">_status<wbr>Code<span class="tsd-signature-symbol">:</span> <a href="../enums/meetingsessionstatuscode.html" class="tsd-signature-type">MeetingSessionStatusCode</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatus.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L11">src/meetingsession/MeetingSessionStatus.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L61">src/meetingsession/MeetingSessionStatus.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L17">src/meetingsession/MeetingSessionStatus.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L40">src/meetingsession/MeetingSessionStatus.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L13">src/meetingsession/MeetingSessionStatus.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/meetingsessionstatuscode.html" class="tsd-signature-type">MeetingSessionStatusCode</a></h4>
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L91">src/meetingsession/MeetingSessionStatus.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L79">src/meetingsession/MeetingSessionStatus.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionStatus.ts:120</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatus.ts#L120">src/meetingsession/MeetingSessionStatus.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/meetingsessionturncredentials.html
+++ b/docs/classes/meetingsessionturncredentials.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">password<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionTURNCredentials.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionTURNCredentials.ts#L9">src/meetingsession/MeetingSessionTURNCredentials.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">ttl<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionTURNCredentials.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionTURNCredentials.ts#L10">src/meetingsession/MeetingSessionTURNCredentials.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">uris<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionTURNCredentials.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionTURNCredentials.ts#L11">src/meetingsession/MeetingSessionTURNCredentials.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionTURNCredentials.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionTURNCredentials.ts#L8">src/meetingsession/MeetingSessionTURNCredentials.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/meetingsessionurls.html
+++ b/docs/classes/meetingsessionurls.html
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">_audio<wbr>HostURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L12">src/meetingsession/MeetingSessionURLs.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">_screen<wbr>DataURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L17">src/meetingsession/MeetingSessionURLs.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">_screen<wbr>SharingURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L22">src/meetingsession/MeetingSessionURLs.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">_screen<wbr>ViewingURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L27">src/meetingsession/MeetingSessionURLs.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">_signalingURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L32">src/meetingsession/MeetingSessionURLs.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">_turn<wbr>ControlURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionURLs.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L37">src/meetingsession/MeetingSessionURLs.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L42">src/meetingsession/MeetingSessionURLs.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L49">src/meetingsession/MeetingSessionURLs.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L56">src/meetingsession/MeetingSessionURLs.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -278,7 +278,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L63">src/meetingsession/MeetingSessionURLs.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L70">src/meetingsession/MeetingSessionURLs.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -320,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L77">src/meetingsession/MeetingSessionURLs.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L84">src/meetingsession/MeetingSessionURLs.ts:84</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -362,7 +362,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L91">src/meetingsession/MeetingSessionURLs.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:98</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L98">src/meetingsession/MeetingSessionURLs.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:105</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L105">src/meetingsession/MeetingSessionURLs.ts:105</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -433,7 +433,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:112</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L112">src/meetingsession/MeetingSessionURLs.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -446,7 +446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L119">src/meetingsession/MeetingSessionURLs.ts:119</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionURLs.ts:127</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionURLs.ts#L127">src/meetingsession/MeetingSessionURLs.ts:127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/meetingsessionvideoavailability.html
+++ b/docs/classes/meetingsessionvideoavailability.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">can<wbr>Start<wbr>Local<wbr>Video<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionVideoAvailability.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionVideoAvailability.ts#L21">src/meetingsession/MeetingSessionVideoAvailability.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">remote<wbr>Video<wbr>Available<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionVideoAvailability.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionVideoAvailability.ts#L13">src/meetingsession/MeetingSessionVideoAvailability.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionVideoAvailability.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionVideoAvailability.ts#L36">src/meetingsession/MeetingSessionVideoAvailability.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingsession/MeetingSessionVideoAvailability.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionVideoAvailability.ts#L26">src/meetingsession/MeetingSessionVideoAvailability.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/monitortask.html
+++ b/docs/classes/monitortask.html
@@ -152,7 +152,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L42">src/task/MonitorTask.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:45</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L45">src/task/MonitorTask.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Available<wbr>Stream<wbr>Avg<wbr>Bitrates<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ISdkBitrateFrame</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L42">src/task/MonitorTask.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Video<wbr>Downlink<wbr>Bandwidth<wbr>Estimation<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L41">src/task/MonitorTask.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">initial<wbr>Connection<wbr>Health<wbr>Data<span class="tsd-signature-symbol">:</span> <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L47">src/task/MonitorTask.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">prev<wbr>Signal<wbr>Strength<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L37">src/task/MonitorTask.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">reconnection<wbr>Health<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="reconnectionhealthpolicy.html" class="tsd-signature-type">ReconnectionHealthPolicy</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L35">src/task/MonitorTask.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L33">src/task/MonitorTask.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">unusable<wbr>Audio<wbr>Warning<wbr>Health<wbr>Policy<span class="tsd-signature-symbol">:</span> <a href="unusableaudiowarningconnectionhealthpolicy.html" class="tsd-signature-type">UnusableAudioWarningConnectionHealthPolicy</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L36">src/task/MonitorTask.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>DOWNLINK_<wbr>CALLRATE_<wbr>OVERSHOOT_<wbr>FACTOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1.5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L39">src/task/MonitorTask.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>DOWNLINK_<wbr>CALLRATE_<wbr>UNDERSHOOT_<wbr>FACTOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0.5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L40">src/task/MonitorTask.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>TIMEOUT_<wbr>FOR_<wbr>START_<wbr>SENDING_<wbr>VIDEO_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 30000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/MonitorTask.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L38">src/task/MonitorTask.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -311,7 +311,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -328,7 +328,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:337</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L337">src/task/MonitorTask.ts:337</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L128">src/task/MonitorTask.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#connectionhealthdidchange">connectionHealthDidChange</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:247</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L247">src/task/MonitorTask.ts:247</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -399,7 +399,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -416,7 +416,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:288</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L288">src/task/MonitorTask.ts:288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -440,7 +440,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:320</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L320">src/task/MonitorTask.ts:320</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -464,7 +464,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -488,7 +488,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#metricsdidreceive">metricsDidReceive</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:169</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L169">src/task/MonitorTask.ts:169</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -530,7 +530,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:355</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L355">src/task/MonitorTask.ts:355</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -554,7 +554,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L61">src/task/MonitorTask.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -573,7 +573,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L72">src/task/MonitorTask.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -592,7 +592,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -616,7 +616,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videoreceivebandwidthdidchange">videoReceiveBandwidthDidChange</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L121">src/task/MonitorTask.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -643,7 +643,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videosendhealthdidchange">videoSendHealthDidChange</a></p>
 								<ul>
-									<li>Defined in src/task/MonitorTask.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L85">src/task/MonitorTask.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/multilogger.html
+++ b/docs/classes/multilogger.html
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L11">src/logger/MultiLogger.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">_loggers<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/MultiLogger.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L11">src/logger/MultiLogger.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L35">src/logger/MultiLogger.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -204,7 +204,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#error">error</a></p>
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L29">src/logger/MultiLogger.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L47">src/logger/MultiLogger.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#info">info</a></p>
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L17">src/logger/MultiLogger.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -270,7 +270,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L41">src/logger/MultiLogger.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -294,7 +294,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#warn">warn</a></p>
 								<ul>
-									<li>Defined in src/logger/MultiLogger.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L23">src/logger/MultiLogger.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/none.html
+++ b/docs/classes/none.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/None.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L9">src/maybe/None.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="none.html" class="tsd-signature-type">None</a></h4>
@@ -148,7 +148,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#isnone">isNone</a></p>
 						<ul>
-							<li>Defined in src/maybe/None.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L9">src/maybe/None.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#issome">isSome</a></p>
 						<ul>
-							<li>Defined in src/maybe/None.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L8">src/maybe/None.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#defaulting">defaulting</a></p>
 								<ul>
-									<li>Defined in src/maybe/None.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L29">src/maybe/None.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/None.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L25">src/maybe/None.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -248,7 +248,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#get">get</a></p>
 								<ul>
-									<li>Defined in src/maybe/None.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L13">src/maybe/None.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span></h4>
@@ -266,7 +266,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#getorelse">getOrElse</a></p>
 								<ul>
-									<li>Defined in src/maybe/None.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L17">src/maybe/None.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -289,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/None.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L21">src/maybe/None.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/None.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/None.ts#L33">src/maybe/None.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -144,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/NoOpAudioVideoController.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/NoOpAudioVideoController.ts#L14">src/audiovideocontroller/NoOpAudioVideoController.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -171,7 +171,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#activespeakerdetector">activeSpeakerDetector</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:142</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L142">src/audiovideocontroller/DefaultAudioVideoController.ts:142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/activespeakerdetector.html" class="tsd-signature-type">ActiveSpeakerDetector</a></h4>
@@ -189,7 +189,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#audiomixcontroller">audioMixController</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L150">src/audiovideocontroller/DefaultAudioVideoController.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a></h4>
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#configuration">configuration</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L134">src/audiovideocontroller/DefaultAudioVideoController.ts:134</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></h4>
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#logger">logger</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:154</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L154">src/audiovideocontroller/DefaultAudioVideoController.ts:154</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#mediastreambroker">mediaStreamBroker</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:162</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L162">src/audiovideocontroller/DefaultAudioVideoController.ts:162</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#realtimecontroller">realtimeController</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L138">src/audiovideocontroller/DefaultAudioVideoController.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></h4>
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#rtcpeerconnection">rtcPeerConnection</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:158</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L158">src/audiovideocontroller/DefaultAudioVideoController.ts:158</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCPeerConnection</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#videotilecontroller">videoTileController</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:146</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L146">src/audiovideocontroller/DefaultAudioVideoController.ts:146</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></h4>
@@ -319,7 +319,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#addobserver">addObserver</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:173</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L173">src/audiovideocontroller/DefaultAudioVideoController.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -343,7 +343,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:183</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L183">src/audiovideocontroller/DefaultAudioVideoController.ts:183</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -386,7 +386,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:166</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L166">src/audiovideocontroller/DefaultAudioVideoController.ts:166</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:709</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L709">src/audiovideocontroller/DefaultAudioVideoController.ts:709</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -435,7 +435,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:652</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L652">src/audiovideocontroller/DefaultAudioVideoController.ts:652</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -463,7 +463,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:731</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L731">src/audiovideocontroller/DefaultAudioVideoController.ts:731</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -488,7 +488,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:543</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L543">src/audiovideocontroller/DefaultAudioVideoController.ts:543</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#removeobserver">removeObserver</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:178</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L178">src/audiovideocontroller/DefaultAudioVideoController.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -537,7 +537,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalaudio">restartLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:459</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L459">src/audiovideocontroller/DefaultAudioVideoController.ts:459</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -573,7 +573,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:436</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L436">src/audiovideocontroller/DefaultAudioVideoController.ts:436</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -610,7 +610,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:737</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L737">src/audiovideocontroller/DefaultAudioVideoController.ts:737</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -635,7 +635,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:700</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L700">src/audiovideocontroller/DefaultAudioVideoController.ts:700</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -660,7 +660,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#start">start</a></p>
 								<p>Overrides <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/NoOpAudioVideoController.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/NoOpAudioVideoController.ts#L37">src/audiovideocontroller/NoOpAudioVideoController.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -679,7 +679,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#stop">stop</a></p>
 								<p>Overrides <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/NoOpAudioVideoController.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/NoOpAudioVideoController.ts#L39">src/audiovideocontroller/NoOpAudioVideoController.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -698,7 +698,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#update">update</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#update">update</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/DefaultAudioVideoController.ts:426</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L426">src/audiovideocontroller/DefaultAudioVideoController.ts:426</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/noopdebuglogger.html
+++ b/docs/classes/noopdebuglogger.html
@@ -136,7 +136,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpDebugLogger.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpDebugLogger.ts#L11">src/logger/NoOpDebugLogger.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="noopdebuglogger.html" class="tsd-signature-type">NoOpDebugLogger</a></h4>
@@ -153,7 +153,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#level">level</a></p>
 						<ul>
-							<li>Defined in src/logger/NoOpLogger.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L11">src/logger/NoOpLogger.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#debug">debug</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L23">src/logger/NoOpLogger.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -208,7 +208,7 @@
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#error">error</a></p>
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#error">error</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L21">src/logger/NoOpLogger.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L34">src/logger/NoOpLogger.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -252,7 +252,7 @@
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#info">info</a></p>
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#info">info</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L17">src/logger/NoOpLogger.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L30">src/logger/NoOpLogger.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -302,7 +302,7 @@
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#warn">warn</a></p>
 								<p>Inherited from <a href="nooplogger.html">NoOpLogger</a>.<a href="nooplogger.html#warn">warn</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L19">src/logger/NoOpLogger.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/noopdevicecontroller.html
+++ b/docs/classes/noopdevicecontroller.html
@@ -133,7 +133,7 @@
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<p>Inherited from <a href="noopmediastreambroker.html">NoOpMediaStreamBroker</a>.<a href="noopmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L11">src/mediastreambroker/NoOpMediaStreamBroker.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -152,7 +152,7 @@
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<p>Inherited from <a href="noopmediastreambroker.html">NoOpMediaStreamBroker</a>.<a href="noopmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L19">src/mediastreambroker/NoOpMediaStreamBroker.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -177,7 +177,7 @@
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<p>Inherited from <a href="noopmediastreambroker.html">NoOpMediaStreamBroker</a>.<a href="noopmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L15">src/mediastreambroker/NoOpMediaStreamBroker.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -195,7 +195,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L37">src/devicecontroller/NoOpDeviceController.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -220,7 +220,7 @@
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<p>Inherited from <a href="noopmediastreambroker.html">NoOpMediaStreamBroker</a>.<a href="noopmediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L25">src/mediastreambroker/NoOpMediaStreamBroker.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L25">src/devicecontroller/NoOpDeviceController.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -268,7 +268,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L33">src/devicecontroller/NoOpDeviceController.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -292,7 +292,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L29">src/devicecontroller/NoOpDeviceController.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -316,7 +316,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L55">src/devicecontroller/NoOpDeviceController.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -349,7 +349,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L41">src/devicecontroller/NoOpDeviceController.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AnalyserNode</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -367,7 +367,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L66">src/devicecontroller/NoOpDeviceController.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -391,7 +391,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L62">src/devicecontroller/NoOpDeviceController.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -409,7 +409,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L13">src/devicecontroller/NoOpDeviceController.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -427,7 +427,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L21">src/devicecontroller/NoOpDeviceController.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -445,7 +445,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L17">src/devicecontroller/NoOpDeviceController.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -463,7 +463,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L51">src/devicecontroller/NoOpDeviceController.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -488,7 +488,7 @@
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#releasemediastream">releaseMediaStream</a></p>
 								<p>Inherited from <a href="noopmediastreambroker.html">NoOpMediaStreamBroker</a>.<a href="noopmediastreambroker.html#releasemediastream">releaseMediaStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L23">src/mediastreambroker/NoOpMediaStreamBroker.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -512,7 +512,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L39">src/devicecontroller/NoOpDeviceController.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -535,7 +535,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L49">src/devicecontroller/NoOpDeviceController.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -571,7 +571,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L45">src/devicecontroller/NoOpDeviceController.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/NoOpDeviceController.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L47">src/devicecontroller/NoOpDeviceController.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/nooplogger.html
+++ b/docs/classes/nooplogger.html
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L11">src/logger/NoOpLogger.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">level<span class="tsd-signature-symbol">:</span> <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/NoOpLogger.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L11">src/logger/NoOpLogger.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L23">src/logger/NoOpLogger.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -209,7 +209,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#error">error</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L21">src/logger/NoOpLogger.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -233,7 +233,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L34">src/logger/NoOpLogger.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#info">info</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L17">src/logger/NoOpLogger.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L30">src/logger/NoOpLogger.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#warn">warn</a></p>
 								<ul>
-									<li>Defined in src/logger/NoOpLogger.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/NoOpLogger.ts#L19">src/logger/NoOpLogger.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/noopmediastreambroker.html
+++ b/docs/classes/noopmediastreambroker.html
@@ -122,7 +122,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L11">src/mediastreambroker/NoOpMediaStreamBroker.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L19">src/mediastreambroker/NoOpMediaStreamBroker.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -164,7 +164,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L15">src/mediastreambroker/NoOpMediaStreamBroker.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -182,7 +182,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L25">src/mediastreambroker/NoOpMediaStreamBroker.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -206,7 +206,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambroker.html">MediaStreamBroker</a>.<a href="../interfaces/mediastreambroker.html#releasemediastream">releaseMediaStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/NoOpMediaStreamBroker.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/NoOpMediaStreamBroker.ts#L23">src/mediastreambroker/NoOpMediaStreamBroker.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/nooptask.html
+++ b/docs/classes/nooptask.html
@@ -109,7 +109,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/NoOpTask.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/NoOpTask.ts#L7">src/task/NoOpTask.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -127,7 +127,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/NoOpTask.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/NoOpTask.ts#L9">src/task/NoOpTask.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -145,7 +145,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/NoOpTask.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/NoOpTask.ts#L13">src/task/NoOpTask.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -163,7 +163,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/NoOpTask.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/NoOpTask.ts#L17">src/task/NoOpTask.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/noopvideoelementfactory.html
+++ b/docs/classes/noopvideoelementfactory.html
@@ -106,7 +106,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videoelementfactory.html">VideoElementFactory</a>.<a href="../interfaces/videoelementfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/videoelementfactory/NoOpVideoElementFactory.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videoelementfactory/NoOpVideoElementFactory.ts#L7">src/videoelementfactory/NoOpVideoElementFactory.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">HTMLVideoElement</span></h4>

--- a/docs/classes/novideodownlinkbandwidthpolicy.html
+++ b/docs/classes/novideodownlinkbandwidthpolicy.html
@@ -110,7 +110,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts#L16">src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -128,7 +128,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatecalculatedoptimalreceiveset">updateCalculatedOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts#L12">src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts#L10">src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -169,7 +169,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts#L11">src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts#L13">src/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/novideouplinkbandwidthpolicy.html
+++ b/docs/classes/novideouplinkbandwidthpolicy.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L10">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="novideouplinkbandwidthpolicy.html" class="tsd-signature-type">NoVideoUplinkBandwidthPolicy</a></h4>
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosecaptureandencodeparameters">chooseCaptureAndEncodeParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L23">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videocaptureandencodeparameter.html" class="tsd-signature-type">VideoCaptureAndEncodeParameter</a></h4>
@@ -158,7 +158,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#chooseencodingparameters">chooseEncodingParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L16">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosemediatrackconstraints">chooseMediaTrackConstraints</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L13">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaTrackConstraints</span></h4>
@@ -194,7 +194,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#maxbandwidthkbps">maxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L26">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -212,7 +212,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#sethasbandwidthpriority">setHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L30">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#setidealmaxbandwidthkbps">setIdealMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L29">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -260,7 +260,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#updateconnectionmetric">updateConnectionMetric</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L12">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -284,7 +284,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L19">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts#L20">src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/nscalevideouplinkbandwidthpolicy.html
+++ b/docs/classes/nscalevideouplinkbandwidthpolicy.html
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L18">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Bandwidth<wbr>Priority<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L18">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">ideal<wbr>Max<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1400</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L17">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">num<wbr>Participants<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L14">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">optimal<wbr>Parameters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L15">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">parameters<wbr>InEffect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L16">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">self<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L20">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L76">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L68">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -266,7 +266,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L60">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -284,7 +284,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosecaptureandencodeparameters">chooseCaptureAndEncodeParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L55">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></h4>
@@ -302,7 +302,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#chooseencodingparameters">chooseEncodingParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L33">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -320,7 +320,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosemediatrackconstraints">chooseMediaTrackConstraints</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L29">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaTrackConstraints</span></h4>
@@ -338,7 +338,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#maxbandwidthkbps">maxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L80">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -356,7 +356,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#sethasbandwidthpriority">setHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L99">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -380,7 +380,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#setidealmaxbandwidthkbps">setIdealMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:95</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L95">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#updateconnectionmetric">updateConnectionMetric</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L25">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -428,7 +428,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L37">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -452,7 +452,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L51">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/openscreensignalingsessiontask.html
+++ b/docs/classes/openscreensignalingsessiontask.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L10">src/task/OpenScreenSignalingSessionTask.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Request<span class="tsd-signature-symbol">:</span> <a href="screenviewingsessionconnectionrequest.html" class="tsd-signature-type">ScreenViewingSessionConnectionRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L14">src/task/OpenScreenSignalingSessionTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L15">src/task/OpenScreenSignalingSessionTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="../interfaces/signalingsession.html" class="tsd-signature-type">SignalingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L13">src/task/OpenScreenSignalingSessionTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L10">src/task/OpenScreenSignalingSessionTask.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -271,7 +271,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -290,7 +290,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/OpenScreenSignalingSessionTask.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenSignalingSessionTask.ts#L20">src/task/OpenScreenSignalingSessionTask.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -309,7 +309,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/openscreenviewingconnectiontask.html
+++ b/docs/classes/openscreenviewingconnectiontask.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L10">src/task/OpenScreenViewingConnectionTask.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingsession.html" class="tsd-signature-type">ScreenViewingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L13">src/task/OpenScreenViewingConnectionTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Request<span class="tsd-signature-symbol">:</span> <a href="screenviewingsessionconnectionrequest.html" class="tsd-signature-type">ScreenViewingSessionConnectionRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L14">src/task/OpenScreenViewingConnectionTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L15">src/task/OpenScreenViewingConnectionTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L10">src/task/OpenScreenViewingConnectionTask.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -271,7 +271,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -290,7 +290,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/OpenScreenViewingConnectionTask.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenScreenViewingConnectionTask.ts#L20">src/task/OpenScreenViewingConnectionTask.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -309,7 +309,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/opensignalingconnectiontask.html
+++ b/docs/classes/opensignalingconnectiontask.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/OpenSignalingConnectionTask.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L16">src/task/OpenSignalingConnectionTask.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenSignalingConnectionTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L18">src/task/OpenSignalingConnectionTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Canceler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/taskcanceler.html" class="tsd-signature-type">TaskCanceler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/OpenSignalingConnectionTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L16">src/task/OpenSignalingConnectionTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/OpenSignalingConnectionTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L14">src/task/OpenSignalingConnectionTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/OpenSignalingConnectionTask.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L22">src/task/OpenSignalingConnectionTask.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -222,7 +222,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -240,7 +240,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -265,7 +265,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -284,7 +284,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/OpenSignalingConnectionTask.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/OpenSignalingConnectionTask.ts#L29">src/task/OpenSignalingConnectionTask.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -303,7 +303,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/parallelgrouptask.html
+++ b/docs/classes/parallelgrouptask.html
@@ -138,7 +138,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ParallelGroupTask.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ParallelGroupTask.ts#L12">src/task/ParallelGroupTask.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ParallelGroupTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ParallelGroupTask.ts#L13">src/task/ParallelGroupTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">tasks<wbr>ToRun<wbr>Parallel<span class="tsd-signature-symbol">:</span> <a href="../interfaces/task.html" class="tsd-signature-type">Task</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ParallelGroupTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ParallelGroupTask.ts#L13">src/task/ParallelGroupTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/ParallelGroupTask.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ParallelGroupTask.ts#L20">src/task/ParallelGroupTask.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -268,7 +268,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -287,7 +287,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ParallelGroupTask.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ParallelGroupTask.ts#L27">src/task/ParallelGroupTask.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -306,7 +306,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/presentationelementfactory.html
+++ b/docs/classes/presentationelementfactory.html
@@ -101,7 +101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationElementFactory.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationElementFactory.ts#L10">src/presentation/PresentationElementFactory.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationElementFactory.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationElementFactory.ts#L41">src/presentation/PresentationElementFactory.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationElementFactory.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationElementFactory.ts#L49">src/presentation/PresentationElementFactory.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/protobufscreenmessagedetail.html
+++ b/docs/classes/protobufscreenmessagedetail.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenmessagedetail/ProtocolScreenMessageDetail.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetail/ProtocolScreenMessageDetail.ts#L7">src/screenmessagedetail/ProtocolScreenMessageDetail.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ISdkScreenSignalingMessage</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenmessagedetail/ProtocolScreenMessageDetail.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetail/ProtocolScreenMessageDetail.ts#L8">src/screenmessagedetail/ProtocolScreenMessageDetail.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenmessagedetail/ProtocolScreenMessageDetail.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetail/ProtocolScreenMessageDetail.ts#L10">src/screenmessagedetail/ProtocolScreenMessageDetail.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/docs/classes/protocolscreenmessagedetailserialization.html
+++ b/docs/classes/protocolscreenmessagedetailserialization.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenmessagedetailserialization/ProtocolScreenMessageDetailSerialization.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetailserialization/ProtocolScreenMessageDetailSerialization.ts#L13">src/screenmessagedetailserialization/ProtocolScreenMessageDetailSerialization.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/realtimeattendeepositioninframe.html
+++ b/docs/classes/realtimeattendeepositioninframe.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Index<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeAttendeePositionInFrame.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeAttendeePositionInFrame.ts#L11">src/realtimecontroller/RealtimeAttendeePositionInFrame.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendees<wbr>InFrame<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeAttendeePositionInFrame.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeAttendeePositionInFrame.ts#L16">src/realtimecontroller/RealtimeAttendeePositionInFrame.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/realtimestate.html
+++ b/docs/classes/realtimestate.html
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>IdChanges<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, externalUserId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, dropped<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span>, posInFrame<span class="tsd-signature-symbol">: </span><a href="realtimeattendeepositioninframe.html" class="tsd-signature-type">RealtimeAttendeePositionInFrame</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L25">src/realtimecontroller/RealtimeState.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>IdTo<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:66</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L66">src/realtimecontroller/RealtimeState.ts:66</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:56</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L56">src/realtimecontroller/RealtimeState.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">can<wbr>Unmute<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L36">src/realtimecontroller/RealtimeState.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">fatal<wbr>Error<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:89</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L89">src/realtimecontroller/RealtimeState.ts:89</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L15">src/realtimecontroller/RealtimeState.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L20">src/realtimecontroller/RealtimeState.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Signal<wbr>Strength<wbr>Change<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>signalStrength<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:84</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L84">src/realtimecontroller/RealtimeState.ts:84</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">mute<wbr>And<wbr>Unmute<wbr>Local<wbr>Audio<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>muted<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L51">src/realtimecontroller/RealtimeState.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -259,7 +259,7 @@
 					<div class="tsd-signature tsd-kind-icon">muted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L46">src/realtimecontroller/RealtimeState.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 					<div class="tsd-signature tsd-kind-icon">receive<wbr>Data<wbr>Message<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>dataMessage<span class="tsd-signature-symbol">: </span><a href="datamessage.html" class="tsd-signature-type">DataMessage</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:103</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L103">src/realtimecontroller/RealtimeState.ts:103</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -289,7 +289,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<wbr>Data<wbr>Message<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>topic<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">any</span>, lifetimeMs<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:94</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L94">src/realtimecontroller/RealtimeState.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>Can<wbr>Unmute<wbr>Local<wbr>Audio<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>canUnmute<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L41">src/realtimecontroller/RealtimeState.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<wbr>Indicator<wbr>Callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:71</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L71">src/realtimecontroller/RealtimeState.ts:71</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<wbr>Indicator<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeState.ts:61</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeState.ts#L61">src/realtimecontroller/RealtimeState.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/realtimevolumeindicator.html
+++ b/docs/classes/realtimevolumeindicator.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">muted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeVolumeIndicator.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeVolumeIndicator.ts#L10">src/realtimecontroller/RealtimeVolumeIndicator.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">signal<wbr>Strength<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeVolumeIndicator.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeVolumeIndicator.ts#L11">src/realtimecontroller/RealtimeVolumeIndicator.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">volume<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/realtimecontroller/RealtimeVolumeIndicator.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeVolumeIndicator.ts#L9">src/realtimecontroller/RealtimeVolumeIndicator.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/receiveaudioinputtask.html
+++ b/docs/classes/receiveaudioinputtask.html
@@ -137,7 +137,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveAudioInputTask.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveAudioInputTask.ts#L11">src/task/ReceiveAudioInputTask.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveAudioInputTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveAudioInputTask.ts#L13">src/task/ReceiveAudioInputTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ReceiveAudioInputTask.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveAudioInputTask.ts#L11">src/task/ReceiveAudioInputTask.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -218,7 +218,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -261,7 +261,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -280,7 +280,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveAudioInputTask.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveAudioInputTask.ts#L17">src/task/ReceiveAudioInputTask.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -299,7 +299,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/receiveturncredentialstask.html
+++ b/docs/classes/receiveturncredentialstask.html
@@ -134,7 +134,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L20">src/task/ReceiveTURNCredentialsTask.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L20">src/task/ReceiveTURNCredentialsTask.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L22">src/task/ReceiveTURNCredentialsTask.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">join<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L19">src/task/ReceiveTURNCredentialsTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">meeting<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L18">src/task/ReceiveTURNCredentialsTask.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L15">src/task/ReceiveTURNCredentialsTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L17">src/task/ReceiveTURNCredentialsTask.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L29">src/task/ReceiveTURNCredentialsTask.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -294,7 +294,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -319,7 +319,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -338,7 +338,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveTURNCredentialsTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveTURNCredentialsTask.ts#L34">src/task/ReceiveTURNCredentialsTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -357,7 +357,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/receivevideoinputtask.html
+++ b/docs/classes/receivevideoinputtask.html
@@ -138,7 +138,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoInputTask.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoInputTask.ts#L12">src/task/ReceiveVideoInputTask.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveVideoInputTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoInputTask.ts#L14">src/task/ReceiveVideoInputTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ReceiveVideoInputTask.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoInputTask.ts#L12">src/task/ReceiveVideoInputTask.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -219,7 +219,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -237,7 +237,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -262,7 +262,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -281,7 +281,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoInputTask.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoInputTask.ts#L18">src/task/ReceiveVideoInputTask.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -300,7 +300,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ReceiveVideoInputTask.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoInputTask.ts#L92">src/task/ReceiveVideoInputTask.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/receivevideostreamindextask.html
+++ b/docs/classes/receivevideostreamindextask.html
@@ -138,7 +138,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L28">src/task/ReceiveVideoStreamIndexTask.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L30">src/task/ReceiveVideoStreamIndexTask.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L28">src/task/ReceiveVideoStreamIndexTask.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -219,7 +219,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:57</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L57">src/task/ReceiveVideoStreamIndexTask.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -259,7 +259,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L135">src/task/ReceiveVideoStreamIndexTask.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L44">src/task/ReceiveVideoStreamIndexTask.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -326,7 +326,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L34">src/task/ReceiveVideoStreamIndexTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L86">src/task/ReceiveVideoStreamIndexTask.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -389,7 +389,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L38">src/task/ReceiveVideoStreamIndexTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -408,7 +408,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -431,7 +431,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/ReceiveVideoStreamIndexTask.ts:113</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/ReceiveVideoStreamIndexTask.ts#L113">src/task/ReceiveVideoStreamIndexTask.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/reconnectingpromisedwebsocket.html
+++ b/docs/classes/reconnectingpromisedwebsocket.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L18">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<span class="tsd-signature-symbol">:</span> <a href="../interfaces/backoff.html" class="tsd-signature-type">Backoff</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L25">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">binary<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="defaultscreensharingsessionfactory.html#binarytype" class="tsd-signature-type">BinaryType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L23">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">callbacks<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Set&lt;EventListener&gt;&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L16">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">protocols<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L22">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<wbr>Scheduler<span class="tsd-signature-symbol">:</span> <a href="timeoutscheduler.html" class="tsd-signature-type">TimeoutScheduler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L17">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#url">url</a></p>
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L21">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocket.html" class="tsd-signature-type">PromisedWebSocket</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L18">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L24">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">normal<wbr>Closure<wbr>Codes<span class="tsd-signature-symbol">:</span> <a href="../enums/promisedwebsocketclosurecode.html" class="tsd-signature-type">PromisedWebSocketClosureCode</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = Array.of(PromisedWebSocketClosureCode.Normal,PromisedWebSocketClosureCode.EmptyCloseFrame)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L12">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:97</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L97">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:97</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#close">close</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L28">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -320,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L108">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -338,7 +338,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L90">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -362,7 +362,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#open">open</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L38">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -385,7 +385,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L104">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -412,7 +412,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocket.html">PromisedWebSocket</a>.<a href="../interfaces/promisedwebsocket.html#send">send</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L83">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -435,7 +435,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocket.ts#L114">src/promisedwebsocket/ReconnectingPromisedWebSocket.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/reconnectingpromisedwebsocketfactory.html
+++ b/docs/classes/reconnectingpromisedwebsocketfactory.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts#L9">src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/backofffactory.html" class="tsd-signature-type">BackoffFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts#L12">src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">promised<wbr>Web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts#L11">src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">reconnect<wbr>Retry<wbr>Limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts#L13">src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/promisedwebsocketfactory.html">PromisedWebSocketFactory</a>.<a href="../interfaces/promisedwebsocketfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts#L16">src/promisedwebsocket/ReconnectingPromisedWebSocketFactory.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/reconnectionhealthpolicy.html
+++ b/docs/classes/reconnectionhealthpolicy.html
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L18">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Delay<wbr>Points<wbr>Over<wbr>Maximum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L18">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#currentdata">currentData</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L9">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#currenthealth">currentHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L21">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#maxhealth">maxHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L11">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#minhealth">minHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L10">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONNECTION_<wbr>UNHEALTHY_<wbr>THRESHOLD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONNECTION_<wbr>WAIT_<wbr>TIME_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L13">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAXIMUM_<wbr>AUDIO_<wbr>DELAY_<wbr>DATA_<wbr>POINTS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L16">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAXIMUM_<wbr>AUDIO_<wbr>DELAY_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L15">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">MISSED_<wbr>PONGS_<wbr>THRESHOLD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L14">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -290,7 +290,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#getconnectionhealthdata">getConnectionHealthData</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L37">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></h4>
@@ -309,7 +309,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#health">health</a></p>
 								<p>Overrides <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#health">health</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ReconnectionHealthPolicy.ts#L35">src/connectionhealthpolicy/ReconnectionHealthPolicy.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -328,7 +328,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthifchanged">healthIfChanged</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#healthifchanged">healthIfChanged</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L45">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -347,7 +347,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthy">healthy</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#healthy">healthy</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L41">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -366,7 +366,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#maximumhealth">maximumHealth</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#maximumhealth">maximumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L25">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -385,7 +385,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#minimumhealth">minimumHealth</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#minimumhealth">minimumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L21">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -404,7 +404,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#update">update</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#update">update</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L33">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/resizeobserveradapterfactory.html
+++ b/docs/classes/resizeobserveradapterfactory.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/ResizeObserverAdapterFactory.ts#L10">src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="../interfaces/resizeobserveradapter.html" class="tsd-signature-type">ResizeObserverAdapter</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/ResizeObserverAdapterFactory.ts#L11">src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/ResizeObserverAdapterFactory.ts#L13">src/resizeobserveradapter/ResizeObserverAdapterFactory.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/runnabletask.html
+++ b/docs/classes/runnabletask.html
@@ -145,7 +145,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/RunnableTask.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/RunnableTask.ts#L10">src/task/RunnableTask.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">fn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/RunnableTask.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/RunnableTask.ts#L11">src/task/RunnableTask.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L12">src/task/BaseTask.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -302,7 +302,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -321,7 +321,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/RunnableTask.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/RunnableTask.ts#L16">src/task/RunnableTask.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -340,7 +340,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/scaletofitpresentationpolicy.html
+++ b/docs/classes/scaletofitpresentationpolicy.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/policy/ScaleToFitPresentationPolicy.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/ScaleToFitPresentationPolicy.ts#L11">src/presentation/policy/ScaleToFitPresentationPolicy.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screensharestream.html
+++ b/docs/classes/screensharestream.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L13">src/screensharestreaming/ScreenShareStream.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListenerOrEventListenerObject</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Set&lt;EventListenerOrEventListenerObject&gt;&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharestreaming/ScreenShareStream.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L13">src/screensharestreaming/ScreenShareStream.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Recording<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediarecording.html" class="tsd-signature-type">MediaRecording</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharestreaming/ScreenShareStream.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L15">src/screensharestreaming/ScreenShareStream.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:74</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L74">src/screensharestreaming/ScreenShareStream.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -203,7 +203,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:81</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L81">src/screensharestreaming/ScreenShareStream.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#key">key</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L17">src/screensharestreaming/ScreenShareStream.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -244,7 +244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L107">src/screensharestreaming/ScreenShareStream.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L96">src/screensharestreaming/ScreenShareStream.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L52">src/screensharestreaming/ScreenShareStream.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L90">src/screensharestreaming/ScreenShareStream.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -335,7 +335,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L21">src/screensharestreaming/ScreenShareStream.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -359,7 +359,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L41">src/screensharestreaming/ScreenShareStream.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -377,7 +377,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreaming.html">ScreenShareStreaming</a>.<a href="../interfaces/screensharestreaming.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStream.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStream.ts#L63">src/screensharestreaming/ScreenShareStream.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/classes/screensharestreamfactory.html
+++ b/docs/classes/screensharestreamfactory.html
@@ -106,7 +106,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharestreamingfactory.html">ScreenShareStreamingFactory</a>.<a href="../interfaces/screensharestreamingfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreamFactory.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamFactory.ts#L10">src/screensharestreaming/ScreenShareStreamFactory.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screensharestreamingcontainer.html
+++ b/docs/classes/screensharestreamingcontainer.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">memo<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharestreamingfactory.html" class="tsd-signature-type">ScreenShareStreamingFactory</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharestreaming/ScreenShareStreamingContainer.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamingContainer.ts#L8">src/screensharestreaming/ScreenShareStreamingContainer.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreamingContainer.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamingContainer.ts#L10">src/screensharestreaming/ScreenShareStreamingContainer.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharestreamingfactory.html" class="tsd-signature-type">ScreenShareStreamingFactory</a></h4>

--- a/docs/classes/screensharingmessageflagserializer.html
+++ b/docs/classes/screensharingmessageflagserializer.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">Broadcast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1 &lt;&lt; 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L9">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">Local<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1 &lt;&lt; 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L10">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">Synthesized<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1 &lt;&lt; 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L11">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unicast<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1 &lt;&lt; 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L12">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessageflagserialization.html">ScreenSharingMessageFlagSerialization</a>.<a href="../interfaces/screensharingmessageflagserialization.html#deserialize">deserialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L32">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -183,7 +183,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L51">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessageflagserialization.html">ScreenSharingMessageFlagSerialization</a>.<a href="../interfaces/screensharingmessageflagserialization.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts#L14">src/screensharingmessageserialization/ScreenSharingMessageFlagSerializer.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screensharingmessageserializer.html
+++ b/docs/classes/screensharingmessageserializer.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L17">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">flag<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessageflagserialization.html" class="tsd-signature-type">ScreenSharingMessageFlagSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L21">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Detail<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenmessagedetailserialization.html" class="tsd-signature-type">ScreenMessageDetailSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L22">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<wbr>Serialization<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingmessagetypeserialization.html" class="tsd-signature-type">ScreenSharingMessageTypeSerialization</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L20">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">detailed<wbr>Signals<span class="tsd-signature-symbol">:</span> <a href="../enums/screensharingmessagetype.html" class="tsd-signature-type">ScreenSharingMessageType</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = Array.of(ScreenSharingMessageType.StreamStart,ScreenSharingMessageType.StreamEnd,ScreenSharingMessageType.PresenterSwitch)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L13">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessageserialization.html">ScreenSharingMessageSerialization</a>.<a href="../interfaces/screensharingmessageserialization.html#deserialize">deserialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L32">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessageserialization.html">ScreenSharingMessageSerialization</a>.<a href="../interfaces/screensharingmessageserialization.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts#L25">src/screensharingmessageserialization/ScreenSharingMessageSerializer.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screensharingmessagetypeserializer.html
+++ b/docs/classes/screensharingmessagetypeserializer.html
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<wbr>Number<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><a href="../enums/screensharingmessagetype.html" class="tsd-signature-type">ScreenSharingMessageType</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;number, ScreenSharingMessageType&gt;([[0x02, ScreenSharingMessageType.KeyRequest],[0x03, ScreenSharingMessageType.StreamStart],[0x04, ScreenSharingMessageType.StreamEnd],[0x05, ScreenSharingMessageType.StreamStop],[0x06, ScreenSharingMessageType.HeartbeatRequestType],[0x07, ScreenSharingMessageType.HeartbeatResponseType],[0x0d, ScreenSharingMessageType.WebM],[0x10, ScreenSharingMessageType.PresenterSwitch],[0x15, ScreenSharingMessageType.StreamPause],[0x16, ScreenSharingMessageType.StreamUnpause],])</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts#L12">src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<wbr>Type<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/screensharingmessagetype.html" class="tsd-signature-type">ScreenSharingMessageType</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;ScreenSharingMessageType, number&gt;(Array.from(ScreenSharingMessageTypeSerializer.fromNumberMap).map(entry &#x3D;&gt; entry.reverse() as [ScreenSharingMessageType, number]))</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts#L25">src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessagetypeserialization.html">ScreenSharingMessageTypeSerialization</a>.<a href="../interfaces/screensharingmessagetypeserialization.html#deserialize">deserialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts#L38">src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screensharingmessagetypeserialization.html">ScreenSharingMessageTypeSerialization</a>.<a href="../interfaces/screensharingmessagetypeserialization.html#serialize">serialize</a></p>
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts#L31">src/screensharingmessageserialization/ScreenSharingMessageTypeSerializer.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screensharingsessioncontainer.html
+++ b/docs/classes/screensharingsessioncontainer.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L33">src/screensharingsession/ScreenSharingSessionContainer.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">backoff<wbr>Factory<wbr>Memo<span class="tsd-signature-symbol">:</span> <a href="../interfaces/backofffactory.html" class="tsd-signature-type">BackoffFactory</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L33">src/screensharingsession/ScreenSharingSessionContainer.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L37">src/screensharingsession/ScreenSharingSessionContainer.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L36">src/screensharingsession/ScreenSharingSessionContainer.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingsessionoptions.html" class="tsd-signature-type">ScreenSharingSessionOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L38">src/screensharingsession/ScreenSharingSessionContainer.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Sharing<wbr>Session<wbr>Factory<wbr>Memo<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensharingsessionfactory.html" class="tsd-signature-type">ScreenSharingSessionFactory</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L32">src/screensharingsession/ScreenSharingSessionContainer.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L94">src/screensharingsession/ScreenSharingSessionContainer.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/backofffactory.html" class="tsd-signature-type">BackoffFactory</a></h4>
@@ -228,7 +228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L56">src/screensharingsession/ScreenSharingSessionContainer.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L104">src/screensharingsession/ScreenSharingSessionContainer.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/domwebsocketfactory.html" class="tsd-signature-type">DOMWebSocketFactory</a></h4>
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:120</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L120">src/screensharingsession/ScreenSharingSessionContainer.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharingmessageflagserialization.html" class="tsd-signature-type">ScreenSharingMessageFlagSerialization</a></h4>
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L80">src/screensharingsession/ScreenSharingSessionContainer.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/mediarecordingfactory.html" class="tsd-signature-type">MediaRecordingFactory</a></h4>
@@ -302,7 +302,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L108">src/screensharingsession/ScreenSharingSessionContainer.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></h4>
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L100">src/screensharingsession/ScreenSharingSessionContainer.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></h4>
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L86">src/screensharingsession/ScreenSharingSessionContainer.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/promisedwebsocketfactory.html" class="tsd-signature-type">PromisedWebSocketFactory</a></h4>
@@ -353,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L41">src/screensharingsession/ScreenSharingSessionContainer.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharingsessionfactory.html" class="tsd-signature-type">ScreenSharingSessionFactory</a></h4>
@@ -370,7 +370,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:76</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L76">src/screensharingsession/ScreenSharingSessionContainer.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharestreamingfactory.html" class="tsd-signature-type">ScreenShareStreamingFactory</a></h4>
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:124</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L124">src/screensharingsession/ScreenSharingSessionContainer.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screenmessagedetailserialization.html" class="tsd-signature-type">ScreenMessageDetailSerialization</a></h4>
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionContainer.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionContainer.ts#L116">src/screensharingsession/ScreenSharingSessionContainer.ts:116</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharingmessagetypeserialization.html" class="tsd-signature-type">ScreenSharingMessageTypeSerialization</a></h4>

--- a/docs/classes/screensignalingsessioncontainer.html
+++ b/docs/classes/screensignalingsessioncontainer.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L15">src/screensignalingsession/ScreenSignalingSessionContainer.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L19">src/screensignalingsession/ScreenSignalingSessionContainer.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">memo<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screensignalingsessionfactory.html" class="tsd-signature-type">ScreenSignalingSessionFactory</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L15">src/screensignalingsession/ScreenSignalingSessionContainer.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">web<wbr>Socket<wbr>Factory<span class="tsd-signature-symbol">:</span> <a href="reconnectingpromisedwebsocketfactory.html" class="tsd-signature-type">ReconnectingPromisedWebSocketFactory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L18">src/screensignalingsession/ScreenSignalingSessionContainer.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L33">src/screensignalingsession/ScreenSignalingSessionContainer.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensharingmessageserialization.html" class="tsd-signature-type">ScreenSharingMessageSerialization</a></h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSessionContainer.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionContainer.ts#L22">src/screensignalingsession/ScreenSignalingSessionContainer.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/screensignalingsessionfactory.html" class="tsd-signature-type">ScreenSignalingSessionFactory</a></h4>

--- a/docs/classes/screenviewingmessagedispatcher.html
+++ b/docs/classes/screenviewingmessagedispatcher.html
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts#L8">src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Handler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/screenviewingmessagehandler.html" class="tsd-signature-type">ScreenViewingMessageHandler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts#L9">src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsessionobserver.html">ScreenViewingSessionObserver</a>.<a href="../interfaces/screenviewingsessionobserver.html#didclosewebsocket">didCloseWebSocket</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts#L11">src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -182,7 +182,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/screenviewingsessionobserver.html">ScreenViewingSessionObserver</a>.<a href="../interfaces/screenviewingsessionobserver.html#didreceivewebsocketmessage">didReceiveWebSocketMessage</a></p>
 								<ul>
-									<li>Defined in src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts#L13">src/screenviewing/clientobserver/ScreenViewingMessageDispatcher.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/screenviewingsessionconnectionrequest.html
+++ b/docs/classes/screenviewingsessionconnectionrequest.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L7">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>DataURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L10">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>ViewingURLWith<wbr>Optional<wbr>Session<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L9">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">session<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L11">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L12">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L15">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts#L23">src/screenviewing/session/ScreenViewingSessionConnectionRequest.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>

--- a/docs/classes/sendandreceivedatamessagestask.html
+++ b/docs/classes/sendandreceivedatamessagestask.html
@@ -138,7 +138,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L22">src/task/SendAndReceiveDataMessagesTask.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L24">src/task/SendAndReceiveDataMessagesTask.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L19">src/task/SendAndReceiveDataMessagesTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">DATA_<wbr>SIZE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 2048</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L22">src/task/SendAndReceiveDataMessagesTask.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">TOPIC_<wbr>REGEX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = new RegExp(/^[a-zA-Z0-9_-]{1,36}$/)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L21">src/task/SendAndReceiveDataMessagesTask.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L24">src/task/BaseTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -239,7 +239,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L41">src/task/SendAndReceiveDataMessagesTask.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -281,7 +281,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -306,7 +306,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -324,7 +324,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L34">src/task/SendAndReceiveDataMessagesTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -343,7 +343,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L28">src/task/SendAndReceiveDataMessagesTask.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -360,7 +360,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L60">src/task/SendAndReceiveDataMessagesTask.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -391,7 +391,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -414,7 +414,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/SendAndReceiveDataMessagesTask.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SendAndReceiveDataMessagesTask.ts#L87">src/task/SendAndReceiveDataMessagesTask.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/serialgrouptask.html
+++ b/docs/classes/serialgrouptask.html
@@ -139,7 +139,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/SerialGroupTask.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L14">src/task/SerialGroupTask.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Task<span class="tsd-signature-symbol">:</span> <a href="../interfaces/task.html" class="tsd-signature-type">Task</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SerialGroupTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L14">src/task/SerialGroupTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/SerialGroupTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L16">src/task/SerialGroupTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">tasks<wbr>ToRun<wbr>Serially<span class="tsd-signature-symbol">:</span> <a href="../interfaces/task.html" class="tsd-signature-type">Task</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SerialGroupTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L16">src/task/SerialGroupTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/SerialGroupTask.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L23">src/task/SerialGroupTask.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -298,7 +298,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/SerialGroupTask.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SerialGroupTask.ts#L32">src/task/SerialGroupTask.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -317,7 +317,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/setlocaldescriptiontask.html
+++ b/docs/classes/setlocaldescriptiontask.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/SetLocalDescriptionTask.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L13">src/task/SetLocalDescriptionTask.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SetLocalDescriptionTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L13">src/task/SetLocalDescriptionTask.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SetLocalDescriptionTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L15">src/task/SetLocalDescriptionTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/SetLocalDescriptionTask.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L11">src/task/SetLocalDescriptionTask.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/SetLocalDescriptionTask.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L19">src/task/SetLocalDescriptionTask.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -286,7 +286,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -305,7 +305,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/SetLocalDescriptionTask.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetLocalDescriptionTask.ts#L24">src/task/SetLocalDescriptionTask.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -324,7 +324,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/setremotedescriptiontask.html
+++ b/docs/classes/setremotedescriptiontask.html
@@ -132,7 +132,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/SetRemoteDescriptionTask.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L17">src/task/SetRemoteDescriptionTask.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancelICEPromise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SetRemoteDescriptionTask.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L17">src/task/SetRemoteDescriptionTask.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SetRemoteDescriptionTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L19">src/task/SetRemoteDescriptionTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/SetRemoteDescriptionTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L15">src/task/SetRemoteDescriptionTask.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/SetRemoteDescriptionTask.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L23">src/task/SetRemoteDescriptionTask.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/SetRemoteDescriptionTask.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L85">src/task/SetRemoteDescriptionTask.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -304,7 +304,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -323,7 +323,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/SetRemoteDescriptionTask.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SetRemoteDescriptionTask.ts#L29">src/task/SetRemoteDescriptionTask.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -342,7 +342,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/signalingandmetricsconnectionmonitor.html
+++ b/docs/classes/signalingandmetricsconnectionmonitor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L21">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L24">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Health<wbr>Data<span class="tsd-signature-symbol">:</span> <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L27">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Seen<wbr>Valid<wbr>Packet<wbr>Metrics<wbr>Before<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L19">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Active<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L18">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Available<wbr>Recv<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L21">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Available<wbr>Send<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L20">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">ping<wbr>Pong<span class="tsd-signature-symbol">:</span> <a href="../interfaces/pingpong.html" class="tsd-signature-type">PingPong</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L28">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L25">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<div class="tsd-signature tsd-kind-icon">stats<wbr>Collector<span class="tsd-signature-symbol">:</span> <a href="../interfaces/statscollector.html" class="tsd-signature-type">StatsCollector</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L29">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -265,7 +265,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L26">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:149</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L149">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:149</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L72">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:72</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/pingpongobserver.html">PingPongObserver</a>.<a href="../interfaces/pingpongobserver.html#didreceivepong">didReceivePong</a></p>
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L65">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -356,7 +356,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#metricsdidreceive">metricsDidReceive</a></p>
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L79">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -379,7 +379,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:199</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L199">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:199</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -405,7 +405,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L54">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -429,7 +429,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionmonitor.html">ConnectionMonitor</a>.<a href="../interfaces/connectionmonitor.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L40">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -447,7 +447,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/connectionmonitor.html">ConnectionMonitor</a>.<a href="../interfaces/connectionmonitor.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L47">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -464,7 +464,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:175</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L175">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:175</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -487,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:156</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L156">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:191</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts#L191">src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts:191</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/signalingclientconnectionrequest.html
+++ b/docs/classes/signalingclientconnectionrequest.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientConnectionRequest.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientConnectionRequest.ts#L7">src/signalingclient/SignalingClientConnectionRequest.ts:7</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">join<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientConnectionRequest.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientConnectionRequest.ts#L13">src/signalingclient/SignalingClientConnectionRequest.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">signalingURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientConnectionRequest.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientConnectionRequest.ts#L13">src/signalingclient/SignalingClientConnectionRequest.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientConnectionRequest.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientConnectionRequest.ts#L23">src/signalingclient/SignalingClientConnectionRequest.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientConnectionRequest.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientConnectionRequest.ts#L16">src/signalingclient/SignalingClientConnectionRequest.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/signalingclientevent.html
+++ b/docs/classes/signalingclientevent.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientEvent.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L12">src/signalingclient/SignalingClientEvent.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">client<span class="tsd-signature-symbol">:</span> <a href="../interfaces/signalingclient.html" class="tsd-signature-type">SignalingClient</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L21">src/signalingclient/SignalingClientEvent.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">close<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L24">src/signalingclient/SignalingClientEvent.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">close<wbr>Reason<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L25">src/signalingclient/SignalingClientEvent.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SdkSignalFrame</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L23">src/signalingclient/SignalingClientEvent.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L12">src/signalingclient/SignalingClientEvent.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/signalingclienteventtype.html" class="tsd-signature-type">SignalingClientEventType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEvent.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L22">src/signalingclient/SignalingClientEvent.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientEvent.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEvent.ts#L30">src/signalingclient/SignalingClientEvent.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/signalingclientjoin.html
+++ b/docs/classes/signalingclientjoin.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientJoin.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientJoin.ts#L7">src/signalingclient/SignalingClientJoin.ts:7</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Videos<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientJoin.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientJoin.ts#L13">src/signalingclient/SignalingClientJoin.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">send<wbr>Bitrates<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientJoin.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientJoin.ts#L13">src/signalingclient/SignalingClientJoin.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/classes/signalingclientsubscribe.html
+++ b/docs/classes/signalingclientsubscribe.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L9">src/signalingclient/SignalingClientSubscribe.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L23">src/signalingclient/SignalingClientSubscribe.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Checkin<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L27">src/signalingclient/SignalingClientSubscribe.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Host<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L25">src/signalingclient/SignalingClientSubscribe.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Muted<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L26">src/signalingclient/SignalingClientSubscribe.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<wbr>Type<wbr>Has<wbr>Video<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L31">src/signalingclient/SignalingClientSubscribe.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Video<wbr>Enabled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L29">src/signalingclient/SignalingClientSubscribe.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">receive<wbr>Stream<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L28">src/signalingclient/SignalingClientSubscribe.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">sdp<wbr>Offer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L24">src/signalingclient/SignalingClientSubscribe.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Descriptions<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientSubscribe.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientSubscribe.ts#L30">src/signalingclient/SignalingClientSubscribe.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/simulcasttransceivercontroller.html
+++ b/docs/classes/simulcasttransceivercontroller.html
@@ -151,7 +151,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L17">src/transceivercontroller/SimulcastTransceiverController.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -177,7 +177,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#_localaudiotransceiver">_localAudioTransceiver</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L12">src/transceivercontroller/DefaultTransceiverController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#_localcameratransceiver">_localCameraTransceiver</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L11">src/transceivercontroller/DefaultTransceiverController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#browserbehavior">browserBehavior</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L17">src/transceivercontroller/DefaultTransceiverController.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#defaultmediastream">defaultMediaStream</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L14">src/transceivercontroller/DefaultTransceiverController.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L17">src/transceivercontroller/DefaultTransceiverController.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#peer">peer</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L15">src/transceivercontroller/DefaultTransceiverController.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Quality<wbr>Control<wbr>Parameter<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string,RTCRtpEncodingParameters&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L14">src/transceivercontroller/SimulcastTransceiverController.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#videosubscriptions">videoSubscriptions</a></p>
 						<ul>
-							<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L13">src/transceivercontroller/DefaultTransceiverController.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">BITRATE_<wbr>ARR_<wbr>ASCENDING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [200, 400, 1100]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L13">src/transceivercontroller/SimulcastTransceiverController.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">HIGH_<wbr>LEVEL_<wbr>NAME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;hi&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L11">src/transceivercontroller/SimulcastTransceiverController.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +283,7 @@
 					<div class="tsd-signature tsd-kind-icon">LOW_<wbr>LEVEL_<wbr>NAME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;low&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L9">src/transceivercontroller/SimulcastTransceiverController.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -293,7 +293,7 @@
 					<div class="tsd-signature tsd-kind-icon">MID_<wbr>LEVEL_<wbr>NAME<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;mid&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L10">src/transceivercontroller/SimulcastTransceiverController.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">NAME_<wbr>ARR_<wbr>ASCENDING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&#x27;low&#x27;, &#x27;mid&#x27;, &#x27;hi&#x27;]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L12">src/transceivercontroller/SimulcastTransceiverController.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -322,7 +322,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#hasvideoinput">hasVideoInput</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#hasvideoinput">hasVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L93">src/transceivercontroller/DefaultTransceiverController.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -341,7 +341,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localaudiotransceiver">localAudioTransceiver</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#localaudiotransceiver">localAudioTransceiver</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L53">src/transceivercontroller/DefaultTransceiverController.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -360,7 +360,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#localvideotransceiver">localVideoTransceiver</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#localvideotransceiver">localVideoTransceiver</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L56">src/transceivercontroller/DefaultTransceiverController.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCRtpTransceiver</span></h4>
@@ -377,7 +377,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:125</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L125">src/transceivercontroller/SimulcastTransceiverController.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -396,7 +396,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#replaceaudiotrack">replaceAudioTrack</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#replaceaudiotrack">replaceAudioTrack</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:134</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L134">src/transceivercontroller/DefaultTransceiverController.ts:134</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -421,7 +421,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#reset">reset</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L77">src/transceivercontroller/DefaultTransceiverController.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -440,7 +440,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setaudioinput">setAudioInput</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setaudioinput">setAudioInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L143">src/transceivercontroller/DefaultTransceiverController.ts:143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -465,7 +465,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setencodingparameters">setEncodingParameters</a></p>
 								<p>Overrides <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setencodingparameters">setEncodingParameters</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L33">src/transceivercontroller/SimulcastTransceiverController.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setpeer">setPeer</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setpeer">setPeer</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L73">src/transceivercontroller/DefaultTransceiverController.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -515,7 +515,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideoinput">setVideoInput</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setvideoinput">setVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:148</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L148">src/transceivercontroller/DefaultTransceiverController.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -540,7 +540,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setvideosendingbitratekbps">setVideoSendingBitrateKbps</a></p>
 								<p>Overrides <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setvideosendingbitratekbps">setVideoSendingBitrateKbps</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:95</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L95">src/transceivercontroller/SimulcastTransceiverController.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -565,7 +565,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#setuplocaltransceivers">setupLocalTransceivers</a></p>
 								<p>Overrides <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setuplocaltransceivers">setupLocalTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L99">src/transceivercontroller/SimulcastTransceiverController.ts:99</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -584,7 +584,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#trackisvideoinput">trackIsVideoInput</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#trackisvideoinput">trackIsVideoInput</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:100</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L100">src/transceivercontroller/DefaultTransceiverController.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -609,7 +609,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#updatevideotransceivers">updateVideoTransceivers</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#updatevideotransceivers">updateVideoTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:153</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L153">src/transceivercontroller/DefaultTransceiverController.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -637,7 +637,7 @@
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#usetransceivers">useTransceivers</a></p>
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#usetransceivers">useTransceivers</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L85">src/transceivercontroller/DefaultTransceiverController.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -655,7 +655,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#replaceaudiotrackforsender">replaceAudioTrackForSender</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/SimulcastTransceiverController.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/SimulcastTransceiverController.ts#L83">src/transceivercontroller/SimulcastTransceiverController.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -682,7 +682,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#setvideosendingbitratekbpsforsender">setVideoSendingBitrateKbpsForSender</a></p>
 								<ul>
-									<li>Defined in src/transceivercontroller/DefaultTransceiverController.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L23">src/transceivercontroller/DefaultTransceiverController.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/simulcastuplinkpolicy.html
+++ b/docs/classes/simulcastuplinkpolicy.html
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L49">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">curr<wbr>Local<wbr>Descriptions<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:48</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L48">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Active<wbr>Streams<span class="tsd-signature-symbol">:</span> <a href="../enums/activestreams.html" class="tsd-signature-type">ActiveStreams</a><span class="tsd-signature-symbol"> = ActiveStreams.kHiAndLow</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L40">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Quality<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, RTCRtpEncodingParameters&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L38">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Updated<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = Date.now()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L44">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Uplink<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = SimulcastUplinkPolicy.defaultUplinkBandwidthKbps</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L41">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L51">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">new<wbr>Active<wbr>Streams<span class="tsd-signature-symbol">:</span> <a href="../enums/activestreams.html" class="tsd-signature-type">ActiveStreams</a><span class="tsd-signature-symbol"> = ActiveStreams.kHiAndLow</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L39">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">new<wbr>Quality<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, RTCRtpEncodingParameters&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L37">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">next<wbr>Local<wbr>Descriptions<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:49</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L49">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 					<div class="tsd-signature tsd-kind-icon">num<wbr>Participants<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L33">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">optimal<wbr>Parameters<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L34">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 					<div class="tsd-signature tsd-kind-icon">parameters<wbr>InEffect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L35">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 					<div class="tsd-signature tsd-kind-icon">self<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L51">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">start<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:43</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L43">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Index<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L46">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Max<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">15</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L27">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Uplink<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1200</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L24">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -356,7 +356,7 @@
 					<div class="tsd-signature tsd-kind-icon">hold<wbr>Down<wbr>Duration<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 4000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L26">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -366,7 +366,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>HiDisabled<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">700</span><span class="tsd-signature-symbol"> = 700</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L30">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Mid<wbr>Disabled<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">240</span><span class="tsd-signature-symbol"> = 240</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L31">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -386,7 +386,7 @@
 					<div class="tsd-signature tsd-kind-icon">startup<wbr>Duration<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 6000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L25">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -403,7 +403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:98</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L98">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:98</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -426,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:272</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L272">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:272</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -443,7 +443,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:266</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L266">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:266</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -460,7 +460,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:260</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L260">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:260</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -478,7 +478,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosecaptureandencodeparameters">chooseCaptureAndEncodeParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:254</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L254">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></h4>
@@ -496,7 +496,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#chooseencodingparameters">chooseEncodingParameters</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:177</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L177">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:177</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -514,7 +514,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#choosemediatrackconstraints">chooseMediaTrackConstraints</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:166</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L166">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:166</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaTrackConstraints</span></h4>
@@ -531,7 +531,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:230</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L230">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:230</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -557,7 +557,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:237</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L237">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:237</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -574,7 +574,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:290</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L290">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:290</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +597,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:313</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L313">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:313</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -621,7 +621,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#maxbandwidthkbps">maxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:277</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L277">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:277</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -639,7 +639,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#sethasbandwidthpriority">setHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:286</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L286">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:286</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -663,7 +663,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#setidealmaxbandwidthkbps">setIdealMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:282</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L282">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:282</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -686,7 +686,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L61">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -715,7 +715,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:183</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L183">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:183</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -739,7 +739,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:201</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L201">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:201</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/simulcastvideostreamindex.html
+++ b/docs/classes/simulcastvideostreamindex.html
@@ -167,7 +167,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L32">src/videostreamindex/SimulcastVideoStreamIndex.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">_last<wbr>Bit<wbr>Rate<wbr>Msg<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L32">src/videostreamindex/SimulcastVideoStreamIndex.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">_local<wbr>Stream<wbr>Infos<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L30">src/videostreamindex/SimulcastVideoStreamIndex.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#currentindex">currentIndex</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L21">src/videostreamindex/DefaultVideoStreamIndex.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#currentsubscribeack">currentSubscribeAck</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L23">src/videostreamindex/DefaultVideoStreamIndex.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#indexforsubscribe">indexForSubscribe</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L22">src/videostreamindex/DefaultVideoStreamIndex.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -243,7 +243,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L36">src/videostreamindex/DefaultVideoStreamIndex.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>IdTo<wbr>Bitrate<wbr>Kbps<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;number, number&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L19">src/videostreamindex/SimulcastVideoStreamIndex.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -264,7 +264,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamtoattendeemap">streamToAttendeeMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L32">src/videostreamindex/DefaultVideoStreamIndex.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -275,7 +275,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamtoexternaluseridmap">streamToExternalUserIdMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L33">src/videostreamindex/DefaultVideoStreamIndex.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribessrctostreammap">subscribeSsrcToStreamMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L29">src/videostreamindex/DefaultVideoStreamIndex.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribestreamtoattendeemap">subscribeStreamToAttendeeMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L27">src/videostreamindex/DefaultVideoStreamIndex.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribestreamtoexternaluseridmap">subscribeStreamToExternalUserIdMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L28">src/videostreamindex/DefaultVideoStreamIndex.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -319,7 +319,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribetracktostreammap">subscribeTrackToStreamMap</a></p>
 						<ul>
-							<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L26">src/videostreamindex/DefaultVideoStreamIndex.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -329,7 +329,7 @@
 					<div class="tsd-signature tsd-kind-icon">Bitrates<wbr>Msg<wbr>Frequency<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 4000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L28">src/videostreamindex/SimulcastVideoStreamIndex.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -339,7 +339,7 @@
 					<div class="tsd-signature tsd-kind-icon">NOT_<wbr>SENDING_<wbr>STREAM_<wbr>BITRATE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L26">src/videostreamindex/SimulcastVideoStreamIndex.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -349,7 +349,7 @@
 					<div class="tsd-signature tsd-kind-icon">RECENTLY_<wbr>INACTIVE_<wbr>STREAM_<wbr>BITRATE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">-1</span><span class="tsd-signature-symbol"> = -1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L24">src/videostreamindex/SimulcastVideoStreamIndex.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -359,7 +359,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNSEEN_<wbr>STREAM_<wbr>BITRATE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">-2</span><span class="tsd-signature-symbol"> = -2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L22">src/videostreamindex/SimulcastVideoStreamIndex.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -378,7 +378,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:275</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L275">src/videostreamindex/DefaultVideoStreamIndex.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -406,7 +406,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L109">src/videostreamindex/DefaultVideoStreamIndex.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -425,7 +425,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingattendeesexcludingself">allVideoSendingAttendeesExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allvideosendingattendeesexcludingself">allVideoSendingAttendeesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L119">src/videostreamindex/DefaultVideoStreamIndex.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -450,7 +450,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:250</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L250">src/videostreamindex/DefaultVideoStreamIndex.ts:250</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -475,7 +475,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:218</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L218">src/videostreamindex/DefaultVideoStreamIndex.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -500,7 +500,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:234</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L234">src/videostreamindex/DefaultVideoStreamIndex.ts:234</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -525,7 +525,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:266</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L266">src/videostreamindex/DefaultVideoStreamIndex.ts:266</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -550,7 +550,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:192</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L192">src/videostreamindex/DefaultVideoStreamIndex.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -575,7 +575,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratebitratesframe">integrateBitratesFrame</a></p>
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#integratebitratesframe">integrateBitratesFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:91</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L91">src/videostreamindex/SimulcastVideoStreamIndex.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -600,7 +600,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integrateindexframe">integrateIndexFrame</a></p>
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#integrateindexframe">integrateIndexFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:160</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L160">src/videostreamindex/SimulcastVideoStreamIndex.ts:160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -625,7 +625,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratesubscribeackframe">integrateSubscribeAckFrame</a></p>
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#integratesubscribeackframe">integrateSubscribeAckFrame</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:185</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L185">src/videostreamindex/SimulcastVideoStreamIndex.ts:185</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -650,7 +650,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integrateuplinkpolicydecision">integrateUplinkPolicyDecision</a></p>
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#integrateuplinkpolicydecision">integrateUplinkPolicyDecision</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L47">src/videostreamindex/SimulcastVideoStreamIndex.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -675,7 +675,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#localstreamdescriptions">localStreamDescriptions</a></p>
 								<p>Overrides <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#localstreamdescriptions">localStreamDescriptions</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L39">src/videostreamindex/SimulcastVideoStreamIndex.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -692,7 +692,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/SimulcastVideoStreamIndex.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/SimulcastVideoStreamIndex.ts#L150">src/videostreamindex/SimulcastVideoStreamIndex.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -711,7 +711,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:214</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L214">src/videostreamindex/DefaultVideoStreamIndex.ts:214</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -736,7 +736,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#remotestreamdescriptions">remoteStreamDescriptions</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#remotestreamdescriptions">remoteStreamDescriptions</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L48">src/videostreamindex/DefaultVideoStreamIndex.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -755,7 +755,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:289</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L289">src/videostreamindex/DefaultVideoStreamIndex.ts:289</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -780,7 +780,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:282</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L282">src/videostreamindex/DefaultVideoStreamIndex.ts:282</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -805,7 +805,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:137</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L137">src/videostreamindex/DefaultVideoStreamIndex.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -839,7 +839,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:296</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L296">src/videostreamindex/DefaultVideoStreamIndex.ts:296</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -858,7 +858,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in src/videostreamindex/DefaultVideoStreamIndex.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L79">src/videostreamindex/DefaultVideoStreamIndex.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/some.html
+++ b/docs/classes/some.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/Some.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L9">src/maybe/Some.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#isnone">isNone</a></p>
 						<ul>
-							<li>Defined in src/maybe/Some.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L9">src/maybe/Some.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#issome">isSome</a></p>
 						<ul>
-							<li>Defined in src/maybe/Some.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L8">src/maybe/Some.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/maybe/Some.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L11">src/maybe/Some.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#defaulting">defaulting</a></p>
 								<ul>
-									<li>Defined in src/maybe/Some.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L29">src/maybe/Some.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -217,7 +217,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/Some.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L17">src/maybe/Some.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -265,7 +265,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#get">get</a></p>
 								<ul>
-									<li>Defined in src/maybe/Some.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L21">src/maybe/Some.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">T</span></h4>
@@ -283,7 +283,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/maybeprovider.html">MaybeProvider</a>.<a href="../interfaces/maybeprovider.html#getorelse">getOrElse</a></p>
 								<ul>
-									<li>Defined in src/maybe/Some.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L25">src/maybe/Some.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -306,7 +306,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/Some.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L13">src/maybe/Some.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -353,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/Some.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/Some.ts#L33">src/maybe/Some.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/streammetricreport.html
+++ b/docs/classes/streammetricreport.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Metrics<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/StreamMetricReport.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/StreamMetricReport.ts#L12">src/clientmetricreport/StreamMetricReport.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">direction<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Direction</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/StreamMetricReport.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/StreamMetricReport.ts#L10">src/clientmetricreport/StreamMetricReport.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaType</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/StreamMetricReport.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/StreamMetricReport.ts#L9">src/clientmetricreport/StreamMetricReport.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Metrics<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/StreamMetricReport.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/StreamMetricReport.ts#L11">src/clientmetricreport/StreamMetricReport.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/StreamMetricReport.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/StreamMetricReport.ts#L8">src/clientmetricreport/StreamMetricReport.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/subscribeandreceivesubscribeacktask.html
+++ b/docs/classes/subscribeandreceivesubscribeacktask.html
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L26">src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L28">src/task/SubscribeAndReceiveSubscribeAckTask.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>Canceler<span class="tsd-signature-symbol">:</span> <a href="../interfaces/taskcanceler.html" class="tsd-signature-type">TaskCanceler</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L26">src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L24">src/task/SubscribeAndReceiveSubscribeAckTask.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L32">src/task/SubscribeAndReceiveSubscribeAckTask.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -231,7 +231,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -249,7 +249,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -274,7 +274,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:95</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L95">src/task/SubscribeAndReceiveSubscribeAckTask.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">SdkSubscribeAckFrame</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -310,7 +310,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/SubscribeAndReceiveSubscribeAckTask.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L39">src/task/SubscribeAndReceiveSubscribeAckTask.ts:39</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -329,7 +329,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/timeoutscheduler.html
+++ b/docs/classes/timeoutscheduler.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/TimeoutScheduler.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L10">src/scheduler/TimeoutScheduler.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/scheduler/TimeoutScheduler.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L12">src/scheduler/TimeoutScheduler.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/scheduler/TimeoutScheduler.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L10">src/scheduler/TimeoutScheduler.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/TimeoutScheduler.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L14">src/scheduler/TimeoutScheduler.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/scheduler.html">Scheduler</a>.<a href="../interfaces/scheduler.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/scheduler/TimeoutScheduler.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/TimeoutScheduler.ts#L22">src/scheduler/TimeoutScheduler.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/timeouttask.html
+++ b/docs/classes/timeouttask.html
@@ -139,7 +139,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/TimeoutTask.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L14">src/task/TimeoutTask.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -168,7 +168,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/TimeoutTask.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L14">src/task/TimeoutTask.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">task<wbr>ToRun<wbr>Before<wbr>Timeout<span class="tsd-signature-symbol">:</span> <a href="../interfaces/task.html" class="tsd-signature-type">Task</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TimeoutTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L16">src/task/TimeoutTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TimeoutTask.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L16">src/task/TimeoutTask.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/TimeoutTask.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L22">src/task/TimeoutTask.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -236,7 +236,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -298,7 +298,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/TimeoutTask.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TimeoutTask.ts#L29">src/task/TimeoutTask.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -317,7 +317,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/unusableaudiowarningconnectionhealthpolicy.html
+++ b/docs/classes/unusableaudiowarningconnectionhealthpolicy.html
@@ -141,7 +141,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L17">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">cool<wbr>Down<wbr>Time<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L11">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#currentdata">currentData</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L9">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#currenthealth">currentHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">fractional<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L13">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Warn<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L17">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#maxhealth">maxHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L11">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Times<wbr>ToWarn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L15">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#minhealth">minHealth</a></p>
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L10">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">packets<wbr>Expected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L14">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">past<wbr>Samples<wbr>ToConsider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">warn<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L16">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L30">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#getconnectionhealthdata">getConnectionHealthData</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L37">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:37</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="connectionhealthdata.html" class="tsd-signature-type">ConnectionHealthData</a></h4>
@@ -324,7 +324,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#health">health</a></p>
 								<p>Overrides <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#health">health</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts#L44">src/connectionhealthpolicy/UnusableAudioWarningConnectionHealthPolicy.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -343,7 +343,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthifchanged">healthIfChanged</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#healthifchanged">healthIfChanged</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L45">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -362,7 +362,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#healthy">healthy</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#healthy">healthy</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L41">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -381,7 +381,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#maximumhealth">maximumHealth</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#maximumhealth">maximumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L25">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -400,7 +400,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#minimumhealth">minimumHealth</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#minimumhealth">minimumHealth</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L21">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -419,7 +419,7 @@
 								<p>Implementation of <a href="../interfaces/connectionhealthpolicy.html">ConnectionHealthPolicy</a>.<a href="../interfaces/connectionhealthpolicy.html#update">update</a></p>
 								<p>Inherited from <a href="baseconnectionhealthpolicy.html">BaseConnectionHealthPolicy</a>.<a href="baseconnectionhealthpolicy.html#update">update</a></p>
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts#L33">src/connectionhealthpolicy/BaseConnectionHealthPolicy.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/versioning.html
+++ b/docs/classes/versioning.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">X_<wbr>AMZN_<wbr>USER_<wbr>AGENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;X-Amzn-User-Agent&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/versioning/Versioning.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L8">src/versioning/Versioning.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">X_<wbr>AMZN_<wbr>VERSION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;X-Amzn-Version&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/versioning/Versioning.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L7">src/versioning/Versioning.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/versioning/Versioning.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L13">src/versioning/Versioning.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/versioning/Versioning.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L27">src/versioning/Versioning.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/versioning/Versioning.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L20">src/versioning/Versioning.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/versioning/Versioning.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L35">src/versioning/Versioning.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L68">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">downlink<wbr>Stats<span class="tsd-signature-symbol">:</span> <a href="linkmediastats.html" class="tsd-signature-type">LinkMediaStats</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:54</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L54">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Upgrade<wbr>Rate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:62</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L62">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">log<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:50</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L50">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:70</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L70">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">optimal<wbr>Receive<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L51">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">pre<wbr>Probe<wbr>Receive<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:53</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L53">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">prev<wbr>Downlink<wbr>Stats<span class="tsd-signature-symbol">:</span> <a href="linkmediastats.html" class="tsd-signature-type">LinkMediaStats</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:55</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L55">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<div class="tsd-signature tsd-kind-icon">prev<wbr>Remote<wbr>Infos<span class="tsd-signature-symbol">:</span> <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:56</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L56">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -265,7 +265,7 @@
 					<div class="tsd-signature tsd-kind-icon">prev<wbr>Target<wbr>Rate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:61</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L61">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<wbr>Probe<wbr>State<span class="tsd-signature-symbol">:</span> <a href="../enums/rateprobestate.html" class="tsd-signature-type">RateProbeState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:58</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L58">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -285,7 +285,7 @@
 					<div class="tsd-signature tsd-kind-icon">startup<wbr>Period<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:59</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L59">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -295,7 +295,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribed<wbr>Receive<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:52</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L52">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -305,7 +305,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:70</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L70">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -315,7 +315,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Before<wbr>Allow<wbr>Probe<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:67</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L67">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -325,7 +325,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Before<wbr>Allow<wbr>Subscribe<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:65</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L65">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>First<wbr>Estimate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:63</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L63">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -345,7 +345,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Last<wbr>Probe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:68</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L68">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -355,7 +355,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Last<wbr>Subscribe<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:64</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L64">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -365,7 +365,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Probe<wbr>Pending<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:66</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L66">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -375,7 +375,7 @@
 					<div class="tsd-signature tsd-kind-icon">using<wbr>Prev<wbr>Target<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:60</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L60">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -385,7 +385,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Index<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:57</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L57">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:57</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -395,7 +395,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>BANDWIDTH_<wbr>KBPS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">2800</span><span class="tsd-signature-symbol"> = 2800</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L42">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -405,7 +405,7 @@
 					<div class="tsd-signature tsd-kind-icon">LARGE_<wbr>RATE_<wbr>CHANGE_<wbr>TRIGGER_<wbr>PERCENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">20</span><span class="tsd-signature-symbol"> = 20</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L44">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -415,7 +415,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAX_<wbr>HOLD_<wbr>MS_<wbr>BEFORE_<wbr>PROBE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">60000</span><span class="tsd-signature-symbol"> = 60000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:48</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L48">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -425,7 +425,7 @@
 					<div class="tsd-signature tsd-kind-icon">MIN_<wbr>TIME_<wbr>BETWEEN_<wbr>PROBE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">5000</span><span class="tsd-signature-symbol"> = 5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L46">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -435,7 +435,7 @@
 					<div class="tsd-signature tsd-kind-icon">MIN_<wbr>TIME_<wbr>BETWEEN_<wbr>SUBSCRIBE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">2000</span><span class="tsd-signature-symbol"> = 2000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L47">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -445,7 +445,7 @@
 					<div class="tsd-signature tsd-kind-icon">STARTUP_<wbr>PERIOD_<wbr>MS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">6000</span><span class="tsd-signature-symbol"> = 6000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:43</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L43">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -455,7 +455,7 @@
 					<div class="tsd-signature tsd-kind-icon">TARGET_<wbr>RATE_<wbr>CHANGE_<wbr>TRIGGER_<wbr>PERCENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">15</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:45</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L45">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -472,7 +472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:647</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L647">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:647</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -495,7 +495,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:154</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L154">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:154</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -512,7 +512,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:585</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L585">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:585</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -538,7 +538,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:632</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L632">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:632</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -565,7 +565,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:145</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L145">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -582,7 +582,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:667</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L667">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:667</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -608,7 +608,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:316</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L316">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -631,7 +631,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:601</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L601">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:601</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -660,7 +660,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:478</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L478">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:478</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -689,7 +689,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:511</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L511">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:511</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -727,7 +727,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:684</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L684">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:684</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -753,7 +753,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:403</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L403">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:403</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -777,7 +777,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatecalculatedoptimalreceiveset">updateCalculatedOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:136</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L136">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -795,7 +795,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:86</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L86">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:86</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -818,7 +818,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L90">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -841,7 +841,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:450</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L450">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:450</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -868,7 +868,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:140</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L140">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/videoqualitysettings.html
+++ b/docs/classes/videoqualitysettings.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/VideoQualitySettings.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoQualitySettings.ts#L8">src/devicecontroller/VideoQualitySettings.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/VideoQualitySettings.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoQualitySettings.ts#L7">src/devicecontroller/VideoQualitySettings.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/VideoQualitySettings.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoQualitySettings.ts#L6">src/devicecontroller/VideoQualitySettings.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Max<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/VideoQualitySettings.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoQualitySettings.ts#L8">src/devicecontroller/VideoQualitySettings.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/VideoQualitySettings.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoQualitySettings.ts#L5">src/devicecontroller/VideoQualitySettings.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/videostreamdescription.html
+++ b/docs/classes/videostreamdescription.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamDescription.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L18">src/videostreamindex/VideoStreamDescription.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L7">src/videostreamindex/VideoStreamDescription.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">avg<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L14">src/videostreamindex/VideoStreamDescription.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">disabled<wbr>ByUplink<wbr>Policy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L18">src/videostreamindex/VideoStreamDescription.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">disabled<wbr>ByWebRTC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L17">src/videostreamindex/VideoStreamDescription.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">group<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L8">src/videostreamindex/VideoStreamDescription.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Bitrate<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L12">src/videostreamindex/VideoStreamDescription.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L15">src/videostreamindex/VideoStreamDescription.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">ssrc<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L10">src/videostreamindex/VideoStreamDescription.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L9">src/videostreamindex/VideoStreamDescription.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Enabled<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L16">src/videostreamindex/VideoStreamDescription.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">track<wbr>Label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videostreamindex/VideoStreamDescription.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L11">src/videostreamindex/VideoStreamDescription.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamDescription.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L34">src/videostreamindex/VideoStreamDescription.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videostreamdescription.html" class="tsd-signature-type">VideoStreamDescription</a></h4>
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamDescription.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamDescription.ts#L50">src/videostreamindex/VideoStreamDescription.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">SdkStreamDescriptor</span></h4>

--- a/docs/classes/videotilestate.html
+++ b/docs/classes/videotilestate.html
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L31">src/videotile/VideoTileState.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">bound<wbr>Attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L46">src/videotile/VideoTileState.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">bound<wbr>External<wbr>User<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L51">src/videotile/VideoTileState.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">bound<wbr>Video<wbr>Element<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HTMLVideoElement</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:61</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L61">src/videotile/VideoTileState.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">bound<wbr>Video<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:56</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L56">src/videotile/VideoTileState.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Pixel<wbr>Ratio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:93</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L93">src/videotile/VideoTileState.ts:93</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Content<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L26">src/videotile/VideoTileState.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Tile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L16">src/videotile/VideoTileState.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">local<wbr>Tile<wbr>Started<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L21">src/videotile/VideoTileState.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">nameplate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:66</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L66">src/videotile/VideoTileState.ts:66</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">paused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L36">src/videotile/VideoTileState.ts:36</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">poor<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:41</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L41">src/videotile/VideoTileState.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:109</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L109">src/videotile/VideoTileState.ts:109</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -323,7 +323,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L11">src/videotile/VideoTileState.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>ElementCSSHeight<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:88</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L88">src/videotile/VideoTileState.ts:88</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -353,7 +353,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>ElementCSSWidth<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:83</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L83">src/videotile/VideoTileState.ts:83</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -368,7 +368,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Element<wbr>Physical<wbr>Height<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:103</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L103">src/videotile/VideoTileState.ts:103</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -383,7 +383,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Element<wbr>Physical<wbr>Width<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:98</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L98">src/videotile/VideoTileState.ts:98</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Content<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:78</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L78">src/videotile/VideoTileState.ts:78</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -414,7 +414,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Stream<wbr>Content<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videotile/VideoTileState.ts:72</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L72">src/videotile/VideoTileState.ts:72</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTileState.ts:111</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTileState.ts#L111">src/videotile/VideoTileState.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>

--- a/docs/classes/waitforattendeepresencetask.html
+++ b/docs/classes/waitforattendeepresencetask.html
@@ -131,7 +131,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in src/task/WaitForAttendeePresenceTask.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L15">src/task/WaitForAttendeePresenceTask.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">cancel<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/WaitForAttendeePresenceTask.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L15">src/task/WaitForAttendeePresenceTask.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">context<span class="tsd-signature-symbol">:</span> <a href="audiovideocontrollerstate.html" class="tsd-signature-type">AudioVideoControllerState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/WaitForAttendeePresenceTask.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L17">src/task/WaitForAttendeePresenceTask.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in src/task/BaseTask.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L19">src/task/BaseTask.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in src/task/WaitForAttendeePresenceTask.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L13">src/task/WaitForAttendeePresenceTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in src/task/WaitForAttendeePresenceTask.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L21">src/task/WaitForAttendeePresenceTask.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#getstatus">getStatus</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L34">src/task/BaseTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/taskstatus.html" class="tsd-signature-type">TaskStatus</a></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#logandthrow">logAndThrow</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L38">src/task/BaseTask.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -286,7 +286,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#name">name</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#name">name</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L26">src/task/BaseTask.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -305,7 +305,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in src/task/WaitForAttendeePresenceTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/WaitForAttendeePresenceTask.ts#L30">src/task/WaitForAttendeePresenceTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -324,7 +324,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#setparent">setParent</a></p>
 								<p>Inherited from <a href="basetask.html">BaseTask</a>.<a href="basetask.html#setparent">setParent</a></p>
 								<ul>
-									<li>Defined in src/task/BaseTask.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/BaseTask.ts#L30">src/task/BaseTask.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/webmmediarecording.html
+++ b/docs/classes/webmmediarecording.html
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L19">src/mediarecording/WebMMediaRecording.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<span class="tsd-signature-symbol">:</span> <a href="defaultbrowserbehavior.html" class="tsd-signature-type">DefaultBrowserBehavior</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L24">src/mediarecording/WebMMediaRecording.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">delegate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaRecorder</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> = null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L16">src/mediarecording/WebMMediaRecording.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">listeners<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Map&lt;string, Set&lt;EventListener&gt;&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L19">src/mediarecording/WebMMediaRecording.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L22">src/mediarecording/WebMMediaRecording.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaRecorderOptions</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L17">src/mediarecording/WebMMediaRecording.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Slice<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L18">src/mediarecording/WebMMediaRecording.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">browser<span class="tsd-signature-symbol">:</span> <a href="defaultbrowserbehavior.html" class="tsd-signature-type">DefaultBrowserBehavior</a><span class="tsd-signature-symbol"> = new DefaultBrowserBehavior()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L11">src/mediarecording/WebMMediaRecording.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L103">src/mediarecording/WebMMediaRecording.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RecordingState</span></h4>
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L107">src/mediarecording/WebMMediaRecording.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -294,7 +294,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#dispatchevent">dispatchEvent</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L114">src/mediarecording/WebMMediaRecording.ts:114</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -318,7 +318,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#key">key</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L29">src/mediarecording/WebMMediaRecording.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -336,7 +336,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L80">src/mediarecording/WebMMediaRecording.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -353,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L121">src/mediarecording/WebMMediaRecording.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -380,7 +380,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L59">src/mediarecording/WebMMediaRecording.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L64">src/mediarecording/WebMMediaRecording.ts:64</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecording.html">MediaRecording</a>.<a href="../interfaces/mediarecording.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecording.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L93">src/mediarecording/WebMMediaRecording.ts:93</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -438,7 +438,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecording.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L12">src/mediarecording/WebMMediaRecording.ts:12</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -447,7 +447,7 @@
 						<div class="tsd-signature tsd-kind-icon">mime<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;video/webm; codecs&#x3D;vp8&quot;</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in src/mediarecording/WebMMediaRecording.ts:13</li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecording.ts#L13">src/mediarecording/WebMMediaRecording.ts:13</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/classes/webmmediarecordingfactory.html
+++ b/docs/classes/webmmediarecordingfactory.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecordingFactory.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecordingFactory.ts#L9">src/mediarecording/WebMMediaRecordingFactory.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Recording<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/mediarecordingoptions.html" class="tsd-signature-type">MediaRecordingOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/WebMMediaRecordingFactory.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecordingFactory.ts#L10">src/mediarecording/WebMMediaRecordingFactory.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediarecordingfactory.html">MediaRecordingFactory</a>.<a href="../interfaces/mediarecordingfactory.html#create">create</a></p>
 								<ul>
-									<li>Defined in src/mediarecording/WebMMediaRecordingFactory.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/WebMMediaRecordingFactory.ts#L12">src/mediarecording/WebMMediaRecordingFactory.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/enums/activestreams.html
+++ b/docs/enums/activestreams.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>HiAnd<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L14">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L16">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Mid<wbr>And<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts#L15">src/videouplinkbandwidthpolicy/SimulcastUplinkPolicy.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/audiologevent.html
+++ b/docs/enums/audiologevent.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connect<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L9">src/statscollector/AudioLogEvent.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connected<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L8">src/statscollector/AudioLogEvent.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">Device<wbr>Changed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L5">src/statscollector/AudioLogEvent.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">Muted<wbr>Local<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L6">src/statscollector/AudioLogEvent.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">Redmic<wbr>End<wbr>Loss<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L11">src/statscollector/AudioLogEvent.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">Redmic<wbr>Start<wbr>Loss<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L10">src/statscollector/AudioLogEvent.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unmuted<wbr>Local<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/AudioLogEvent.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/AudioLogEvent.ts#L7">src/statscollector/AudioLogEvent.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkaudioconnectivityfeedback.html
+++ b/docs/enums/checkaudioconnectivityfeedback.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Input<wbr>Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts#L7">src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Input<wbr>Request<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts#L6">src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Not<wbr>Received<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts#L9">src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts#L8">src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts#L5">src/meetingreadinesschecker/CheckAudioConnectivityFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkaudioinputfeedback.html
+++ b/docs/enums/checkaudioinputfeedback.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioInputFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioInputFeedback.ts#L6">src/meetingreadinesschecker/CheckAudioInputFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioInputFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioInputFeedback.ts#L7">src/meetingreadinesschecker/CheckAudioInputFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioInputFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioInputFeedback.ts#L5">src/meetingreadinesschecker/CheckAudioInputFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkaudiooutputfeedback.html
+++ b/docs/enums/checkaudiooutputfeedback.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioOutputFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioOutputFeedback.ts#L6">src/meetingreadinesschecker/CheckAudioOutputFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckAudioOutputFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckAudioOutputFeedback.ts#L5">src/meetingreadinesschecker/CheckAudioOutputFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkcameraresolutionfeedback.html
+++ b/docs/enums/checkcameraresolutionfeedback.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts#L6">src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts#L8">src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Resolution<wbr>Not<wbr>Supported<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts#L7">src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts#L5">src/meetingreadinesschecker/CheckCameraResolutionFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkcontentshareconnectivityfeedback.html
+++ b/docs/enums/checkcontentshareconnectivityfeedback.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts#L9">src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts#L6">src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts#L7">src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts#L5">src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Timed<wbr>Out<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts#L8">src/meetingreadinesschecker/CheckContentShareConnectivityFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checknetworktcpconnectivityfeedback.html
+++ b/docs/enums/checknetworktcpconnectivityfeedback.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts#L7">src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">ICENegotiation<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts#L8">src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Meeting<wbr>SessionURLs<wbr>Not<wbr>Initialized<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts#L6">src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts#L5">src/meetingreadinesschecker/CheckNetworkTCPConnectivityFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checknetworkudpconnectivityfeedback.html
+++ b/docs/enums/checknetworkudpconnectivityfeedback.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts#L7">src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">ICENegotiation<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts#L8">src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Meeting<wbr>SessionURLs<wbr>Not<wbr>Initialized<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts#L6">src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts#L5">src/meetingreadinesschecker/CheckNetworkUDPConnectivityFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkvideoconnectivityfeedback.html
+++ b/docs/enums/checkvideoconnectivityfeedback.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts#L8">src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts#L5">src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Video<wbr>Input<wbr>Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts#L7">src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Video<wbr>Input<wbr>Request<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts#L6">src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Video<wbr>Not<wbr>Sent<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts#L9">src/meetingreadinesschecker/CheckVideoConnectivityFeedback.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/checkvideoinputfeedback.html
+++ b/docs/enums/checkvideoinputfeedback.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoInputFeedback.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoInputFeedback.ts#L6">src/meetingreadinesschecker/CheckVideoInputFeedback.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoInputFeedback.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoInputFeedback.ts#L7">src/meetingreadinesschecker/CheckVideoInputFeedback.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Succeeded<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingreadinesschecker/CheckVideoInputFeedback.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/CheckVideoInputFeedback.ts#L5">src/meetingreadinesschecker/CheckVideoInputFeedback.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/clientmetricreportdirection.html
+++ b/docs/enums/clientmetricreportdirection.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">DOWNSTREAM<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientMetricReportDirection.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientMetricReportDirection.ts#L6">src/clientmetricreport/ClientMetricReportDirection.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">UPSTREAM<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientMetricReportDirection.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientMetricReportDirection.ts#L5">src/clientmetricreport/ClientMetricReportDirection.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/clientmetricreportmediatype.html
+++ b/docs/enums/clientmetricreportmediatype.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">AUDIO<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientMetricReportMediaType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientMetricReportMediaType.ts#L5">src/clientmetricreport/ClientMetricReportMediaType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">VIDEO<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/clientmetricreport/ClientMetricReportMediaType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientMetricReportMediaType.ts#L6">src/clientmetricreport/ClientMetricReportMediaType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/contentshareconstants.html
+++ b/docs/enums/contentshareconstants.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Modality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;#content&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/contentsharecontroller/ContentShareConstants.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareConstants.ts#L5">src/contentsharecontroller/ContentShareConstants.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/devicepermission.html
+++ b/docs/enums/devicepermission.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<wbr>ByBrowser<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DevicePermission.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DevicePermission.ts#L20">src/devicecontroller/DevicePermission.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Denied<wbr>ByUser<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DevicePermission.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DevicePermission.ts#L16">src/devicecontroller/DevicePermission.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Granted<wbr>ByBrowser<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DevicePermission.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DevicePermission.ts#L12">src/devicecontroller/DevicePermission.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Granted<wbr>ByUser<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DevicePermission.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DevicePermission.ts#L8">src/devicecontroller/DevicePermission.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">Permission<wbr>Granted<wbr>Previously<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/DevicePermission.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DevicePermission.ts#L24">src/devicecontroller/DevicePermission.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/dragtype.html
+++ b/docs/enums/dragtype.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">BEGIN<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragType.ts#L5">src/dragobserver/DragType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">DRAG<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragType.ts#L6">src/dragobserver/DragType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">END<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragType.ts#L7">src/dragobserver/DragType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/loglevel.html
+++ b/docs/enums/loglevel.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEBUG<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/LogLevel.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/LogLevel.ts#L5">src/logger/LogLevel.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERROR<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/LogLevel.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/LogLevel.ts#L8">src/logger/LogLevel.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">INFO<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/LogLevel.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/LogLevel.ts#L6">src/logger/LogLevel.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">OFF<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/LogLevel.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/LogLevel.ts#L9">src/logger/LogLevel.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">WARN<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/logger/LogLevel.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/LogLevel.ts#L7">src/logger/LogLevel.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/mediarecordingevent.html
+++ b/docs/enums/mediarecordingevent.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ended<wbr>Event<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ended&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/MediaRecordingEvent.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecordingEvent.ts#L5">src/mediarecording/MediaRecordingEvent.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/meetingsessionlifecycleevent.html
+++ b/docs/enums/meetingsessionlifecycleevent.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connecting<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEvent.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEvent.ts#L12">src/meetingsession/MeetingSessionLifecycleEvent.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEvent.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEvent.ts#L18">src/meetingsession/MeetingSessionLifecycleEvent.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEvent.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEvent.ts#L23">src/meetingsession/MeetingSessionLifecycleEvent.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/meetingsessionlifecycleeventcondition.html
+++ b/docs/enums/meetingsessionlifecycleeventcondition.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connecting<wbr>New<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L12">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">Reconnecting<wbr>Existing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L17">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<wbr>After<wbr>Reconnect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L33">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<wbr>Existing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L28">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:28</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">Started<wbr>New<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:22</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L22">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<wbr>Cleanly<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L38">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:38</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stopped<wbr>With<wbr>Failure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionLifecycleEventCondition.ts:44</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionLifecycleEventCondition.ts#L44">src/meetingsession/MeetingSessionLifecycleEventCondition.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/meetingsessionstatuscode.html
+++ b/docs/enums/meetingsessionstatuscode.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Authentication<wbr>Rejected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:29</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L29">src/meetingsession/MeetingSessionStatusCode.ts:29</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Call<wbr>AtCapacity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L34">src/meetingsession/MeetingSessionStatusCode.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Call<wbr>Ended<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:40</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L40">src/meetingsession/MeetingSessionStatusCode.ts:40</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Device<wbr>Switched<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 20</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:127</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L127">src/meetingsession/MeetingSessionStatusCode.ts:127</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Disconnect<wbr>Audio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:24</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L24">src/meetingsession/MeetingSessionStatusCode.ts:24</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Disconnected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 9</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:66</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L66">src/meetingsession/MeetingSessionStatusCode.ts:66</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -204,7 +204,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Internal<wbr>Server<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 7</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:56</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L56">src/meetingsession/MeetingSessionStatusCode.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Joined<wbr>From<wbr>Another<wbr>Device<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L18">src/meetingsession/MeetingSessionStatusCode.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -234,7 +234,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Service<wbr>Unavailable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 8</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:61</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L61">src/meetingsession/MeetingSessionStatusCode.ts:61</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Health<wbr>Reconnect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 17</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:112</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L112">src/meetingsession/MeetingSessionStatusCode.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 					<div class="tsd-signature tsd-kind-icon">ICEGathering<wbr>Timeout<wbr>Workaround<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 16</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:107</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L107">src/meetingsession/MeetingSessionStatusCode.ts:107</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">IncompatibleSDP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 21</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:132</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L132">src/meetingsession/MeetingSessionStatusCode.ts:132</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">Left<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L13">src/meetingsession/MeetingSessionStatusCode.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 					<div class="tsd-signature tsd-kind-icon">Meeting<wbr>Ended<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:51</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L51">src/meetingsession/MeetingSessionStatusCode.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -327,7 +327,7 @@
 					<div class="tsd-signature tsd-kind-icon">No<wbr>Attendee<wbr>Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 23</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:142</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L142">src/meetingsession/MeetingSessionStatusCode.ts:142</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">OK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L8">src/meetingsession/MeetingSessionStatusCode.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -357,7 +357,7 @@
 					<div class="tsd-signature tsd-kind-icon">Realtime<wbr>Api<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 18</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:117</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L117">src/meetingsession/MeetingSessionStatusCode.ts:117</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -372,7 +372,7 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Bad<wbr>Request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 12</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:84</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L84">src/meetingsession/MeetingSessionStatusCode.ts:84</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Internal<wbr>Server<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 13</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:89</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L89">src/meetingsession/MeetingSessionStatusCode.ts:89</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -402,7 +402,7 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Request<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 14</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:94</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L94">src/meetingsession/MeetingSessionStatusCode.ts:94</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -417,7 +417,7 @@
 					<div class="tsd-signature tsd-kind-icon">State<wbr>Machine<wbr>Transition<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:99</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L99">src/meetingsession/MeetingSessionStatusCode.ts:99</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -432,7 +432,7 @@
 					<div class="tsd-signature tsd-kind-icon">TURNCredentials<wbr>Forbidden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 22</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:137</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L137">src/meetingsession/MeetingSessionStatusCode.ts:137</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -447,7 +447,7 @@
 					<div class="tsd-signature tsd-kind-icon">TURNMeeting<wbr>Ended<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:46</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L46">src/meetingsession/MeetingSessionStatusCode.ts:46</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -463,7 +463,7 @@
 					<div class="tsd-signature tsd-kind-icon">Task<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 19</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:122</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L122">src/meetingsession/MeetingSessionStatusCode.ts:122</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -478,7 +478,7 @@
 					<div class="tsd-signature tsd-kind-icon">Video<wbr>Call<wbr>AtSource<wbr>Capacity<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 11</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:79</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L79">src/meetingsession/MeetingSessionStatusCode.ts:79</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -496,7 +496,7 @@
 					<div class="tsd-signature tsd-kind-icon">Video<wbr>Call<wbr>Switch<wbr>ToView<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 10</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSessionStatusCode.ts:73</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L73">src/meetingsession/MeetingSessionStatusCode.ts:73</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/presentationboxtype.html
+++ b/docs/enums/presentationboxtype.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">LETTER_<wbr>BOX<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/PresentationBoxType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationBoxType.ts#L5">src/presentation/PresentationBoxType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">NONE<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/PresentationBoxType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationBoxType.ts#L7">src/presentation/PresentationBoxType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">PILLAR_<wbr>BOX<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/PresentationBoxType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationBoxType.ts#L6">src/presentation/PresentationBoxType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/promisedwebsocketclosurecode.html
+++ b/docs/enums/promisedwebsocketclosurecode.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Empty<wbr>Close<wbr>Frame<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1005</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/PromisedWebSocketClosureCode.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocketClosureCode.ts#L6">src/promisedwebsocket/PromisedWebSocketClosureCode.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Normal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/PromisedWebSocketClosureCode.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocketClosureCode.ts#L5">src/promisedwebsocket/PromisedWebSocketClosureCode.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/rateprobestate.html
+++ b/docs/enums/rateprobestate.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Not<wbr>Probing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Not Probing&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L31">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Probe<wbr>Pending<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Probe Pending&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L32">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Probing<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Probing&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L33">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/screensharestreamingevent.html
+++ b/docs/enums/screensharestreamingevent.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Ended<wbr>Event<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ended&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharestreaming/ScreenShareStreamingEvent.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamingEvent.ts#L5">src/screensharestreaming/ScreenShareStreamingEvent.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Message<wbr>Event<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;message&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharestreaming/ScreenShareStreamingEvent.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamingEvent.ts#L6">src/screensharestreaming/ScreenShareStreamingEvent.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/screensharingmessageflag.html
+++ b/docs/enums/screensharingmessageflag.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Broadcast<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageFlag.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageFlag.ts#L5">src/screensharingmessage/ScreenSharingMessageFlag.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Local<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageFlag.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageFlag.ts#L6">src/screensharingmessage/ScreenSharingMessageFlag.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Synthesized<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageFlag.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageFlag.ts#L7">src/screensharingmessage/ScreenSharingMessageFlag.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unicast<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageFlag.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageFlag.ts#L8">src/screensharingmessage/ScreenSharingMessageFlag.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/screensharingmessagetype.html
+++ b/docs/enums/screensharingmessagetype.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">Heartbeat<wbr>Request<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;HeartbeatRequest&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L9">src/screensharingmessage/ScreenSharingMessageType.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">Heartbeat<wbr>Response<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;HeartbeatResponse&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L10">src/screensharingmessage/ScreenSharingMessageType.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">Key<wbr>Request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;KeyRequest&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L18">src/screensharingmessage/ScreenSharingMessageType.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">Presenter<wbr>Switch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;PresenterSwitch&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L17">src/screensharingmessage/ScreenSharingMessageType.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>End<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;StreamEnd&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L12">src/screensharingmessage/ScreenSharingMessageType.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Pause<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;StreamPause&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L14">src/screensharingmessage/ScreenSharingMessageType.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;StreamStart&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L11">src/screensharingmessage/ScreenSharingMessageType.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Stop<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;StreamStop&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L13">src/screensharingmessage/ScreenSharingMessageType.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Unpause<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;StreamUnpause&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L15">src/screensharingmessage/ScreenSharingMessageType.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">Unknown<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L8">src/screensharingmessage/ScreenSharingMessageType.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 					<div class="tsd-signature tsd-kind-icon">WebM<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;WebM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessageType.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessageType.ts#L16">src/screensharingmessage/ScreenSharingMessageType.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/screensignalingsessioneventtype.html
+++ b/docs/enums/screensignalingsessioneventtype.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;close&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionEventType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionEventType.ts#L5">src/screensignalingsession/ScreenSignalingSessionEventType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Heartbeat<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;heartbeat&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionEventType.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionEventType.ts#L9">src/screensignalingsession/ScreenSignalingSessionEventType.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>End<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;streamend&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionEventType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionEventType.ts#L7">src/screensignalingsession/ScreenSignalingSessionEventType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;streamstart&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionEventType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionEventType.ts#L6">src/screensignalingsession/ScreenSignalingSessionEventType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stream<wbr>Switch<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;streamswitch&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensignalingsession/ScreenSignalingSessionEventType.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionEventType.ts#L8">src/screensignalingsession/ScreenSignalingSessionEventType.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/screenviewingpackettype.html
+++ b/docs/enums/screenviewingpackettype.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">DELTA<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L6">src/screenviewing/session/ScreenViewingPacketType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">ECHO_<wbr>REQUEST<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L8">src/screenviewing/session/ScreenViewingPacketType.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">ECHO_<wbr>RESPONSE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L9">src/screenviewing/session/ScreenViewingPacketType.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENDSCREEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 8</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L11">src/screenviewing/session/ScreenViewingPacketType.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">JPEG_<wbr>HEADER_<wbr>BYTE_<wbr>0<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 255</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L12">src/screenviewing/session/ScreenViewingPacketType.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">JPEG_<wbr>HEADER_<wbr>BYTE_<wbr>1<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 216</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L13">src/screenviewing/session/ScreenViewingPacketType.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">NOSCREEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 7</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L10">src/screenviewing/session/ScreenViewingPacketType.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">SETUP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L5">src/screenviewing/session/ScreenViewingPacketType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">SYNC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/session/ScreenViewingPacketType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingPacketType.ts#L7">src/screenviewing/session/ScreenViewingPacketType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/sdpcandidatetype.html
+++ b/docs/enums/sdpcandidatetype.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Host<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;host&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/SDPCandidateType.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDPCandidateType.ts#L5">src/sdp/SDPCandidateType.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Peer<wbr>Reflexive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;prflx&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/SDPCandidateType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDPCandidateType.ts#L7">src/sdp/SDPCandidateType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Relay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;relay&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/SDPCandidateType.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDPCandidateType.ts#L8">src/sdp/SDPCandidateType.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Server<wbr>Reflexive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;srflx&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sdp/SDPCandidateType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDPCandidateType.ts#L6">src/sdp/SDPCandidateType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/sessionstatecontrolleraction.html
+++ b/docs/enums/sessionstatecontrolleraction.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connect<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L8">src/sessionstatecontroller/SessionStateControllerAction.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Disconnect<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L13">src/sessionstatecontroller/SessionStateControllerAction.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fail<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L14">src/sessionstatecontroller/SessionStateControllerAction.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Finish<wbr>Connecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L9">src/sessionstatecontroller/SessionStateControllerAction.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">Finish<wbr>Disconnecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L15">src/sessionstatecontroller/SessionStateControllerAction.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">Finish<wbr>Updating<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L11">src/sessionstatecontroller/SessionStateControllerAction.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">Reconnect<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L12">src/sessionstatecontroller/SessionStateControllerAction.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">Update<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerAction.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerAction.ts#L10">src/sessionstatecontroller/SessionStateControllerAction.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/sessionstatecontrollerdeferpriority.html
+++ b/docs/enums/sessionstatecontrollerdeferpriority.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Do<wbr>Not<wbr>Defer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerDeferPriority.ts#L10">src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">High<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerDeferPriority.ts#L13">src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Low<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerDeferPriority.ts#L11">src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Medium<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerDeferPriority.ts#L12">src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Very<wbr>High<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerDeferPriority.ts#L14">src/sessionstatecontroller/SessionStateControllerDeferPriority.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/sessionstatecontrollerstate.html
+++ b/docs/enums/sessionstatecontrollerstate.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connected<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerState.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerState.ts#L10">src/sessionstatecontroller/SessionStateControllerState.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerState.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerState.ts#L9">src/sessionstatecontroller/SessionStateControllerState.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">Disconnecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerState.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerState.ts#L12">src/sessionstatecontroller/SessionStateControllerState.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">Not<wbr>Connected<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerState.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerState.ts#L8">src/sessionstatecontroller/SessionStateControllerState.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">Updating<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerState.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerState.ts#L11">src/sessionstatecontroller/SessionStateControllerState.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/sessionstatecontrollertransitionresult.html
+++ b/docs/enums/sessionstatecontrollertransitionresult.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Deferred<wbr>Transition<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:21</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerTransitionResult.ts#L21">src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:21</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">No<wbr>Transition<wbr>Available<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerTransitionResult.ts#L16">src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">Transition<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerTransitionResult.ts#L26">src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">Transitioned<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateControllerTransitionResult.ts#L11">src/sessionstatecontroller/SessionStateControllerTransitionResult.ts:11</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/signalingclienteventtype.html
+++ b/docs/enums/signalingclienteventtype.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Protocol<wbr>Decode<wbr>Failure<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L15">src/signalingclient/SignalingClientEventType.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">Received<wbr>Signal<wbr>Frame<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L16">src/signalingclient/SignalingClientEventType.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Closed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L10">src/signalingclient/SignalingClientEventType.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Closing<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L9">src/signalingclient/SignalingClientEventType.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Connecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L6">src/signalingclient/SignalingClientEventType.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Error<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L8">src/signalingclient/SignalingClientEventType.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L11">src/signalingclient/SignalingClientEventType.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Message<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L12">src/signalingclient/SignalingClientEventType.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Open<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L7">src/signalingclient/SignalingClientEventType.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Send<wbr>Message<wbr>Failure<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L13">src/signalingclient/SignalingClientEventType.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Sent<wbr>Message<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L14">src/signalingclient/SignalingClientEventType.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Socket<wbr>Skipped<wbr>Message<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/signalingclient/SignalingClientEventType.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClientEventType.ts#L17">src/signalingclient/SignalingClientEventType.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/taskstatus.html
+++ b/docs/enums/taskstatus.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CANCELED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CANCELED&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TaskStatus.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TaskStatus.ts#L7">src/task/TaskStatus.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">FINISHED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;FINISHED&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TaskStatus.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TaskStatus.ts#L8">src/task/TaskStatus.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">IDLE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;IDLE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TaskStatus.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TaskStatus.ts#L5">src/task/TaskStatus.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">RUNNING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;RUNNING&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/task/TaskStatus.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/TaskStatus.ts#L6">src/task/TaskStatus.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/usereceiveset.html
+++ b/docs/enums/usereceiveset.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>New<wbr>Optimal<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L37">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Pre<wbr>Probe<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:39</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L39">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Previous<wbr>Optimal<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L38">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/videologevent.html
+++ b/docs/enums/videologevent.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Input<wbr>Attached<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/VideoLogEvent.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/VideoLogEvent.ts#L5">src/statscollector/VideoLogEvent.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sending<wbr>Failed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/VideoLogEvent.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/VideoLogEvent.ts#L6">src/statscollector/VideoLogEvent.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sending<wbr>Success<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/VideoLogEvent.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/VideoLogEvent.ts#L7">src/statscollector/VideoLogEvent.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/websocketreadystate.html
+++ b/docs/enums/websocketreadystate.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Closed<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/WebSocketReadyState.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketReadyState.ts#L9">src/websocketadapter/WebSocketReadyState.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">Closing<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/WebSocketReadyState.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketReadyState.ts#L8">src/websocketadapter/WebSocketReadyState.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connecting<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/WebSocketReadyState.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketReadyState.ts#L6">src/websocketadapter/WebSocketReadyState.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/WebSocketReadyState.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketReadyState.ts#L5">src/websocketadapter/WebSocketReadyState.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Open<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/websocketadapter/WebSocketReadyState.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketReadyState.ts#L7">src/websocketadapter/WebSocketReadyState.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/zoomtype.html
+++ b/docs/enums/zoomtype.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">NONE<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:82</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L82">src/presentation/policy/PresentationPolicy.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">RESET<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:81</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L81">src/presentation/policy/PresentationPolicy.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">ZOOM<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:80</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L80">src/presentation/policy/PresentationPolicy.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -445,7 +445,7 @@
 					<div class="tsd-signature tsd-kind-icon">Detector<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>attendeeIds<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L12">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:12</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 					<div class="tsd-signature tsd-kind-icon">Detector<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>attendeeId<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, present<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/DefaultActiveSpeakerDetector.ts#L13">src/activespeakerdetector/DefaultActiveSpeakerDetector.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -515,7 +515,7 @@
 					<div class="tsd-signature tsd-kind-icon">Device<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MediaTrackConstraints</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/devicecontroller/Device.ts:4</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/Device.ts#L4">src/devicecontroller/Device.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -525,7 +525,7 @@
 					<div class="tsd-signature tsd-kind-icon">Drag<wbr>Observer<wbr>Factory<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>window<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Window</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>dragEvent<span class="tsd-signature-symbol">: </span><a href="interfaces/dragevent.html" class="tsd-signature-type">DragEvent</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span>, element<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">HTMLElement</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="interfaces/dragobserver.html" class="tsd-signature-type">DragObserver</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragObserver.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragObserver.ts#L6">src/dragobserver/DragObserver.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -580,7 +580,7 @@
 					<div class="tsd-signature tsd-kind-icon">Listener<wbr>Function<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>type<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, listener<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">EventListenerOrEventListenerObject</span>, options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AddEventListenerOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediadevicefactory/MediaDeviceProxyHandler.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceProxyHandler.ts#L7">src/mediadevicefactory/MediaDeviceProxyHandler.ts:7</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -617,7 +617,7 @@
 					<div class="tsd-signature tsd-kind-icon">Raw<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:28</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L28">src/statscollector/DefaultStatsCollector.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -627,7 +627,7 @@
 					<div class="tsd-signature tsd-kind-icon">Stats<wbr>Report<wbr>Item<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/statscollector/DefaultStatsCollector.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L31">src/statscollector/DefaultStatsCollector.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -640,7 +640,7 @@
 					<div class="tsd-signature tsd-kind-icon">CSS_<wbr>OVERFLOW_<wbr>HIDDEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"hidden"</span><span class="tsd-signature-symbol"> = &quot;hidden&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/DefaultPresentation.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L17">src/presentation/DefaultPresentation.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -650,7 +650,7 @@
 					<div class="tsd-signature tsd-kind-icon">CSS_<wbr>POSITION_<wbr>ABSOLUTE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"absolute"</span><span class="tsd-signature-symbol"> = &quot;absolute&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/DefaultPresentation.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L18">src/presentation/DefaultPresentation.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -660,7 +660,7 @@
 					<div class="tsd-signature tsd-kind-icon">CSS_<wbr>POSITION_<wbr>RELATIVE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"relative"</span><span class="tsd-signature-symbol"> = &quot;relative&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/DefaultPresentation.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/DefaultPresentation.ts#L19">src/presentation/DefaultPresentation.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/activespeakerdetector.html
+++ b/docs/interfaces/activespeakerdetector.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetector.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetector.ts#L14">src/activespeakerdetector/ActiveSpeakerDetector.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetector.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetector.ts#L24">src/activespeakerdetector/ActiveSpeakerDetector.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/activespeakerdetectorfacade.html
+++ b/docs/interfaces/activespeakerdetectorfacade.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts#L13">src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts#L24">src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/activespeakerpolicy.html
+++ b/docs/interfaces/activespeakerpolicy.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerpolicy/ActiveSpeakerPolicy.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/ActiveSpeakerPolicy.ts#L12">src/activespeakerpolicy/ActiveSpeakerPolicy.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/activespeakerpolicy/ActiveSpeakerPolicy.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerpolicy/ActiveSpeakerPolicy.ts#L19">src/activespeakerpolicy/ActiveSpeakerPolicy.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/interfaces/audiomixcontroller.html
+++ b/docs/interfaces/audiomixcontroller.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixController.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixController.ts#L29">src/audiomixcontroller/AudioMixController.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="audiomixcontrollerfacade.html">AudioMixControllerFacade</a>.<a href="audiomixcontrollerfacade.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixController.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixController.ts#L14">src/audiomixcontroller/AudioMixController.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixController.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixController.ts#L24">src/audiomixcontroller/AudioMixController.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="audiomixcontrollerfacade.html">AudioMixControllerFacade</a>.<a href="audiomixcontrollerfacade.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixController.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixController.ts#L19">src/audiomixcontroller/AudioMixController.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/audiomixcontrollerfacade.html
+++ b/docs/interfaces/audiomixcontrollerfacade.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixControllerFacade.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixControllerFacade.ts#L5">src/audiomixcontroller/AudioMixControllerFacade.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixControllerFacade.ts:6</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixControllerFacade.ts#L6">src/audiomixcontroller/AudioMixControllerFacade.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/audiovideocontroller.html
+++ b/docs/interfaces/audiovideocontroller.html
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<wbr>Speaker<wbr>Detector<span class="tsd-signature-symbol">:</span> <a href="activespeakerdetector.html" class="tsd-signature-type">ActiveSpeakerDetector</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:80</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L80">src/audiovideocontroller/AudioVideoController.ts:80</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Mix<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="audiomixcontroller.html" class="tsd-signature-type">AudioMixController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:106</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L106">src/audiovideocontroller/AudioVideoController.ts:106</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="../classes/meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:70</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L70">src/audiovideocontroller/AudioVideoController.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:90</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L90">src/audiovideocontroller/AudioVideoController.ts:90</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">media<wbr>Stream<wbr>Broker<span class="tsd-signature-symbol">:</span> <a href="mediastreambroker.html" class="tsd-signature-type">MediaStreamBroker</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:101</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L101">src/audiovideocontroller/AudioVideoController.ts:101</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">realtime<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="realtimecontroller.html" class="tsd-signature-type">RealtimeController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:75</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L75">src/audiovideocontroller/AudioVideoController.ts:75</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">rtc<wbr>Peer<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTCPeerConnection</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:96</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L96">src/audiovideocontroller/AudioVideoController.ts:96</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="videotilecontroller.html" class="tsd-signature-type">VideoTileController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/audiovideocontroller/AudioVideoController.ts:85</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L85">src/audiovideocontroller/AudioVideoController.ts:85</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -269,7 +269,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L7">src/audiovideocontroller/AudioVideoControllerFacade.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -292,7 +292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L23">src/audiovideocontroller/AudioVideoController.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -340,7 +340,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L11">src/audiovideocontroller/AudioVideoControllerFacade.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L50">src/audiovideocontroller/AudioVideoController.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -394,7 +394,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L60">src/audiovideocontroller/AudioVideoController.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L45">src/audiovideocontroller/AudioVideoController.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -451,7 +451,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L8">src/audiovideocontroller/AudioVideoControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -474,7 +474,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L40">src/audiovideocontroller/AudioVideoController.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -515,7 +515,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L34">src/audiovideocontroller/AudioVideoController.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -556,7 +556,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L65">src/audiovideocontroller/AudioVideoController.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -584,7 +584,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L55">src/audiovideocontroller/AudioVideoController.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L9">src/audiovideocontroller/AudioVideoControllerFacade.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -631,7 +631,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L10">src/audiovideocontroller/AudioVideoControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -648,7 +648,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoController.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoController.ts#L28">src/audiovideocontroller/AudioVideoController.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/audiovideocontrollerfacade.html
+++ b/docs/interfaces/audiovideocontrollerfacade.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L7">src/audiovideocontroller/AudioVideoControllerFacade.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L11">src/audiovideocontroller/AudioVideoControllerFacade.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L8">src/audiovideocontroller/AudioVideoControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L9">src/audiovideocontroller/AudioVideoControllerFacade.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L10">src/audiovideocontroller/AudioVideoControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -197,7 +197,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L35">src/contentsharecontroller/ContentShareControllerFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:82</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L82">src/devicecontroller/DeviceController.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L7">src/audiovideocontroller/AudioVideoControllerFacade.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#addvideotile">addVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L19">src/videotilecontroller/VideoTileControllerFacade.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a></h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiomixcontrollerfacade.html">AudioMixControllerFacade</a>.<a href="audiomixcontrollerfacade.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixControllerFacade.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixControllerFacade.ts#L5">src/audiomixcontroller/AudioMixControllerFacade.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L7">src/videotilecontroller/VideoTileControllerFacade.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -348,7 +348,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L23">src/videotilecontroller/VideoTileControllerFacade.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -372,7 +372,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L64">src/devicecontroller/DeviceController.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L77">src/devicecontroller/DeviceController.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -433,7 +433,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L72">src/devicecontroller/DeviceController.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L128">src/devicecontroller/DeviceController.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -505,7 +505,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L94">src/devicecontroller/DeviceController.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -530,7 +530,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -559,7 +559,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L17">src/videotilecontroller/VideoTileControllerFacade.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -577,7 +577,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L18">src/videotilecontroller/VideoTileControllerFacade.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L13">src/videotilecontroller/VideoTileControllerFacade.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L11">src/audiovideocontroller/AudioVideoControllerFacade.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -637,7 +637,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L138">src/devicecontroller/DeviceController.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -660,7 +660,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L16">src/videotilecontroller/VideoTileControllerFacade.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -684,7 +684,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#hasstartedlocalvideotile">hasStartedLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L11">src/videotilecontroller/VideoTileControllerFacade.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -702,7 +702,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L46">src/devicecontroller/DeviceController.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -725,7 +725,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L56">src/devicecontroller/DeviceController.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -748,7 +748,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L51">src/devicecontroller/DeviceController.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -771,7 +771,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L121">src/devicecontroller/DeviceController.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -800,7 +800,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L20">src/contentsharecontroller/ContentShareControllerFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -823,7 +823,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L14">src/videotilecontroller/VideoTileControllerFacade.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -847,7 +847,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L29">src/realtimecontroller/RealtimeControllerFacade.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -865,7 +865,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L34">src/realtimecontroller/RealtimeControllerFacade.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -883,7 +883,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L30">src/realtimecontroller/RealtimeControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -901,7 +901,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L48">src/realtimecontroller/RealtimeControllerFacade.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -931,7 +931,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L26">src/realtimecontroller/RealtimeControllerFacade.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -955,7 +955,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetoattendeeidpresence">realtimeSubscribeToAttendeeIdPresence</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L8">src/realtimecontroller/RealtimeControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1009,7 +1009,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetofatalerror">realtimeSubscribeToFatalError</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L58">src/realtimecontroller/RealtimeControllerFacade.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1051,7 +1051,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetolocalsignalstrengthchange">realtimeSubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L46">src/realtimecontroller/RealtimeControllerFacade.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1093,7 +1093,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetomuteandunmutelocalaudio">realtimeSubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1135,7 +1135,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetoreceivedatamessage">realtimeSubscribeToReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L53">src/realtimecontroller/RealtimeControllerFacade.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1180,7 +1180,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetosetcanunmutelocalaudio">realtimeSubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L27">src/realtimecontroller/RealtimeControllerFacade.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1222,7 +1222,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L35">src/realtimecontroller/RealtimeControllerFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1279,7 +1279,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L31">src/realtimecontroller/RealtimeControllerFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1297,7 +1297,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:57</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L57">src/realtimecontroller/RealtimeControllerFacade.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1321,7 +1321,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1345,7 +1345,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetoattendeeidpresence">realtimeUnsubscribeToAttendeeIdPresence</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L17">src/realtimecontroller/RealtimeControllerFacade.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1399,7 +1399,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetofatalerror">realtimeUnsubscribeToFatalError</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L59">src/realtimecontroller/RealtimeControllerFacade.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1441,7 +1441,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetolocalsignalstrengthchange">realtimeUnsubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L47">src/realtimecontroller/RealtimeControllerFacade.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1483,7 +1483,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetomuteandunmutelocalaudio">realtimeUnsubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L33">src/realtimecontroller/RealtimeControllerFacade.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1525,7 +1525,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="realtimecontrollerfacade.html">RealtimeControllerFacade</a>.<a href="realtimecontrollerfacade.html#realtimeunsubscribetosetcanunmutelocalaudio">realtimeUnsubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L28">src/realtimecontroller/RealtimeControllerFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1567,7 +1567,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L22">src/videotilecontroller/VideoTileControllerFacade.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1585,7 +1585,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L40">src/contentsharecontroller/ContentShareControllerFacade.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1614,7 +1614,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L87">src/devicecontroller/DeviceController.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1643,7 +1643,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#removelocalvideotile">removeLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L12">src/videotilecontroller/VideoTileControllerFacade.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1661,7 +1661,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L8">src/audiovideocontroller/AudioVideoControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1685,7 +1685,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L20">src/videotilecontroller/VideoTileControllerFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1709,7 +1709,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L21">src/videotilecontroller/VideoTileControllerFacade.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1733,7 +1733,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#setdevicelabeltrigger">setDeviceLabelTrigger</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L116">src/devicecontroller/DeviceController.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1776,7 +1776,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#start">start</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L9">src/audiovideocontroller/AudioVideoControllerFacade.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1794,7 +1794,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L10">src/contentsharecontroller/ContentShareControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1823,7 +1823,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L15">src/contentsharecontroller/ContentShareControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1855,7 +1855,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#startlocalvideotile">startLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L9">src/videotilecontroller/VideoTileControllerFacade.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -1873,7 +1873,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L103">src/devicecontroller/DeviceController.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1906,7 +1906,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiovideocontrollerfacade.html">AudioVideoControllerFacade</a>.<a href="audiovideocontrollerfacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in src/audiovideocontroller/AudioVideoControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/AudioVideoControllerFacade.ts#L10">src/audiovideocontroller/AudioVideoControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1924,7 +1924,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L30">src/contentsharecontroller/ContentShareControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1947,7 +1947,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#stoplocalvideotile">stopLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L10">src/videotilecontroller/VideoTileControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1965,7 +1965,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L109">src/devicecontroller/DeviceController.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1995,7 +1995,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="activespeakerdetectorfacade.html">ActiveSpeakerDetectorFacade</a>.<a href="activespeakerdetectorfacade.html#subscribetoactivespeakerdetector">subscribeToActiveSpeakerDetector</a></p>
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts#L13">src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2069,7 +2069,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="audiomixcontrollerfacade.html">AudioMixControllerFacade</a>.<a href="audiomixcontrollerfacade.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in src/audiomixcontroller/AudioMixControllerFacade.ts:6</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiomixcontroller/AudioMixControllerFacade.ts#L6">src/audiomixcontroller/AudioMixControllerFacade.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2087,7 +2087,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#unbindvideoelement">unbindVideoElement</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L8">src/videotilecontroller/VideoTileControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2111,7 +2111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L25">src/contentsharecontroller/ContentShareControllerFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -2134,7 +2134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videotilecontrollerfacade.html">VideoTileControllerFacade</a>.<a href="videotilecontrollerfacade.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L15">src/videotilecontroller/VideoTileControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2158,7 +2158,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="activespeakerdetectorfacade.html">ActiveSpeakerDetectorFacade</a>.<a href="activespeakerdetectorfacade.html#unsubscribefromactivespeakerdetector">unsubscribeFromActiveSpeakerDetector</a></p>
 								<ul>
-									<li>Defined in src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts#L24">src/activespeakerdetector/ActiveSpeakerDetectorFacade.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/audiovideoobserver.html
+++ b/docs/interfaces/audiovideoobserver.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L20">src/audiovideoobserver/AudioVideoObserver.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L15">src/audiovideoobserver/AudioVideoObserver.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -173,7 +173,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L26">src/audiovideoobserver/AudioVideoObserver.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:102</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L102">src/audiovideoobserver/AudioVideoObserver.ts:102</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L90">src/audiovideoobserver/AudioVideoObserver.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L96">src/audiovideoobserver/AudioVideoObserver.ts:96</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L85">src/audiovideoobserver/AudioVideoObserver.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:67</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L67">src/audiovideoobserver/AudioVideoObserver.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L80">src/audiovideoobserver/AudioVideoObserver.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L43">src/audiovideoobserver/AudioVideoObserver.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:75</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L75">src/audiovideoobserver/AudioVideoObserver.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:62</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L62">src/audiovideoobserver/AudioVideoObserver.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -446,7 +446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L53">src/audiovideoobserver/AudioVideoObserver.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -480,7 +480,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L109">src/audiovideoobserver/AudioVideoObserver.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -504,7 +504,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L48">src/audiovideoobserver/AudioVideoObserver.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -535,7 +535,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L31">src/audiovideoobserver/AudioVideoObserver.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -563,7 +563,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/audiovideoobserver/AudioVideoObserver.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L36">src/audiovideoobserver/AudioVideoObserver.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/backoff.html
+++ b/docs/interfaces/backoff.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/Backoff.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/Backoff.ts#L18">src/backoff/Backoff.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/Backoff.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/Backoff.ts#L12">src/backoff/Backoff.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/backofffactory.html
+++ b/docs/interfaces/backofffactory.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/BackoffFactory.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/BackoffFactory.ts#L11">src/backoff/BackoffFactory.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/backoff/BackoffFactory.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/backoff/BackoffFactory.ts#L17">src/backoff/BackoffFactory.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/browserbehavior.html
+++ b/docs/interfaces/browserbehavior.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L23">src/browserbehavior/BrowserBehavior.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L28">src/browserbehavior/BrowserBehavior.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:88</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L88">src/browserbehavior/BrowserBehavior.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L13">src/browserbehavior/BrowserBehavior.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L18">src/browserbehavior/BrowserBehavior.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L58">src/browserbehavior/BrowserBehavior.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L68">src/browserbehavior/BrowserBehavior.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L43">src/browserbehavior/BrowserBehavior.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:78</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L78">src/browserbehavior/BrowserBehavior.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L63">src/browserbehavior/BrowserBehavior.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -343,7 +343,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L53">src/browserbehavior/BrowserBehavior.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L73">src/browserbehavior/BrowserBehavior.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L38">src/browserbehavior/BrowserBehavior.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L48">src/browserbehavior/BrowserBehavior.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -431,7 +431,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L33">src/browserbehavior/BrowserBehavior.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -453,7 +453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L83">src/browserbehavior/BrowserBehavior.ts:83</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:93</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L93">src/browserbehavior/BrowserBehavior.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -497,7 +497,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:98</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L98">src/browserbehavior/BrowserBehavior.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -519,7 +519,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/browserbehavior/BrowserBehavior.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/BrowserBehavior.ts#L8">src/browserbehavior/BrowserBehavior.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/clientmetricreport.html
+++ b/docs/interfaces/clientmetricreport.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/clientmetricreport/ClientMetricReport.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/ClientMetricReport.ts#L12">src/clientmetricreport/ClientMetricReport.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/connectionhealthpolicy.html
+++ b/docs/interfaces/connectionhealthpolicy.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L27">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L37">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L32">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L17">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L12">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -224,7 +224,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionhealthpolicy/ConnectionHealthPolicy.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionhealthpolicy/ConnectionHealthPolicy.ts#L22">src/connectionhealthpolicy/ConnectionHealthPolicy.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/connectionmetrics.html
+++ b/docs/interfaces/connectionmetrics.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/ConnectionMetrics.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/ConnectionMetrics.ts#L6">src/videouplinkbandwidthpolicy/ConnectionMetrics.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">uplink<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/videouplinkbandwidthpolicy/ConnectionMetrics.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/ConnectionMetrics.ts#L5">src/videouplinkbandwidthpolicy/ConnectionMetrics.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/connectionmonitor.html
+++ b/docs/interfaces/connectionmonitor.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/ConnectionMonitor.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/ConnectionMonitor.ts#L11">src/connectionmonitor/ConnectionMonitor.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/connectionmonitor/ConnectionMonitor.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/connectionmonitor/ConnectionMonitor.ts#L16">src/connectionmonitor/ConnectionMonitor.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/contentsharecontroller.html
+++ b/docs/interfaces/contentsharecontroller.html
@@ -118,7 +118,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L35">src/contentsharecontroller/ContentShareControllerFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareController.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareController.ts#L12">src/contentsharecontroller/ContentShareController.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L20">src/contentsharecontroller/ContentShareControllerFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L40">src/contentsharecontroller/ContentShareControllerFacade.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L10">src/contentsharecontroller/ContentShareControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L15">src/contentsharecontroller/ContentShareControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -307,7 +307,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L30">src/contentsharecontroller/ContentShareControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -330,7 +330,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="contentsharecontrollerfacade.html">ContentShareControllerFacade</a>.<a href="contentsharecontrollerfacade.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L25">src/contentsharecontroller/ContentShareControllerFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/contentsharecontrollerfacade.html
+++ b/docs/interfaces/contentsharecontrollerfacade.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L35">src/contentsharecontroller/ContentShareControllerFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L20">src/contentsharecontroller/ContentShareControllerFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L40">src/contentsharecontroller/ContentShareControllerFacade.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L10">src/contentsharecontroller/ContentShareControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L15">src/contentsharecontroller/ContentShareControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -250,7 +250,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L30">src/contentsharecontroller/ContentShareControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentsharecontroller/ContentShareControllerFacade.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentsharecontroller/ContentShareControllerFacade.ts#L25">src/contentsharecontroller/ContentShareControllerFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/contentshareobserver.html
+++ b/docs/interfaces/contentshareobserver.html
@@ -102,7 +102,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentshareobserver/ContentShareObserver.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentshareobserver/ContentShareObserver.ts#L16">src/contentshareobserver/ContentShareObserver.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentshareobserver/ContentShareObserver.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentshareobserver/ContentShareObserver.ts#L8">src/contentshareobserver/ContentShareObserver.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentshareobserver/ContentShareObserver.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentshareobserver/ContentShareObserver.ts#L12">src/contentshareobserver/ContentShareObserver.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/contentshareobserver/ContentShareObserver.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/contentshareobserver/ContentShareObserver.ts#L20">src/contentshareobserver/ContentShareObserver.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicechangeobserver.html
+++ b/docs/interfaces/devicechangeobserver.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicechangeobserver/DeviceChangeObserver.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicechangeobserver/DeviceChangeObserver.ts#L26">src/devicechangeobserver/DeviceChangeObserver.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicechangeobserver/DeviceChangeObserver.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicechangeobserver/DeviceChangeObserver.ts#L11">src/devicechangeobserver/DeviceChangeObserver.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicechangeobserver/DeviceChangeObserver.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicechangeobserver/DeviceChangeObserver.ts#L16">src/devicechangeobserver/DeviceChangeObserver.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicechangeobserver/DeviceChangeObserver.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicechangeobserver/DeviceChangeObserver.ts#L31">src/devicechangeobserver/DeviceChangeObserver.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicechangeobserver/DeviceChangeObserver.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicechangeobserver/DeviceChangeObserver.ts#L21">src/devicechangeobserver/DeviceChangeObserver.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicecontroller.html
+++ b/docs/interfaces/devicecontroller.html
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:82</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L82">src/devicecontroller/DeviceController.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L64">src/devicecontroller/DeviceController.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L77">src/devicecontroller/DeviceController.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L72">src/devicecontroller/DeviceController.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L128">src/devicecontroller/DeviceController.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L94">src/devicecontroller/DeviceController.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L138">src/devicecontroller/DeviceController.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L46">src/devicecontroller/DeviceController.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L56">src/devicecontroller/DeviceController.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -429,7 +429,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L51">src/devicecontroller/DeviceController.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -451,7 +451,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L121">src/devicecontroller/DeviceController.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -479,7 +479,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L87">src/devicecontroller/DeviceController.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -507,7 +507,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L116">src/devicecontroller/DeviceController.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -549,7 +549,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L103">src/devicecontroller/DeviceController.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L109">src/devicecontroller/DeviceController.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicecontrollerbasedmediastreambroker.html
+++ b/docs/interfaces/devicecontrollerbasedmediastreambroker.html
@@ -135,7 +135,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="mediastreambroker.html">MediaStreamBroker</a>.<a href="mediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L17">src/mediastreambroker/MediaStreamBroker.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="mediastreambroker.html">MediaStreamBroker</a>.<a href="mediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L28">src/mediastreambroker/MediaStreamBroker.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="mediastreambroker.html">MediaStreamBroker</a>.<a href="mediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L23">src/mediastreambroker/MediaStreamBroker.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:82</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L82">src/devicecontroller/DeviceController.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="mediastreambroker.html">MediaStreamBroker</a>.<a href="mediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L40">src/mediastreambroker/MediaStreamBroker.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -271,7 +271,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L64">src/devicecontroller/DeviceController.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:77</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L77">src/devicecontroller/DeviceController.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -332,7 +332,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L72">src/devicecontroller/DeviceController.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -364,7 +364,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:128</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L128">src/devicecontroller/DeviceController.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -404,7 +404,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L94">src/devicecontroller/DeviceController.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -429,7 +429,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:143</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:138</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L138">src/devicecontroller/DeviceController.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L46">src/devicecontroller/DeviceController.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -504,7 +504,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L56">src/devicecontroller/DeviceController.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -527,7 +527,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L51">src/devicecontroller/DeviceController.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -550,7 +550,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L121">src/devicecontroller/DeviceController.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -579,7 +579,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="mediastreambroker.html">MediaStreamBroker</a>.<a href="mediastreambroker.html#releasemediastream">releaseMediaStream</a></p>
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L34">src/mediastreambroker/MediaStreamBroker.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -609,7 +609,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:87</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L87">src/devicecontroller/DeviceController.ts:87</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -638,7 +638,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#setdevicelabeltrigger">setDeviceLabelTrigger</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L116">src/devicecontroller/DeviceController.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -681,7 +681,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L103">src/devicecontroller/DeviceController.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +714,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in src/devicecontroller/DeviceController.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L109">src/devicecontroller/DeviceController.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicepixelratiomonitor.html
+++ b/docs/interfaces/devicepixelratiomonitor.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts#L13">src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts#L18">src/devicepixelratiomonitor/DevicePixelRatioMonitor.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicepixelratioobserver.html
+++ b/docs/interfaces/devicepixelratioobserver.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratioobserver/DevicePixelRatioObserver.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratioobserver/DevicePixelRatioObserver.ts#L15">src/devicepixelratioobserver/DevicePixelRatioObserver.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/devicepixelratiosource.html
+++ b/docs/interfaces/devicepixelratiosource.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/devicepixelratiosource/DevicePixelRatioSource.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicepixelratiosource/DevicePixelRatioSource.ts#L12">src/devicepixelratiosource/DevicePixelRatioSource.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/domwebsocket.html
+++ b/docs/interfaces/domwebsocket.html
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">onclose<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DOMWebSocket.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L8">src/domwebsocket/DOMWebSocket.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">onerror<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DOMWebSocket.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L7">src/domwebsocket/DOMWebSocket.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">onmessage<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DOMWebSocket.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L9">src/domwebsocket/DOMWebSocket.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">onopen<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">EventListener</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DOMWebSocket.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L6">src/domwebsocket/DOMWebSocket.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/domwebsocket/DOMWebSocket.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L5">src/domwebsocket/DOMWebSocket.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DOMWebSocket.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L21">src/domwebsocket/DOMWebSocket.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DOMWebSocket.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocket.ts#L14">src/domwebsocket/DOMWebSocket.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/domwebsocketfactory.html
+++ b/docs/interfaces/domwebsocketfactory.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/domwebsocket/DOMWebSocketFactory.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/domwebsocket/DOMWebSocketFactory.ts#L14">src/domwebsocket/DOMWebSocketFactory.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/dragcontext.html
+++ b/docs/interfaces/dragcontext.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Mouse<wbr>Down<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragContext.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragContext.ts#L7">src/dragobserver/DragContext.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<span class="tsd-signature-symbol">:</span> <a href="dragevent.html" class="tsd-signature-type">DragEvent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragContext.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragContext.ts#L8">src/dragobserver/DragContext.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/dragevent.html
+++ b/docs/interfaces/dragevent.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">coords<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragEvent.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragEvent.ts#L8">src/dragobserver/DragEvent.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<span class="tsd-signature-symbol">:</span> <a href="dragevent.html" class="tsd-signature-type">DragEvent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragEvent.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragEvent.ts#L9">src/dragobserver/DragEvent.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/dragtype.html" class="tsd-signature-type">DragType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/dragobserver/DragEvent.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragEvent.ts#L7">src/dragobserver/DragEvent.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/dragobserver.html
+++ b/docs/interfaces/dragobserver.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/dragobserver/DragObserver.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/dragobserver/DragObserver.ts#L16">src/dragobserver/DragObserver.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/jpegdecodercomponentfactory.html
+++ b/docs/interfaces/jpegdecodercomponentfactory.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/JPEGDecoderComponentFactory.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/JPEGDecoderComponentFactory.ts#L14">src/jpegdecoder/JPEGDecoderComponentFactory.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/jpegdecodercontroller.html
+++ b/docs/interfaces/jpegdecodercontroller.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/JPEGDecoderController.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/JPEGDecoderController.ts#L16">src/jpegdecoder/controller/JPEGDecoderController.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/controller/JPEGDecoderController.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/controller/JPEGDecoderController.ts#L23">src/jpegdecoder/controller/JPEGDecoderController.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/jpegdecoderinstance.html
+++ b/docs/interfaces/jpegdecoderinstance.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/instance/JPEGDecoderInstance.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/JPEGDecoderInstance.ts#L12">src/jpegdecoder/instance/JPEGDecoderInstance.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/jpegdecoder/instance/JPEGDecoderInstance.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/jpegdecoder/instance/JPEGDecoderInstance.ts#L19">src/jpegdecoder/instance/JPEGDecoderInstance.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logger.html
+++ b/docs/interfaces/logger.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L15">src/logger/Logger.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L30">src/logger/Logger.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L40">src/logger/Logger.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L20">src/logger/Logger.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L35">src/logger/Logger.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/logger/Logger.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/Logger.ts#L25">src/logger/Logger.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/maybeprovider.html
+++ b/docs/interfaces/maybeprovider.html
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/maybe/MaybeProvider.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L13">src/maybe/MaybeProvider.ts:13</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Some<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/maybe/MaybeProvider.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L8">src/maybe/MaybeProvider.ts:8</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/MaybeProvider.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L42">src/maybe/MaybeProvider.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/MaybeProvider.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L22">src/maybe/MaybeProvider.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/MaybeProvider.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L28">src/maybe/MaybeProvider.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -255,7 +255,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/MaybeProvider.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L35">src/maybe/MaybeProvider.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/maybe/MaybeProvider.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/maybe/MaybeProvider.ts#L20">src/maybe/MaybeProvider.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/mediadevicefactory.html
+++ b/docs/interfaces/mediadevicefactory.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediadevicefactory/MediaDeviceFactory.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediadevicefactory/MediaDeviceFactory.ts#L11">src/mediadevicefactory/MediaDeviceFactory.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/mediarecording.html
+++ b/docs/interfaces/mediarecording.html
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">recording<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RecordingState</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/MediaRecording.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L34">src/mediarecording/MediaRecording.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecording.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L14">src/mediarecording/MediaRecording.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecording.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L24">src/mediarecording/MediaRecording.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -324,7 +324,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecording.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L9">src/mediarecording/MediaRecording.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -354,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecording.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L19">src/mediarecording/MediaRecording.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecording.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecording.ts#L29">src/mediarecording/MediaRecording.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/mediarecordingfactory.html
+++ b/docs/interfaces/mediarecordingfactory.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediarecording/MediaRecordingFactory.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecordingFactory.ts#L12">src/mediarecording/MediaRecordingFactory.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/mediarecordingoptions.html
+++ b/docs/interfaces/mediarecordingoptions.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Bits<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/mediarecording/MediaRecordingOptions.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediarecording/MediaRecordingOptions.ts#L5">src/mediarecording/MediaRecordingOptions.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/mediastreambroker.html
+++ b/docs/interfaces/mediastreambroker.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L17">src/mediastreambroker/MediaStreamBroker.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L28">src/mediastreambroker/MediaStreamBroker.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L23">src/mediastreambroker/MediaStreamBroker.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L40">src/mediastreambroker/MediaStreamBroker.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/mediastreambroker/MediaStreamBroker.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/mediastreambroker/MediaStreamBroker.ts#L34">src/mediastreambroker/MediaStreamBroker.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/meetingreadinesschecker.html
+++ b/docs/interfaces/meetingreadinesschecker.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:52</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L52">src/meetingreadinesschecker/MeetingReadinessChecker.ts:52</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L18">src/meetingreadinesschecker/MeetingReadinessChecker.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L23">src/meetingreadinesschecker/MeetingReadinessChecker.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L37">src/meetingreadinesschecker/MeetingReadinessChecker.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L47">src/meetingreadinesschecker/MeetingReadinessChecker.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -278,7 +278,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:71</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L71">src/meetingreadinesschecker/MeetingReadinessChecker.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L66">src/meetingreadinesschecker/MeetingReadinessChecker.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -322,7 +322,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L59">src/meetingreadinesschecker/MeetingReadinessChecker.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -350,7 +350,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/meetingreadinesschecker/MeetingReadinessChecker.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingreadinesschecker/MeetingReadinessChecker.ts#L32">src/meetingreadinesschecker/MeetingReadinessChecker.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/meetingsession.html
+++ b/docs/interfaces/meetingsession.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Video<span class="tsd-signature-symbol">:</span> <a href="audiovideofacade.html" class="tsd-signature-type">AudioVideoFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L15">src/meetingsession/MeetingSession.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">configuration<span class="tsd-signature-symbol">:</span> <a href="../classes/meetingsessionconfiguration.html" class="tsd-signature-type">MeetingSessionConfiguration</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L13">src/meetingsession/MeetingSession.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Share<span class="tsd-signature-symbol">:</span> <a href="contentsharecontroller.html" class="tsd-signature-type">ContentShareController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L16">src/meetingsession/MeetingSession.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">device<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="devicecontroller.html" class="tsd-signature-type">DeviceController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:19</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L19">src/meetingsession/MeetingSession.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L14">src/meetingsession/MeetingSession.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<span class="tsd-signature-symbol">:</span> <a href="screensharefacade.html" class="tsd-signature-type">ScreenShareFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L17">src/meetingsession/MeetingSession.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Share<wbr>View<span class="tsd-signature-symbol">:</span> <a href="screenshareviewfacade.html" class="tsd-signature-type">ScreenShareViewFacade</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/meetingsession/MeetingSession.ts:18</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSession.ts#L18">src/meetingsession/MeetingSession.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/modality.html
+++ b/docs/interfaces/modality.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/Modality.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/Modality.ts#L17">src/modality/Modality.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/Modality.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/Modality.ts#L27">src/modality/Modality.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/Modality.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/Modality.ts#L12">src/modality/Modality.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/Modality.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/Modality.ts#L22">src/modality/Modality.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/modality/Modality.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/modality/Modality.ts#L32">src/modality/Modality.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/pingpong.html
+++ b/docs/interfaces/pingpong.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/PingPong.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/PingPong.ts#L16">src/pingpong/PingPong.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/PingPong.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/PingPong.ts#L27">src/pingpong/PingPong.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/PingPong.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/PingPong.ts#L21">src/pingpong/PingPong.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/PingPong.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/PingPong.ts#L32">src/pingpong/PingPong.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpong/PingPong.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpong/PingPong.ts#L37">src/pingpong/PingPong.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/pingpongobserver.html
+++ b/docs/interfaces/pingpongobserver.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpongobserver/PingPongObserver.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpongobserver/PingPongObserver.ts#L19">src/pingpongobserver/PingPongObserver.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/pingpongobserver/PingPongObserver.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/pingpongobserver/PingPongObserver.ts#L13">src/pingpongobserver/PingPongObserver.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/presentation.html
+++ b/docs/interfaces/presentation.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/Presentation.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/Presentation.ts#L14">src/presentation/Presentation.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/presentationcontentelement.html
+++ b/docs/interfaces/presentationcontentelement.html
@@ -104,7 +104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L13">src/presentation/PresentationContentElement.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></h4>
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L5">src/presentation/PresentationContentElement.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L9">src/presentation/PresentationContentElement.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></h4>
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L15">src/presentation/PresentationContentElement.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L7">src/presentation/PresentationContentElement.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -201,7 +201,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationContentElement.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationContentElement.ts#L11">src/presentation/PresentationContentElement.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/presentationcontentplacement.html
+++ b/docs/interfaces/presentationcontentplacement.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">dimensions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L15">src/presentation/policy/PresentationPolicy.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">translations<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L20">src/presentation/policy/PresentationPolicy.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/presentationpolicy.html
+++ b/docs/interfaces/presentationpolicy.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">calculate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>state<span class="tsd-signature-symbol">: </span><a href="presentationstate.html" class="tsd-signature-type">PresentationState</a>, updateEvent<span class="tsd-signature-symbol">?: </span><a href="presentationupdateevent.html" class="tsd-signature-type">PresentationUpdateEvent</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="presentationcontentplacement.html" class="tsd-signature-type">PresentationContentPlacement</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:97</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L97">src/presentation/policy/PresentationPolicy.ts:97</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/presentationsourceelement.html
+++ b/docs/interfaces/presentationsourceelement.html
@@ -99,7 +99,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationSourceElement.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationSourceElement.ts#L5">src/presentation/PresentationSourceElement.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></h4>

--- a/docs/interfaces/presentationstate.html
+++ b/docs/interfaces/presentationstate.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">box<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/presentationboxtype.html" class="tsd-signature-type">PresentationBoxType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:71</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L71">src/presentation/policy/PresentationPolicy.ts:71</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">content<wbr>Placement<span class="tsd-signature-symbol">:</span> <a href="presentationcontentplacement.html" class="tsd-signature-type">PresentationContentPlacement</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:42</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L42">src/presentation/policy/PresentationPolicy.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">focus<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>normalizedContentFocus<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">; </span>normalizedViewportFocus<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:73</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L73">src/presentation/policy/PresentationPolicy.ts:73</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">scale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:62</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L62">src/presentation/policy/PresentationPolicy.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">source<wbr>Aspect<wbr>Ratio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:53</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L53">src/presentation/policy/PresentationPolicy.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">source<wbr>Dimensions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:47</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L47">src/presentation/policy/PresentationPolicy.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewport<wbr>Aspect<wbr>Ratio<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L37">src/presentation/policy/PresentationPolicy.ts:37</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewport<wbr>Dimensions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L31">src/presentation/policy/PresentationPolicy.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/presentationupdateevent.html
+++ b/docs/interfaces/presentationupdateevent.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">drag<span class="tsd-signature-symbol">:</span> <a href="dragevent.html" class="tsd-signature-type">DragEvent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:92</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L92">src/presentation/policy/PresentationPolicy.ts:92</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">zoom<span class="tsd-signature-symbol">:</span> <a href="zoomevent.html" class="tsd-signature-type">ZoomEvent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:93</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L93">src/presentation/policy/PresentationPolicy.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/presentationviewportelement.html
+++ b/docs/interfaces/presentationviewportelement.html
@@ -101,7 +101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationViewportElement.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationViewportElement.ts#L5">src/presentation/PresentationViewportElement.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></h4>
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationViewportElement.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationViewportElement.ts#L9">src/presentation/PresentationViewportElement.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/presentation/PresentationViewportElement.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/PresentationViewportElement.ts#L7">src/presentation/PresentationViewportElement.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/promisedwebsocket.html
+++ b/docs/interfaces/promisedwebsocket.html
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/promisedwebsocket/PromisedWebSocket.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocket.ts#L5">src/promisedwebsocket/PromisedWebSocket.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/PromisedWebSocket.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocket.ts#L19">src/promisedwebsocket/PromisedWebSocket.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/PromisedWebSocket.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocket.ts#L12">src/promisedwebsocket/PromisedWebSocket.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/PromisedWebSocket.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocket.ts#L26">src/promisedwebsocket/PromisedWebSocket.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/promisedwebsocketfactory.html
+++ b/docs/interfaces/promisedwebsocketfactory.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/promisedwebsocket/PromisedWebSocketFactory.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/promisedwebsocket/PromisedWebSocketFactory.ts#L7">src/promisedwebsocket/PromisedWebSocketFactory.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/realtimecontroller.html
+++ b/docs/interfaces/realtimecontroller.html
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:107</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L107">src/realtimecontroller/RealtimeController.ts:107</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:140</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L140">src/realtimecontroller/RealtimeController.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L116">src/realtimecontroller/RealtimeController.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -222,7 +222,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:232</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L232">src/realtimecontroller/RealtimeController.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -250,7 +250,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:210</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L210">src/realtimecontroller/RealtimeController.ts:210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:92</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L92">src/realtimecontroller/RealtimeController.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L84">src/realtimecontroller/RealtimeController.ts:84</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -342,7 +342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L55">src/realtimecontroller/RealtimeController.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -401,7 +401,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:242</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L242">src/realtimecontroller/RealtimeController.ts:242</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -450,7 +450,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:186</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L186">src/realtimecontroller/RealtimeController.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -496,7 +496,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:130</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L130">src/realtimecontroller/RealtimeController.ts:130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -542,7 +542,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:219</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L219">src/realtimecontroller/RealtimeController.ts:219</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -591,7 +591,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:196</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L196">src/realtimecontroller/RealtimeController.ts:196</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -643,7 +643,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:97</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L97">src/realtimecontroller/RealtimeController.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -689,7 +689,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:150</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L150">src/realtimecontroller/RealtimeController.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -753,7 +753,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:125</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L125">src/realtimecontroller/RealtimeController.ts:125</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -779,7 +779,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:227</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L227">src/realtimecontroller/RealtimeController.ts:227</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -807,7 +807,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:203</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L203">src/realtimecontroller/RealtimeController.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -859,7 +859,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:164</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L164">src/realtimecontroller/RealtimeController.ts:164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -887,7 +887,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L68">src/realtimecontroller/RealtimeController.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -945,7 +945,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:247</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L247">src/realtimecontroller/RealtimeController.ts:247</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -991,7 +991,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:191</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L191">src/realtimecontroller/RealtimeController.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1037,7 +1037,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:135</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L135">src/realtimecontroller/RealtimeController.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1083,7 +1083,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeController.ts:102</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeController.ts#L102">src/realtimecontroller/RealtimeController.ts:102</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/realtimecontrollerfacade.html
+++ b/docs/interfaces/realtimecontrollerfacade.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L29">src/realtimecontroller/RealtimeControllerFacade.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L34">src/realtimecontroller/RealtimeControllerFacade.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L30">src/realtimecontroller/RealtimeControllerFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L48">src/realtimecontroller/RealtimeControllerFacade.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L26">src/realtimecontroller/RealtimeControllerFacade.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L8">src/realtimecontroller/RealtimeControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -279,7 +279,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L58">src/realtimecontroller/RealtimeControllerFacade.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -320,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L46">src/realtimecontroller/RealtimeControllerFacade.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L32">src/realtimecontroller/RealtimeControllerFacade.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -402,7 +402,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L53">src/realtimecontroller/RealtimeControllerFacade.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -446,7 +446,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L27">src/realtimecontroller/RealtimeControllerFacade.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -487,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L35">src/realtimecontroller/RealtimeControllerFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -543,7 +543,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L31">src/realtimecontroller/RealtimeControllerFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -560,7 +560,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:57</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L57">src/realtimecontroller/RealtimeControllerFacade.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -583,7 +583,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L45">src/realtimecontroller/RealtimeControllerFacade.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -606,7 +606,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L17">src/realtimecontroller/RealtimeControllerFacade.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -659,7 +659,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L59">src/realtimecontroller/RealtimeControllerFacade.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -700,7 +700,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L47">src/realtimecontroller/RealtimeControllerFacade.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -741,7 +741,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L33">src/realtimecontroller/RealtimeControllerFacade.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -782,7 +782,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/realtimecontroller/RealtimeControllerFacade.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/realtimecontroller/RealtimeControllerFacade.ts#L28">src/realtimecontroller/RealtimeControllerFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/reconnectcontroller.html
+++ b/docs/interfaces/reconnectcontroller.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L40">src/reconnectcontroller/ReconnectController.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L65">src/reconnectcontroller/ReconnectController.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L34">src/reconnectcontroller/ReconnectController.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L47">src/reconnectcontroller/ReconnectController.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L24">src/reconnectcontroller/ReconnectController.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L29">src/reconnectcontroller/ReconnectController.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L12">src/reconnectcontroller/ReconnectController.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L60">src/reconnectcontroller/ReconnectController.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -341,7 +341,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L70">src/reconnectcontroller/ReconnectController.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -369,7 +369,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L53">src/reconnectcontroller/ReconnectController.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -396,7 +396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/reconnectcontroller/ReconnectController.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/reconnectcontroller/ReconnectController.ts#L19">src/reconnectcontroller/ReconnectController.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/removableobserver.html
+++ b/docs/interfaces/removableobserver.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/removableobserver/RemovableObserver.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/removableobserver/RemovableObserver.ts#L11">src/removableobserver/RemovableObserver.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/resizeobserveradapter.html
+++ b/docs/interfaces/resizeobserveradapter.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/resizeobserveradapter/ResizeObserverAdapter.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/ResizeObserverAdapter.ts#L9">src/resizeobserveradapter/ResizeObserverAdapter.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/resizeobserveradapter/ResizeObserverAdapter.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/resizeobserveradapter/ResizeObserverAdapter.ts#L15">src/resizeobserveradapter/ResizeObserverAdapter.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/scheduler.html
+++ b/docs/interfaces/scheduler.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/Scheduler.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/Scheduler.ts#L11">src/scheduler/Scheduler.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/scheduler/Scheduler.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/scheduler/Scheduler.ts#L16">src/scheduler/Scheduler.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screenmessagedetail.html
+++ b/docs/interfaces/screenmessagedetail.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">attendee<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenmessagedetail/ScreenMessageDetail.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetail/ScreenMessageDetail.ts#L5">src/screenmessagedetail/ScreenMessageDetail.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/screenmessagedetailserialization.html
+++ b/docs/interfaces/screenmessagedetailserialization.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenmessagedetailserialization/ScreenMessageDetailSerialization.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenmessagedetailserialization/ScreenMessageDetailSerialization.ts#L13">src/screenmessagedetailserialization/ScreenMessageDetailSerialization.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screenobserver.html
+++ b/docs/interfaces/screenobserver.html
@@ -101,7 +101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/observer/ScreenObserver.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/observer/ScreenObserver.ts#L7">src/screenviewing/observer/ScreenObserver.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/observer/ScreenObserver.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/observer/ScreenObserver.ts#L8">src/screenviewing/observer/ScreenObserver.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/observer/ScreenObserver.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/observer/ScreenObserver.ts#L9">src/screenviewing/observer/ScreenObserver.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/screensharefacade.html
+++ b/docs/interfaces/screensharefacade.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L15">src/screensharefacade/ScreenShareFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L10">src/screensharefacade/ScreenShareFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L30">src/screensharefacade/ScreenShareFacade.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L41">src/screensharefacade/ScreenShareFacade.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L20">src/screensharefacade/ScreenShareFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L25">src/screensharefacade/ScreenShareFacade.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L35">src/screensharefacade/ScreenShareFacade.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacade.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacade.ts#L47">src/screensharefacade/ScreenShareFacade.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharefacadeobserver.html
+++ b/docs/interfaces/screensharefacadeobserver.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:6</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L6">src/screensharefacade/ScreenShareFacadeObserver.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L5">src/screensharefacade/ScreenShareFacadeObserver.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L9">src/screensharefacade/ScreenShareFacadeObserver.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L7">src/screensharefacade/ScreenShareFacadeObserver.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L8">src/screensharefacade/ScreenShareFacadeObserver.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -202,7 +202,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L10">src/screensharefacade/ScreenShareFacadeObserver.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharefacade/ScreenShareFacadeObserver.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharefacade/ScreenShareFacadeObserver.ts#L11">src/screensharefacade/ScreenShareFacadeObserver.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/screensharestreaming.html
+++ b/docs/interfaces/screensharestreaming.html
@@ -229,7 +229,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreaming.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreaming.ts#L33">src/screensharestreaming/ScreenShareStreaming.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreaming.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreaming.ts#L22">src/screensharestreaming/ScreenShareStreaming.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreaming.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreaming.ts#L10">src/screensharestreaming/ScreenShareStreaming.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -336,7 +336,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreaming.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreaming.ts#L16">src/screensharestreaming/ScreenShareStreaming.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreaming.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreaming.ts#L28">src/screensharestreaming/ScreenShareStreaming.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharestreamingfactory.html
+++ b/docs/interfaces/screensharestreamingfactory.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharestreaming/ScreenShareStreamingFactory.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharestreaming/ScreenShareStreamingFactory.ts#L8">src/screensharestreaming/ScreenShareStreamingFactory.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/screenshareviewfacade.html
+++ b/docs/interfaces/screenshareviewfacade.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L15">src/screenshareviewfacade/ScreenShareViewFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L10">src/screenshareviewfacade/ScreenShareViewFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L36">src/screenshareviewfacade/ScreenShareViewFacade.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L31">src/screenshareviewfacade/ScreenShareViewFacade.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L61">src/screenshareviewfacade/ScreenShareViewFacade.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L21">src/screenshareviewfacade/ScreenShareViewFacade.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -261,7 +261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L26">src/screenshareviewfacade/ScreenShareViewFacade.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -283,7 +283,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L66">src/screenshareviewfacade/ScreenShareViewFacade.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L51">src/screenshareviewfacade/ScreenShareViewFacade.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -339,7 +339,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L41">src/screenshareviewfacade/ScreenShareViewFacade.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L46">src/screenshareviewfacade/ScreenShareViewFacade.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -395,7 +395,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenshareviewfacade/ScreenShareViewFacade.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenshareviewfacade/ScreenShareViewFacade.ts#L56">src/screenshareviewfacade/ScreenShareViewFacade.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingmessage.html
+++ b/docs/interfaces/screensharingmessage.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Blob</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessage.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessage.ts#L20">src/screensharingmessage/ScreenSharingMessage.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">detail<span class="tsd-signature-symbol">:</span> <a href="screenmessagedetail.html" class="tsd-signature-type">ScreenMessageDetail</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessage.ts:30</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessage.ts#L30">src/screensharingmessage/ScreenSharingMessage.ts:30</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">flags<span class="tsd-signature-symbol">:</span> <a href="../enums/screensharingmessageflag.html" class="tsd-signature-type">ScreenSharingMessageFlag</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessage.ts:25</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessage.ts#L25">src/screensharingmessage/ScreenSharingMessage.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/screensharingmessagetype.html" class="tsd-signature-type">ScreenSharingMessageType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingmessage/ScreenSharingMessage.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessage/ScreenSharingMessage.ts#L15">src/screensharingmessage/ScreenSharingMessage.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingmessageflagserialization.html
+++ b/docs/interfaces/screensharingmessageflagserialization.html
@@ -106,7 +106,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts#L19">src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts#L12">src/screensharingmessageserialization/ScreenSharingMessageFlagSerialization.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingmessageserialization.html
+++ b/docs/interfaces/screensharingmessageserialization.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts#L22">src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts#L15">src/screensharingmessageserialization/ScreenSharingMessageSerialization.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingmessagetypeserialization.html
+++ b/docs/interfaces/screensharingmessagetypeserialization.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts#L20">src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts#L15">src/screensharingmessageserialization/ScreenSharingMessageTypeSerialization.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingsession.html
+++ b/docs/interfaces/screensharingsession.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L17">src/screensharingsession/ScreenSharingSession.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L49">src/screensharingsession/ScreenSharingSession.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L10">src/screensharingsession/ScreenSharingSession.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L32">src/screensharingsession/ScreenSharingSession.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L43">src/screensharingsession/ScreenSharingSession.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L22">src/screensharingsession/ScreenSharingSession.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L27">src/screensharingsession/ScreenSharingSession.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSession.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSession.ts#L37">src/screensharingsession/ScreenSharingSession.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensharingsessionfactory.html
+++ b/docs/interfaces/screensharingsessionfactory.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionFactory.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionFactory.ts#L7">src/screensharingsession/ScreenSharingSessionFactory.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/screensharingsessionobserver.html
+++ b/docs/interfaces/screensharingsessionobserver.html
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L8">src/screensharingsession/ScreenSharingSessionObserver.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L31">src/screensharingsession/ScreenSharingSessionObserver.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L25">src/screensharingsession/ScreenSharingSessionObserver.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L7">src/screensharingsession/ScreenSharingSessionObserver.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -219,7 +219,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L16">src/screensharingsession/ScreenSharingSessionObserver.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -236,7 +236,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L9">src/screensharingsession/ScreenSharingSessionObserver.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L10">src/screensharingsession/ScreenSharingSessionObserver.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L13">src/screensharingsession/ScreenSharingSessionObserver.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -287,7 +287,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L12">src/screensharingsession/ScreenSharingSessionObserver.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L11">src/screensharingsession/ScreenSharingSessionObserver.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L18">src/screensharingsession/ScreenSharingSessionObserver.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -344,7 +344,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L14">src/screensharingsession/ScreenSharingSessionObserver.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L15">src/screensharingsession/ScreenSharingSessionObserver.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L17">src/screensharingsession/ScreenSharingSessionObserver.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -395,7 +395,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensharingsession/ScreenSharingSessionObserver.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionObserver.ts#L19">src/screensharingsession/ScreenSharingSessionObserver.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/screensharingsessionoptions.html
+++ b/docs/interfaces/screensharingsessionoptions.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">bit<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionOptions.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionOptions.ts#L5">src/screensharingsession/ScreenSharingSessionOptions.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">reconnect<wbr>Retry<wbr>Limit<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screensharingsession/ScreenSharingSessionOptions.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensharingsession/ScreenSharingSessionOptions.ts#L6">src/screensharingsession/ScreenSharingSessionOptions.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/screensignalingsession.html
+++ b/docs/interfaces/screensignalingsession.html
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSession.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSession.ts#L15">src/screensignalingsession/ScreenSignalingSession.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSession.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSession.ts#L8">src/screensignalingsession/ScreenSignalingSession.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screensignalingsessionfactory.html
+++ b/docs/interfaces/screensignalingsessionfactory.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screensignalingsession/ScreenSignalingSessionFactory.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screensignalingsession/ScreenSignalingSessionFactory.ts#L7">src/screensignalingsession/ScreenSignalingSessionFactory.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/screenviewing.html
+++ b/docs/interfaces/screenviewing.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L16">src/screenviewing/ScreenViewing.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L11">src/screenviewing/ScreenViewing.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:37</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L37">src/screenviewing/ScreenViewing.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L32">src/screenviewing/ScreenViewing.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L64">src/screenviewing/ScreenViewing.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L22">src/screenviewing/ScreenViewing.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L27">src/screenviewing/ScreenViewing.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -292,7 +292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L70">src/screenviewing/ScreenViewing.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -322,7 +322,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L53">src/screenviewing/ScreenViewing.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -352,7 +352,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L42">src/screenviewing/ScreenViewing.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -380,7 +380,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:47</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L47">src/screenviewing/ScreenViewing.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -408,7 +408,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/ScreenViewing.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/ScreenViewing.ts#L58">src/screenviewing/ScreenViewing.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screenviewingcomponentcontext.html
+++ b/docs/interfaces/screenviewingcomponentcontext.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Renderer<span class="tsd-signature-symbol">:</span> <a href="screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:32</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L32">src/screenviewing/context/ScreenViewingComponentContext.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Source<span class="tsd-signature-symbol">:</span> <a href="screenviewingdeltasource.html" class="tsd-signature-type">ScreenViewingDeltaSource</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:33</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L33">src/screenviewing/context/ScreenViewingComponentContext.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Decoder<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../classes/defaultjpegdecodercontroller.html" class="tsd-signature-type">DefaultJPEGDecoderController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:34</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L34">src/screenviewing/context/ScreenViewingComponentContext.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Dispatcher<span class="tsd-signature-symbol">:</span> <a href="screenviewingsessionobserver.html" class="tsd-signature-type">ScreenViewingSessionObserver</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:35</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L35">src/screenviewing/context/ScreenViewingComponentContext.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Handler<span class="tsd-signature-symbol">:</span> <a href="screenviewingmessagehandler.html" class="tsd-signature-type">ScreenViewingMessageHandler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:36</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L36">src/screenviewing/context/ScreenViewingComponentContext.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="signalingsession.html" class="tsd-signature-type">SignalingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:37</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L37">src/screenviewing/context/ScreenViewingComponentContext.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewer<span class="tsd-signature-symbol">:</span> <a href="screenviewingviewer.html" class="tsd-signature-type">ScreenViewingViewer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:38</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L38">src/screenviewing/context/ScreenViewingComponentContext.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewing<wbr>Session<span class="tsd-signature-symbol">:</span> <a href="screenviewingsession.html" class="tsd-signature-type">ScreenViewingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:31</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L31">src/screenviewing/context/ScreenViewingComponentContext.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/screenviewingcomponentproviders.html
+++ b/docs/interfaces/screenviewingcomponentproviders.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Renderer<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>deltaRenderer<span class="tsd-signature-symbol">: </span><a href="screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingdeltarenderer.html" class="tsd-signature-type">ScreenViewingDeltaRenderer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L15">src/screenviewing/context/ScreenViewingComponentContext.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">delta<wbr>Source<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>deltaSource<span class="tsd-signature-symbol">: </span><a href="screenviewingdeltasource.html" class="tsd-signature-type">ScreenViewingDeltaSource</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingdeltasource.html" class="tsd-signature-type">ScreenViewingDeltaSource</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:16</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L16">src/screenviewing/context/ScreenViewingComponentContext.ts:16</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Decoder<wbr>Controller<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>jpegDecoderController<span class="tsd-signature-symbol">: </span><a href="../classes/defaultjpegdecodercontroller.html" class="tsd-signature-type">DefaultJPEGDecoderController</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="../classes/defaultjpegdecodercontroller.html" class="tsd-signature-type">DefaultJPEGDecoderController</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:17</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L17">src/screenviewing/context/ScreenViewingComponentContext.ts:17</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Dispatcher<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>messageDispatcher<span class="tsd-signature-symbol">: </span><a href="screenviewingsessionobserver.html" class="tsd-signature-type">ScreenViewingSessionObserver</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingsessionobserver.html" class="tsd-signature-type">ScreenViewingSessionObserver</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:20</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L20">src/screenviewing/context/ScreenViewingComponentContext.ts:20</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">message<wbr>Handler<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>messageHandler<span class="tsd-signature-symbol">: </span><a href="screenviewingmessagehandler.html" class="tsd-signature-type">ScreenViewingMessageHandler</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingmessagehandler.html" class="tsd-signature-type">ScreenViewingMessageHandler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:23</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L23">src/screenviewing/context/ScreenViewingComponentContext.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">session<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>screenViewingSession<span class="tsd-signature-symbol">: </span><a href="screenviewingsession.html" class="tsd-signature-type">ScreenViewingSession</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingsession.html" class="tsd-signature-type">ScreenViewingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L14">src/screenviewing/context/ScreenViewingComponentContext.ts:14</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">signaling<wbr>Session<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>signalingSession<span class="tsd-signature-symbol">: </span><a href="signalingsession.html" class="tsd-signature-type">SignalingSession</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="signalingsession.html" class="tsd-signature-type">SignalingSession</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:26</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L26">src/screenviewing/context/ScreenViewingComponentContext.ts:26</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -319,7 +319,7 @@
 					<div class="tsd-signature tsd-kind-icon">viewer<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>viewerProvider<span class="tsd-signature-symbol">: </span><a href="screenviewingviewer.html" class="tsd-signature-type">ScreenViewingViewer</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><a href="screenviewingviewer.html" class="tsd-signature-type">ScreenViewingViewer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/context/ScreenViewingComponentContext.ts:27</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/context/ScreenViewingComponentContext.ts#L27">src/screenviewing/context/ScreenViewingComponentContext.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/screenviewingdeltarenderer.html
+++ b/docs/interfaces/screenviewingdeltarenderer.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Rendered<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L13">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<wbr>Dimensions<span class="tsd-signature-symbol">:</span> <a href="screenviewingimagedimensions.html" class="tsd-signature-type">ScreenViewingImageDimensions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:14</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L14">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">jpeg<wbr>Data<wbr>Arrays<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L11">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">last<wbr>Resize<wbr>And<wbr>Sync<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:15</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L15">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Buffer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L9">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L21">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L34">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L36">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:36</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L30">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L26">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -286,7 +286,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:32</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L32">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -303,7 +303,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L28">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -326,7 +326,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L40">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -349,7 +349,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L38">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -372,7 +372,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:42</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts#L42">src/screenviewing/deltarenderer/ScreenViewingDeltaRenderer.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/screenviewingdeltasource.html
+++ b/docs/interfaces/screenviewingdeltasource.html
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">not<wbr>Shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/ScreenViewingDeltaSource.ts#L5">src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">pending<wbr>Dx<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/ScreenViewingDeltaSource.ts#L6">src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">pending<wbr>Dy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/ScreenViewingDeltaSource.ts#L7">src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/deltasource/ScreenViewingDeltaSource.ts#L9">src/screenviewing/deltasource/ScreenViewingDeltaSource.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/screenviewingimagedimensions.html
+++ b/docs/interfaces/screenviewingimagedimensions.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">edge<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:11</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L11">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">edge<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:10</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L10">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<wbr>Height<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:6</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L6">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<wbr>Width<wbr>Pixels<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:5</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L5">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">macro<wbr>Block<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:7</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L7">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:9</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L9">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">screen<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:8</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L8">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:13</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L13">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:12</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts#L12">src/screenviewing/messagehandler/ScreenViewingImageDimensions.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/screenviewingmessagehandler.html
+++ b/docs/interfaces/screenviewingmessagehandler.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L39">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L19">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L9">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L34">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L29">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L14">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts#L24">src/screenviewing/messagehandler/ScreenViewingMessageHandler.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screenviewingsession.html
+++ b/docs/interfaces/screenviewingsession.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSession.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSession.ts#L21">src/screenviewing/session/ScreenViewingSession.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSession.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSession.ts#L16">src/screenviewing/session/ScreenViewingSession.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -165,7 +165,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSession.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSession.ts#L26">src/screenviewing/session/ScreenViewingSession.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/session/ScreenViewingSession.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/session/ScreenViewingSession.ts#L11">src/screenviewing/session/ScreenViewingSession.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/screenviewingsessionobserver.html
+++ b/docs/interfaces/screenviewingsessionobserver.html
@@ -114,7 +114,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts#L13">src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts#L19">src/screenviewing/clientobserver/ScreenViewingSessionObserver.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/screenviewingviewer.html
+++ b/docs/interfaces/screenviewingviewer.html
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/viewer/ScreenViewingViewer.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/ScreenViewingViewer.ts#L9">src/screenviewing/viewer/ScreenViewingViewer.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/viewer/ScreenViewingViewer.ts:5</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/ScreenViewingViewer.ts#L5">src/screenviewing/viewer/ScreenViewingViewer.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/viewer/ScreenViewingViewer.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/viewer/ScreenViewingViewer.ts#L7">src/screenviewing/viewer/ScreenViewingViewer.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/sdp.html
+++ b/docs/interfaces/sdp.html
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L13">src/sdp/SDP.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:38</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L38">src/sdp/SDP.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L23">src/sdp/SDP.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L28">src/sdp/SDP.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -218,7 +218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L18">src/sdp/SDP.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L73">src/sdp/SDP.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:63</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L63">src/sdp/SDP.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L68">src/sdp/SDP.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:53</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L53">src/sdp/SDP.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -343,7 +343,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L33">src/sdp/SDP.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L58">src/sdp/SDP.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L43">src/sdp/SDP.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sdp/SDP.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L48">src/sdp/SDP.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sessionstatecontroller.html
+++ b/docs/interfaces/sessionstatecontroller.html
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/SessionStateController.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateController.ts#L21">src/sessionstatecontroller/SessionStateController.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/sessionstatecontroller/SessionStateController.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sessionstatecontroller/SessionStateController.ts#L29">src/sessionstatecontroller/SessionStateController.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/signalingclient.html
+++ b/docs/interfaces/signalingclient.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L89">src/signalingclient/SignalingClient.ts:89</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:58</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L58">src/signalingclient/SignalingClient.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L70">src/signalingclient/SignalingClient.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L96">src/signalingclient/SignalingClient.ts:96</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:43</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L43">src/signalingclient/SignalingClient.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:108</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L108">src/signalingclient/SignalingClient.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L51">src/signalingclient/SignalingClient.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -327,7 +327,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:103</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L103">src/signalingclient/SignalingClient.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -350,7 +350,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L23">src/signalingclient/SignalingClient.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -381,7 +381,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L30">src/signalingclient/SignalingClient.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -412,7 +412,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:113</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L113">src/signalingclient/SignalingClient.ts:113</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -440,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:75</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L75">src/signalingclient/SignalingClient.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -468,7 +468,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L80">src/signalingclient/SignalingClient.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -496,7 +496,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclient/SignalingClient.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclient/SignalingClient.ts#L65">src/signalingclient/SignalingClient.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/signalingclientobserver.html
+++ b/docs/interfaces/signalingclientobserver.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/signalingclientobserver/SignalingClientObserver.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/signalingclientobserver/SignalingClientObserver.ts#L15">src/signalingclientobserver/SignalingClientObserver.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/signalingsession.html
+++ b/docs/interfaces/signalingsession.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/SignalingSession.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/SignalingSession.ts#L9">src/screenviewing/signalingsession/SignalingSession.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/SignalingSession.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/SignalingSession.ts#L8">src/screenviewing/signalingsession/SignalingSession.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/SignalingSession.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/SignalingSession.ts#L10">src/screenviewing/signalingsession/SignalingSession.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/screenviewing/signalingsession/SignalingSession.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/screenviewing/signalingsession/SignalingSession.ts#L11">src/screenviewing/signalingsession/SignalingSession.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/statscollector.html
+++ b/docs/interfaces/statscollector.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L34">src/statscollector/StatsCollector.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L44">src/statscollector/StatsCollector.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L59">src/statscollector/StatsCollector.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L54">src/statscollector/StatsCollector.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L49">src/statscollector/StatsCollector.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -289,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L39">src/statscollector/StatsCollector.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L20">src/statscollector/StatsCollector.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/statscollector/StatsCollector.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/StatsCollector.ts#L29">src/statscollector/StatsCollector.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/task.html
+++ b/docs/interfaces/task.html
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/Task.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/Task.ts#L21">src/task/Task.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/Task.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/Task.ts#L12">src/task/Task.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/Task.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/Task.ts#L29">src/task/Task.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/task/Task.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/Task.ts#L34">src/task/Task.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/taskcanceler.html
+++ b/docs/interfaces/taskcanceler.html
@@ -99,7 +99,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/taskcanceler/TaskCanceler.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/taskcanceler/TaskCanceler.ts#L11">src/taskcanceler/TaskCanceler.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/transceivercontroller.html
+++ b/docs/interfaces/transceivercontroller.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L30">src/transceivercontroller/TransceiverController.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:73</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L73">src/transceivercontroller/TransceiverController.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:78</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L78">src/transceivercontroller/TransceiverController.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L50">src/transceivercontroller/TransceiverController.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L20">src/transceivercontroller/TransceiverController.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -243,7 +243,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L45">src/transceivercontroller/TransceiverController.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -271,7 +271,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:83</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L83">src/transceivercontroller/TransceiverController.ts:83</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L15">src/transceivercontroller/TransceiverController.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -327,7 +327,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L55">src/transceivercontroller/TransceiverController.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -355,7 +355,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:68</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L68">src/transceivercontroller/TransceiverController.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -383,7 +383,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L40">src/transceivercontroller/TransceiverController.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -405,7 +405,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L35">src/transceivercontroller/TransceiverController.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -433,7 +433,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L60">src/transceivercontroller/TransceiverController.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -464,7 +464,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/transceivercontroller/TransceiverController.ts:25</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/TransceiverController.ts#L25">src/transceivercontroller/TransceiverController.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videocaptureandencodeparameter.html
+++ b/docs/interfaces/videocaptureandencodeparameter.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L31">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L26">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L21">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L16">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -207,7 +207,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L36">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L46">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L41">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts#L11">src/videocaptureandencodeparameter/VideoCaptureAndEncodeParameter.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videodownlinkbandwidthpolicy.html
+++ b/docs/interfaces/videodownlinkbandwidthpolicy.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts#L39">src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:27</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts#L27">src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts#L17">src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts#L22">src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts#L33">src/videodownlinkbandwidthpolicy/VideoDownlinkBandwidthPolicy.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videoelementfactory.html
+++ b/docs/interfaces/videoelementfactory.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videoelementfactory/VideoElementFactory.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videoelementfactory/VideoElementFactory.ts#L11">src/videoelementfactory/VideoElementFactory.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videostreamidset.html
+++ b/docs/interfaces/videostreamidset.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L11">src/videostreamidset/VideoStreamIdSet.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L16">src/videostreamidset/VideoStreamIdSet.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L41">src/videostreamidset/VideoStreamIdSet.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -192,7 +192,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L21">src/videostreamidset/VideoStreamIdSet.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:26</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L26">src/videostreamidset/VideoStreamIdSet.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:36</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L36">src/videostreamidset/VideoStreamIdSet.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:46</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L46">src/videostreamidset/VideoStreamIdSet.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -298,7 +298,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:31</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L31">src/videostreamidset/VideoStreamIdSet.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -320,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamidset/VideoStreamIdSet.ts:51</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamidset/VideoStreamIdSet.ts#L51">src/videostreamidset/VideoStreamIdSet.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videostreamindex.html
+++ b/docs/interfaces/videostreamindex.html
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:89</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L89">src/videostreamindex/VideoStreamIndex.ts:89</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L39">src/videostreamindex/VideoStreamIndex.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,7 +185,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L44">src/videostreamindex/VideoStreamIndex.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:79</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L79">src/videostreamindex/VideoStreamIndex.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:69</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L69">src/videostreamindex/VideoStreamIndex.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -269,7 +269,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:74</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L74">src/videostreamindex/VideoStreamIndex.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -297,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:84</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L84">src/videostreamindex/VideoStreamIndex.ts:84</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L59">src/videostreamindex/VideoStreamIndex.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -353,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L34">src/videostreamindex/VideoStreamIndex.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -381,7 +381,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L19">src/videostreamindex/VideoStreamIndex.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L29">src/videostreamindex/VideoStreamIndex.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:109</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L109">src/videostreamindex/VideoStreamIndex.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:114</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L114">src/videostreamindex/VideoStreamIndex.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -487,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:64</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L64">src/videostreamindex/VideoStreamIndex.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -515,7 +515,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:119</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L119">src/videostreamindex/VideoStreamIndex.ts:119</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -537,7 +537,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:99</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L99">src/videostreamindex/VideoStreamIndex.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -565,7 +565,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:94</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L94">src/videostreamindex/VideoStreamIndex.ts:94</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -593,7 +593,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L49">src/videostreamindex/VideoStreamIndex.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -630,7 +630,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:104</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L104">src/videostreamindex/VideoStreamIndex.ts:104</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -652,7 +652,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videostreamindex/VideoStreamIndex.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/VideoStreamIndex.ts#L24">src/videostreamindex/VideoStreamIndex.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videotile.html
+++ b/docs/interfaces/videotile.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L45">src/videotile/VideoTile.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -154,7 +154,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L29">src/videotile/VideoTile.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:78</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L78">src/videotile/VideoTile.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:72</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L72">src/videotile/VideoTile.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L14">src/videotile/VideoTile.ts:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:61</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L61">src/videotile/VideoTile.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L50">src/videotile/VideoTile.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L19">src/videotile/VideoTile.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L24">src/videotile/VideoTile.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +356,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:66</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L66">src/videotile/VideoTile.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotile/VideoTile.ts:56</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/VideoTile.ts#L56">src/videotile/VideoTile.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videotilecontroller.html
+++ b/docs/interfaces/videotilecontroller.html
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:85</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L85">src/videotilecontroller/VideoTileController.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -157,7 +157,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L19">src/videotilecontroller/VideoTileController.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:121</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L121">src/videotilecontroller/VideoTileController.ts:121</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -218,7 +218,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:75</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L75">src/videotilecontroller/VideoTileController.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:80</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L80">src/videotilecontroller/VideoTileController.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:50</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L50">src/videotilecontroller/VideoTileController.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:65</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L65">src/videotilecontroller/VideoTileController.ts:65</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:70</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L70">src/videotilecontroller/VideoTileController.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -340,7 +340,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:40</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L40">src/videotilecontroller/VideoTileController.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -362,7 +362,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:116</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L116">src/videotilecontroller/VideoTileController.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -390,7 +390,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:111</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L111">src/videotilecontroller/VideoTileController.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -412,7 +412,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:55</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L55">src/videotilecontroller/VideoTileController.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -440,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:101</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L101">src/videotilecontroller/VideoTileController.ts:101</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:45</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L45">src/videotilecontroller/VideoTileController.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:90</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L90">src/videotilecontroller/VideoTileController.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -512,7 +512,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:96</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L96">src/videotilecontroller/VideoTileController.ts:96</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -541,7 +541,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:106</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L106">src/videotilecontroller/VideoTileController.ts:106</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -569,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:30</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L30">src/videotilecontroller/VideoTileController.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -592,7 +592,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:35</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L35">src/videotilecontroller/VideoTileController.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -614,7 +614,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:24</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L24">src/videotilecontroller/VideoTileController.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -642,7 +642,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileController.ts:60</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileController.ts#L60">src/videotilecontroller/VideoTileController.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videotilecontrollerfacade.html
+++ b/docs/interfaces/videotilecontrollerfacade.html
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:19</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L19">src/videotilecontroller/VideoTileControllerFacade.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a></h4>
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:7</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L7">src/videotilecontroller/VideoTileControllerFacade.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L23">src/videotilecontroller/VideoTileControllerFacade.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L17">src/videotilecontroller/VideoTileControllerFacade.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:18</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L18">src/videotilecontroller/VideoTileControllerFacade.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:13</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L13">src/videotilecontroller/VideoTileControllerFacade.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:16</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L16">src/videotilecontroller/VideoTileControllerFacade.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:11</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L11">src/videotilecontroller/VideoTileControllerFacade.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:14</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L14">src/videotilecontroller/VideoTileControllerFacade.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:22</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L22">src/videotilecontroller/VideoTileControllerFacade.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:12</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L12">src/videotilecontroller/VideoTileControllerFacade.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:20</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L20">src/videotilecontroller/VideoTileControllerFacade.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:21</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L21">src/videotilecontroller/VideoTileControllerFacade.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -380,7 +380,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:9</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L9">src/videotilecontroller/VideoTileControllerFacade.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:10</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L10">src/videotilecontroller/VideoTileControllerFacade.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -414,7 +414,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:8</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L8">src/videotilecontroller/VideoTileControllerFacade.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -437,7 +437,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilecontroller/VideoTileControllerFacade.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/VideoTileControllerFacade.ts#L15">src/videotilecontroller/VideoTileControllerFacade.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/videotilefactory.html
+++ b/docs/interfaces/videotilefactory.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videotilefactory/VideoTileFactory.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilefactory/VideoTileFactory.ts#L15">src/videotilefactory/VideoTileFactory.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/videouplinkbandwidthpolicy.html
+++ b/docs/interfaces/videouplinkbandwidthpolicy.html
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:29</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L29">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:49</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L49">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:59</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L59">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:34</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L34">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:44</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L44">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -240,7 +240,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:39</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L39">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -268,7 +268,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:54</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L54">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:54</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:17</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L17">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -325,7 +325,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts#L23">src/videouplinkbandwidthpolicy/VideoUplinkBandwidthPolicy.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/websocketadapter.html
+++ b/docs/interfaces/websocketadapter.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:41</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L41">src/websocketadapter/WebSocketAdapter.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -156,7 +156,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:28</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L28">src/websocketadapter/WebSocketAdapter.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:15</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L15">src/websocketadapter/WebSocketAdapter.ts:15</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:33</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L33">src/websocketadapter/WebSocketAdapter.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -248,7 +248,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:48</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L48">src/websocketadapter/WebSocketAdapter.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in src/websocketadapter/WebSocketAdapter.ts:23</li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/websocketadapter/WebSocketAdapter.ts#L23">src/websocketadapter/WebSocketAdapter.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/zoomevent.html
+++ b/docs/interfaces/zoomevent.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">absolute<wbr>Factor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:88</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L88">src/presentation/policy/PresentationPolicy.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">relative<wbr>Factor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:87</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L87">src/presentation/policy/PresentationPolicy.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/zoomtype.html" class="tsd-signature-type">ZoomType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in src/presentation/policy/PresentationPolicy.ts:86</li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/presentation/policy/PresentationPolicy.ts#L86">src/presentation/policy/PresentationPolicy.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:publish": "npm run build && npm run lint && npm run check && npm run doc && npm run test:retry",
     "postbuild:publish": "script/postbuild",
     "predoc": "rm -rf docs && node script/build-guides.js",
-    "doc": "node node_modules/typedoc/bin/typedoc --options typedoc.json --gitRemote https://github.com/aws/amazon-chime-sdk-js",
+    "doc": "script/generate-docs",
     "postdoc": "node script/update-typedoc-link.js",
     "test": "npm run test:fast",
     "test:fast": "cross-env TS_NODE_CACHE=false nyc mocha -rv ts-node/register \"test/**/*.test.ts\"",

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+# We prefer 'upstream' because a fork will likely have both.
+# We fall back to 'origin' to support Travis.
+compare_to = ['upstream', 'origin']
+
+intersection = compare_to & `git remote`.split
+
+if intersection.empty?
+  STDERR.puts "Cannot generate docs: unable to determine remote. Create a remote named 'upstream' or 'origin'."
+  exit 1
+end
+
+remote = intersection[0]
+branch = 'master'
+
+STDERR.puts "Generating docs against #{remote}/#{branch}."
+
+`node node_modules/typedoc/bin/typedoc --options typedoc.json --gitRemote #{remote} --gitRevision #{branch}`


### PR DESCRIPTION
**Issue #:**

None.

**Description of changes:**

This commit breaks out doc generation into a Ruby script so we can
determine the Git remote at runtime. This is necessary to support forks
(which need to use 'upstream') and Travis (which uses 'origin').

We also explicitly pass `master` as the revision against which to link, which makes our doc links more stable.

This change convinces TypeDoc that this is a GitHub repo, which brings
back the "Defined in" links that I broke in my last commit.

**Testing**

`npm run build:release` passes locally. Changes are doc-only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
