### PR TITLE
Increase roster check time for sip test

### DIFF
--- a/integration/js/SipCallTest.js
+++ b/integration/js/SipCallTest.js
@@ -1,5 +1,5 @@
 const {OpenAppStep, JoinMeetingStep, AuthenticateUserStep, GetSipUriForCallStep} = require('./steps');
-const {UserJoinedMeetingCheck, UserAuthenticationCheck, RemoteAudioCheck, RosterCheck} = require('./checks');
+const {UserJoinedMeetingCheck, UserAuthenticationCheck, RemoteAudioCheck, RosterCheck, RosterCheckConfig} = require('./checks');
 const {AppPage} = require('./pages/AppPage');
 const {TestUtils} = require('./node_modules/kite-common');
 const SdkBaseTest = require('./utils/SdkBaseTest');
@@ -34,7 +34,7 @@ class SipCallTest extends SdkBaseTest {
     const sipCallClient = new SipCallClient(this.payload.sipTestAssetPath, this.payload.resultPath);
     const sipCall = sipCallClient.call(this.payload.voiceConnectorId, this.sipUri);
 
-    await test_window.runCommands(async () => await await RosterCheck.executeStep(this, session, 2));
+    await test_window.runCommands(async () => await await RosterCheck.executeStep(this, session, 2, new RosterCheckConfig(60, 500)));
     await test_window.runCommands(async () => await RemoteAudioCheck.executeStep(this, session, 'AUDIO_ON'));
 
     sipCallClient.end(sipCall);

--- a/integration/js/checks/RosterCheck.js
+++ b/integration/js/checks/RosterCheck.js
@@ -1,15 +1,18 @@
 const {KiteTestError, Status, TestUtils} = require('kite-common');
 const demo = require('../pages/AppPage');
 const AppTestStep = require('../utils/AppTestStep');
+const {RosterCheckConfig} = require('./RosterCheckConfig');
 
 class RosterCheck extends AppTestStep {
-  constructor(kiteBaseTest, sessionInfo, numberOfParticipant) {
+
+  constructor(kiteBaseTest, sessionInfo, numberOfParticipant, config) {
     super(kiteBaseTest, sessionInfo);
     this.numberOfParticipant = numberOfParticipant;
+    this.config = config;
   }
 
-  static async executeStep(KiteBaseTest, sessionInfo, numberOfParticipant) {
-    const step = new RosterCheck(KiteBaseTest, sessionInfo, numberOfParticipant);
+  static async executeStep(KiteBaseTest, sessionInfo, numberOfParticipant, config = new RosterCheckConfig()) {
+    const step = new RosterCheck(KiteBaseTest, sessionInfo, numberOfParticipant, config);
     await step.execute(KiteBaseTest);
   }
 
@@ -26,7 +29,7 @@ class RosterCheck extends AppTestStep {
   }
 
   async run() {
-    const rosterCheckPassed = await this.page.rosterCheck(this.numberOfParticipant);
+    const rosterCheckPassed = await this.page.rosterCheck(this.numberOfParticipant, this.config.checkCount, this.config.waitTimeMs);
     if (!rosterCheckPassed) {
       throw new KiteTestError(Status.FAILED, 'Participants are not present on the roster');
     }

--- a/integration/js/checks/RosterCheckConfig.js
+++ b/integration/js/checks/RosterCheckConfig.js
@@ -1,0 +1,9 @@
+
+class RosterCheckConfig {
+  constructor(checkCount = 10, waitTimeMs = 100){
+    this.checkCount = checkCount;
+    this.waitTimeMs = waitTimeMs;
+  }
+}
+
+module.exports = RosterCheckConfig;

--- a/integration/js/checks/index.js
+++ b/integration/js/checks/index.js
@@ -5,6 +5,7 @@ exports.UserAuthenticationCheck = require('./UserAuthenticationCheck');
 exports.RemoteAudioCheck = require('./RemoteAudioCheck');
 exports.MeetingJoinFailedCheck = require('./MeetingJoinFailedCheck');
 exports.RosterCheck = require('./RosterCheck');
+exports.RosterCheckConfig = require('./RosterCheckConfig');
 exports.ScreenViewingCheck = require('./ScreenViewingCheck');
 exports.ContentShareVideoCheck = require('./ContentShareVideoCheck');
 exports.DataMessageCheck = require('./DataMessageCheck');

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -279,20 +279,24 @@ class AppPage {
     return await this.driver.findElement(elements.failedMeetingFlow).isDisplayed();
   }
 
-  async rosterCheck(numberOfParticipants) {
+  async rosterCheck(numberOfParticipants, checkCount = 10, waitTimeMs = 100) {
     let i = 0;
-    let timeout = 10;
-    while (i < timeout) {
+    let start = performance.now();
+    while (i < checkCount) {
       try {
         const participantCountOnRoster = await this.getNumberOfParticipantsOnRoster();
         if (participantCountOnRoster === numberOfParticipants) {
+          let end = performance.now();
+          console.log("Roster check completed successfully in : %d secs", (start - end)/1000);
           return true;
         }
       } catch (err) {
       }
-      await TestUtils.waitAround(10);
+      await TestUtils.waitAround(waitTimeMs);
       i++;
     }
+    let end = performance.now();
+    console.log("Roster check failed in : %d secs", (start - end)/1000);
     return false;
   }
 


### PR DESCRIPTION
SIp test is failing because roster updates are not coming in time. Increasing the roster check duration.