### PR TITLE
Add sendEvent observer for client analytics

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -506,8 +506,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         await this.endMeeting();
         this.leave();
         (buttonMeetingEnd as HTMLButtonElement).disabled = false;
-        // @ts-ignore
-        window.location = window.location.pathname;
       });
     });
 
@@ -517,8 +515,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         (buttonMeetingLeave as HTMLButtonElement).disabled = true;
         this.leave();
         (buttonMeetingLeave as HTMLButtonElement).disabled = false;
-        // @ts-ignore
-        window.location = window.location.pathname;
       });
     });
   }
@@ -669,6 +665,12 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
       (document.getElementById('video-downlink-bandwidth') as HTMLSpanElement).innerText =
         'Available Downlink Bandwidth: Unknown';
     }
+  }
+
+  eventDidReceive(name: string, attributes: { [attributeName: string]: string | string [] }): void {
+    // TODO: Implement this observer function
+    console.log("Event name: " + name);
+    console.log("Attributes: " + JSON.stringify(attributes));
   }
 
   async initializeMeetingSession(configuration: MeetingSessionConfiguration): Promise<void> {
@@ -1379,6 +1381,11 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     this.log(`session stopped from ${JSON.stringify(sessionStatus)}`);
     if (sessionStatus.statusCode() === MeetingSessionStatusCode.AudioCallEnded) {
       this.log(`meeting ended`);
+      // @ts-ignore
+      window.location = window.location.pathname;
+    } else if (sessionStatus.statusCode() === MeetingSessionStatusCode.Left) {
+      this.log('left meeting');
+
       // @ts-ignore
       window.location = window.location.pathname;
     }

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4877,9 +4877,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.760.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.760.0.tgz",
-      "integrity": "sha512-u1DhOXbN8/yLRaJ2sjY2ZmjiwEPl4KuGKafaM4oJXzEyOPo5Kwtvau62FgqeRSBVxkw9sipuA5sfYxdwLbq6vg==",
+      "version": "2.761.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.761.0.tgz",
+      "integrity": "sha512-mSzdiqlnruFlJYrQVWPMyPQ8ynJe9P5QVD+edv8HFlYDQNOwpPCjlqI9kE1VE3cVcxkh0j2Q2kfLQa/pAY2w7Q==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.760.0",
+    "aws-sdk": "^2.761.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/src/audiovideocontroller/AudioVideoController.ts
+++ b/src/audiovideocontroller/AudioVideoController.ts
@@ -65,6 +65,18 @@ export default interface AudioVideoController extends AudioVideoControllerFacade
   resumeReceivingStream(streamId: number): void;
 
   /**
+   * Send an event related to the meeting along with attributes of the event
+   * @param name Name of the event
+   * @param attribute Map of attributes related to the environment
+   */
+  sendEvent(name: string, attribute: { [attributeName: string]: string | string[] }): void;
+
+  /**
+   * Get attributes of the meeting, OS, and device.
+   */
+  getAttributes(): { [attributeName: string]: string | string[] };
+
+  /**
    * Returns the session configuration for this audio-video controller.
    */
   readonly configuration: MeetingSessionConfiguration;

--- a/src/audiovideoobserver/AudioVideoObserver.ts
+++ b/src/audiovideoobserver/AudioVideoObserver.ts
@@ -107,4 +107,10 @@ export default interface AudioVideoObserver {
    * trigger a message to the user about the situation.
    */
   videoSendDidBecomeUnavailable?(): void;
+
+  /**
+   * Called when specific events occur during the meeting and includes attributes of the event. This can be used to
+   * create analytics around meeting metric.
+   */
+  eventDidReceive?(name: string, attributes: { [attributeName: string]: string | string[] }): void;
 }

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -667,6 +667,10 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
       }
       newDevice.groupId = this.getGroupIdFromDeviceId(kind, this.getDeviceIdStr(device));
     } catch (error) {
+      this.boundAudioVideoController.sendEvent(
+        'DeviceSetupFailed',
+        this.boundAudioVideoController.getAttributes()
+      );
       this.logger.error(
         `failed to get ${kind} device for constraints ${JSON.stringify(proposedConstraints)}: ${
           error.name

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -5,6 +5,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 
 import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
+import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
 import DeviceChangeObserver from '../../src/devicechangeobserver/DeviceChangeObserver';
 import DefaultDeviceController from '../../src/devicecontroller/DefaultDeviceController';
 import Device from '../../src/devicecontroller/Device';
@@ -427,12 +428,18 @@ describe('DefaultDeviceController', () => {
     });
 
     it('denies the permission by browser', async () => {
+      deviceController.bindToAudioVideoController(audioVideoController);
+      // @ts-ignore
+      audioVideoController.meetingSessionContext.browserBehavior = new DefaultBrowserBehavior();
       domMockBehavior.getUserMediaSucceeds = false;
       const permission = await deviceController.chooseVideoInputDevice(stringDeviceId);
       expect(permission).to.equal(DevicePermission.PermissionDeniedByBrowser);
     });
 
     it('denies the permission by user', async () => {
+      deviceController.bindToAudioVideoController(audioVideoController);
+      // @ts-ignore
+      audioVideoController.meetingSessionContext.browserBehavior = new DefaultBrowserBehavior();
       domMockBehavior.getUserMediaSucceeds = false;
       domMockBehavior.asyncWaitMs = 1500;
       const permission = await deviceController.chooseVideoInputDevice(stringDeviceId);
@@ -440,6 +447,9 @@ describe('DefaultDeviceController', () => {
     });
 
     it('cannot choose the device of an empty string ID', async () => {
+      deviceController.bindToAudioVideoController(audioVideoController);
+      // @ts-ignore
+      audioVideoController.meetingSessionContext.browserBehavior = new DefaultBrowserBehavior();
       const device: Device = '';
       const permission = await deviceController.chooseVideoInputDevice(device);
       expect(permission).to.equal(DevicePermission.PermissionDeniedByBrowser);
@@ -629,6 +639,9 @@ describe('DefaultDeviceController', () => {
     });
 
     it('cannot acquire a video input stream if the permission is denied by user', async () => {
+      deviceController.bindToAudioVideoController(audioVideoController);
+      // @ts-ignore
+      audioVideoController.meetingSessionContext.browserBehavior = new DefaultBrowserBehavior();
       // Choose the video input device.
       await deviceController.chooseVideoInputDevice(stringDeviceId);
       domMockBehavior.getUserMediaSucceeds = false;

--- a/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
+++ b/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
@@ -7,6 +7,8 @@ import AudioVideoController from '../../src/audiovideocontroller/AudioVideoContr
 import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import AudioVideoFacade from '../../src/audiovideofacade/AudioVideoFacade';
 import DefaultAudioVideoFacade from '../../src/audiovideofacade/DefaultAudioVideoFacade';
+import BrowserBehavior from '../../src/browserbehavior/BrowserBehavior';
+import DefaultBrowserBehavior from '../../src/browserbehavior/DefaultBrowserBehavior';
 import ContentShareController from '../../src/contentsharecontroller/ContentShareController';
 import ContentShareMediaStreamBroker from '../../src/contentsharecontroller/ContentShareMediaStreamBroker';
 import DefaultContentShareController from '../../src/contentsharecontroller/DefaultContentShareController';
@@ -157,6 +159,16 @@ describe('DefaultMeetingReadinessChecker', () => {
 
     getRTCPeerConnectionStats(_selector?: MediaStreamTrack): Promise<RTCStatsReport> {
       return !this.noRTCConnection ? new RTCPeerConnection().getStats() : null;
+    }
+
+    getAttributes(
+      browserBehavior: BrowserBehavior = new DefaultBrowserBehavior(),
+      configuration: MeetingSessionConfiguration = this.configuration
+    ): { [attributeName: string]: string | string[] } {
+      return {
+        browserName: browserBehavior.name(),
+        meetingId: configuration.meetingId,
+      };
     }
   }
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Send Event observer function should send the meeting event to the observer.

Also, refactored the demo app so that the window.location is changed in the audioVideoDidStop observer function

**Testing**
Mock certain conditions to send meeting events.

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? 
    1. Start a meeting. Verify that the 'ConnectionSucceeded' event is sent.  
    2. Leave or End the meeting. Verify that the 'MeetingEnded' event is sent. 
    3. Mock a error in meeting join tasks, and veriy that the MeetingEndedWithError event is sent
    4. Mock a connection error and verify that the 'ConnectionFailed' event is sent



3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
