### PR TITLE
Fix meeting readiness checker integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Maven installation script
 - Fix SIP integration test
 - Fixed v1 meeting bug related to bootstrap row class
+- Fix meeting readiness checker integration test
 
 ## [1.18.0] - 2020-09-22
 ### Added

--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
@@ -49,7 +49,7 @@
         </select>
       </div>
       <div class="row mt-3">
-        <button id="authenticate" class="btn btn-lg btn-primary btn-block" type="submit">Check my device</button>
+        <button id="authenticate" class="btn btn-lg btn-primary btn-block" type="submit" disabled>Check my device</button>
       </div>
       <div class="row mt-3">
         <p>This page will check whether your devices are able to reach the Amazon Chime SDK services.</p>

--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -100,6 +100,8 @@ export class DemoMeetingApp {
         try {
           chimeMeetingId = await this.authenticate();
           this.log(`chimeMeetingId: ${chimeMeetingId}`);
+          const button = document.getElementById("authenticate") as HTMLButtonElement;
+          button.disabled = false;
         } catch (error) {
           return error;
         }

--- a/integration/js/MeetingReadinessCheckerRunAllTest.js
+++ b/integration/js/MeetingReadinessCheckerRunAllTest.js
@@ -1,4 +1,4 @@
-const {OpenMeetingReadinessCheckerAppStep, StartMeetingReadinessCheckerStep, WaitForContentShareTestToBeReady, StartContentShareConnectivityCheckStep} = require('./steps');
+const {OpenMeetingReadinessCheckerAppStep, StartMeetingReadinessCheckerStep, WaitForContentShareTestToBeReady, WaitForStartMeetingReadinessCheckerButtonToBeEnabled, StartContentShareConnectivityCheckStep} = require('./steps');
 const {MeetingReadinessCheckerNetworkTcpCheck, MeetingReadinessCheckerAudioOutputCheck, MeetingReadinessCheckerVideoConnectivityCheck, MeetingReadinessCheckerContentShareConnectivityCheck, MeetingReadinessCheckerAudioConnectivityCheck, MeetingReadinessCheckerNetworkUdpCheck} = require('./checks');
 const {MeetingReadinessCheckerPage} = require('./pages/MeetingReadinessCheckerPage');
 const {TestUtils} = require('./node_modules/kite-common');
@@ -17,6 +17,7 @@ class MeetingReadinessCheckerRunAllTest extends SdkBaseTest {
   async runIntegrationTest() {
     const session = this.seleniumSessions[0];
     await OpenMeetingReadinessCheckerAppStep.executeStep(this, session);
+    await WaitForStartMeetingReadinessCheckerButtonToBeEnabled.executeStep(this, session);
     await StartMeetingReadinessCheckerStep.executeStep(this, session);
     await MeetingReadinessCheckerAudioOutputCheck.executeStep(this, session);
     await WaitForContentShareTestToBeReady.executeStep(this, session);

--- a/integration/js/pages/MeetingReadinessCheckerPage.js
+++ b/integration/js/pages/MeetingReadinessCheckerPage.js
@@ -63,6 +63,7 @@ class MeetingReadinessCheckerPage {
     } else {
       await this.speakerCheckFeedbackNo();
     }
+    await TestUtils.waitAround(3000);
     let checkSpeakerFeedback = await this.driver.findElement(elements.speakerTest).getAttribute('class');
     return checkSpeakerFeedback.includes(badgeSuccessLabel);
   }
@@ -186,6 +187,11 @@ class MeetingReadinessCheckerPage {
   async isTestContentShareConnectivityButtonEnabled() {
     let button = await this.driver.findElement(elements.contentShareConnectivityTestButton);
     return await button.isEnabled();
+  }
+
+  async isStartMeetingReadinessCheckerButtonEnabled() {
+    let authenticateButton = await this.driver.findElement(elements.authenticateButton);
+    return await authenticateButton.isEnabled();
   }
 }
 

--- a/integration/js/steps/StartMeetingReadinessCheckerStep.js
+++ b/integration/js/steps/StartMeetingReadinessCheckerStep.js
@@ -1,4 +1,4 @@
-const {KiteTestError, Status} = require('kite-common');
+const {KiteTestError, Status, TestUtils} = require('kite-common');
 const AppTestStep = require('../utils/AppTestStep');
 
 class StartMeetingReadinessCheckerStep extends AppTestStep {
@@ -20,12 +20,8 @@ class StartMeetingReadinessCheckerStep extends AppTestStep {
   }
 
   async run() {
-    const sleep = (milliseconds) => {
-      return new Promise(resolve => setTimeout(resolve, milliseconds))
-    };
-
     await this.page.startCheck();
-    await sleep(10000);
+    await TestUtils.waitAround(5000);
   }
 }
 

--- a/integration/js/steps/WaitForStartMeetingReadinessCheckerButtonToBeEnabled.js
+++ b/integration/js/steps/WaitForStartMeetingReadinessCheckerButtonToBeEnabled.js
@@ -1,0 +1,27 @@
+const {KiteTestError, Status, TestUtils} = require('kite-common');
+const AsyncAppWaitTestStep = require('../utils/AsyncAppWaitTestStep');
+
+class WaitForStartMeetingReadinessCheckerButtonToBeEnabled extends AsyncAppWaitTestStep {
+  constructor(kiteBaseTest, sessionInfo) {
+    super(kiteBaseTest, sessionInfo);
+  }
+
+  static async executeStep(KiteBaseTest, sessionInfo) {
+    const step = new WaitForStartMeetingReadinessCheckerButtonToBeEnabled(KiteBaseTest, sessionInfo);
+    await step.execute(KiteBaseTest);
+  }
+
+  stepDescription() {
+    return 'Waiting for meeting to be created and start button to be ready';
+  }
+
+  async waitCompleteCondition() {
+    return await this.page.isStartMeetingReadinessCheckerButtonEnabled()
+  }
+
+  waitCompleteMessage() {
+    this.logger('Meeting is created and start button is enabled');
+  }
+}
+
+module.exports = WaitForStartMeetingReadinessCheckerButtonToBeEnabled;

--- a/integration/js/steps/index.js
+++ b/integration/js/steps/index.js
@@ -30,3 +30,4 @@ exports.OpenMeetingReadinessCheckerAppStep = require('./OpenMeetingReadinessChec
 exports.StartMeetingReadinessCheckerStep = require('./StartMeetingReadinessCheckerStep');
 exports.StartContentShareConnectivityCheckStep = require('./StartContentShareConnectivityCheckStep');
 exports.WaitForContentShareTestToBeReady = require('./WaitForContentShareTestToBeReady');
+exports.WaitForStartMeetingReadinessCheckerButtonToBeEnabled = require('./WaitForStartMeetingReadinessCheckerButtonToBeEnabled');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.9",
+  "version": "1.18.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.9",
+  "version": "1.18.10",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.18.9';
+    return '1.18.10';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Fix meeting readiness checker integration test by 
1. Adding a sleep of 3 seconds between the audio output check succeeding and checking for the succeed label on the UI.
2. Waiting for the meeting to be created before enabling the `start` button which was causing a race condition.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
    - Unit tests succeeded.
    - Ran the integration tests and all of them succeeded.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
