### PR TITLE
Create log stream before logging begins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add a Travis check to make sure version update
 - Add metrics for Selenium initialization metrics for integration tests
+- Create log stream before logging begins
 
 ### Changed
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update Travis config to improve PR build speed
-- Disable saucelab capabilities
+- Disable configs in saucelab capabilities
 - Use credentials sent via signaling connection JOIN_ACK to improve audio-video startup time.
 - [Demo] Adjust demo css to prevent unecessary scrollbars on windows and stretching in video grid
 - Update dependencies to TypeScript 4, `ts-loader`, and modern linting

--- a/demos/browser/app/meeting/meeting.ts
+++ b/demos/browser/app/meeting/meeting.ts
@@ -644,11 +644,30 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver 
     }
   }
 
+  async createLogStream(configuration: MeetingSessionConfiguration): Promise<void> {
+    const body = JSON.stringify({
+      meetingId: configuration.meetingId,
+      attendeeId: configuration.credentials.attendeeId,
+    });
+    try {
+      const response = await fetch(`${DemoMeetingApp.BASE_URL}create_log_stream`, {
+        method: 'POST',
+        body
+      });
+      if (response.status === 200) {
+        console.log('Log stream created');
+      }
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
     let logger: Logger;
     if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
       logger = new ConsoleLogger('SDK', LogLevel.INFO);
     } else {
+      await this.createLogStream(configuration);
       logger = new MeetingSessionPOSTLogger(
         'SDK',
         configuration,

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -666,6 +666,24 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     }
   }
 
+  async createLogStream(configuration: MeetingSessionConfiguration): Promise<void> {
+    const body = JSON.stringify({
+      meetingId: configuration.meetingId,
+      attendeeId: configuration.credentials.attendeeId,
+    });
+    try {
+      const response = await fetch(`${DemoMeetingApp.BASE_URL}create_log_stream`, {
+        method: 'POST',
+        body
+      });
+      if (response.status === 200) {
+        console.log('Log stream created');
+      }
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
     let logger: Logger;
     const logLevel = LogLevel.INFO;
@@ -673,6 +691,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
       logger = consoleLogger;
     } else {
+      await this.createLogStream(configuration);
       logger = new MultiLogger(
         consoleLogger,
         new MeetingSessionPOSTLogger(

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -59,6 +59,7 @@ Resources:
             Resource: '*'
       Roles:
         - Ref: ChimeSdkBrowserLogsLambdaRole
+        - Ref: ChimeSdkBrowserCreateLogStreamLambdaRole
   Meetings:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -174,6 +175,17 @@ Resources:
           Type: Api
           Properties:
             Path: /logs
+            Method: POST
+  ChimeSdkBrowserCreateLogStreamLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.create_log_stream
+      CodeUri: src/
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /create_log_stream
             Method: POST
   ChimeNotificationsQueuePolicy:
     Type: AWS::SQS::QueuePolicy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.4';
+    return '1.19.5';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
We recently observed ResourceAlreadyExistsException on Log stream - we already have a mechanism to check if a log stream exists - and if it exists we re-use that or else we create a new log stream. 
A race condition is taking place, two or more processes reach the createLogStream() in ensureLogStream at the same time. While one gets the priority and creates a logStream, the other process fails to create a LogStream with the same logStream name. So this process fails for the first time and is retried at the CW end. Upon retry the previously failed process executes without error on the LogStream returned by ensureLogStream - thus there is no data loss but we see ERROR entry due to the failed execution.

**Description of changes:**
We are creating a log stream at the beginning of the meeting itself. So there should be no race condition when multiple process start writing to a log.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Verified by running the serverless demo app successfully that create_log_stream endpoint is hit before the logs endpoint in the network tab
Tested by removing the endpoint logs and running the serverless demo app to see that the application is creating a new Log Stream in the cloudwatch.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
