### PR TITLE
Revert "Fix issue with removeLocalVideoTile not removing video tile f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Revert the "Create log stream before logging begins" commit
 - Revert "Fix unbinding video tile bug" commit
+- Revert "Fix issue with removeLocalVideoTile not removing video tile for remote attendees" commit
 
 ### Fixed
 - Fix Maven installation script

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -38,12 +38,11 @@ import {
 class DemoTileOrganizer {
   // this is index instead of length
   static MAX_TILES = 17;
-  static LOCAL_VIDEO_INDEX = 16;
   public tiles: { [id: number]: number } = {};
   public tileStates: {[id: number]: boolean } = {};
   public remoteTileCount = 0;
 
-  acquireTileIndex(tileId: number, isLocalTile: boolean): number {
+  acquireTileIndex(tileId: number): number {
     for (let index = 0; index <= DemoTileOrganizer.MAX_TILES; index++) {
       if (this.tiles[index] === tileId) {
         return index;
@@ -51,10 +50,6 @@ class DemoTileOrganizer {
     }
     for (let index = 0; index <= DemoTileOrganizer.MAX_TILES; index++) {
       if (!(index in this.tiles)) {
-        if (isLocalTile) {
-          this.tiles[DemoTileOrganizer.LOCAL_VIDEO_INDEX] = tileId;
-          return DemoTileOrganizer.LOCAL_VIDEO_INDEX;
-        }
         this.tiles[index] = tileId;
         this.remoteTileCount++;
         return index;
@@ -418,7 +413,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           }
         } else {
           this.audioVideo.stopLocalVideoTile();
-          this.hideTile(DemoTileOrganizer.LOCAL_VIDEO_INDEX);
+          this.hideTile(DemoTileOrganizer.MAX_TILES);
         }
       });
     });
@@ -1389,7 +1384,9 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     if (!tileState.boundAttendeeId) {
       return;
     }
-    const tileIndex = this.tileOrganizer.acquireTileIndex(tileState.tileId, tileState.localTile);
+    const tileIndex = tileState.localTile
+      ? 16
+      : this.tileOrganizer.acquireTileIndex(tileState.tileId);
     const tileElement = document.getElementById(`tile-${tileIndex}`) as HTMLDivElement;
     const videoElement = document.getElementById(`video-${tileIndex}`) as HTMLVideoElement;
     const nameplateElement = document.getElementById(`nameplate-${tileIndex}`) as HTMLDivElement;

--- a/docs/classes/defaultvideotilecontroller.html
+++ b/docs/classes/defaultvideotilecontroller.html
@@ -260,7 +260,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L137">src/videotilecontroller/DefaultVideoTileController.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L136">src/videotilecontroller/DefaultVideoTileController.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -310,7 +310,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L204">src/videotilecontroller/DefaultVideoTileController.ts:204</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L203">src/videotilecontroller/DefaultVideoTileController.ts:203</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L212">src/videotilecontroller/DefaultVideoTileController.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L211">src/videotilecontroller/DefaultVideoTileController.ts:211</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L123">src/videotilecontroller/DefaultVideoTileController.ts:123</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L122">src/videotilecontroller/DefaultVideoTileController.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L133">src/videotilecontroller/DefaultVideoTileController.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L132">src/videotilecontroller/DefaultVideoTileController.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L82">src/videotilecontroller/DefaultVideoTileController.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L81">src/videotilecontroller/DefaultVideoTileController.ts:81</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L108">src/videotilecontroller/DefaultVideoTileController.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L107">src/videotilecontroller/DefaultVideoTileController.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -429,7 +429,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#getvideotilearea">getVideoTileArea</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L112">src/videotilecontroller/DefaultVideoTileController.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L111">src/videotilecontroller/DefaultVideoTileController.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -471,7 +471,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#havevideotileforattendeeid">haveVideoTileForAttendeeId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L194">src/videotilecontroller/DefaultVideoTileController.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L193">src/videotilecontroller/DefaultVideoTileController.ts:193</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -495,7 +495,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#havevideotileswithstreams">haveVideoTilesWithStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L185">src/videotilecontroller/DefaultVideoTileController.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L184">src/videotilecontroller/DefaultVideoTileController.ts:184</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -513,7 +513,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L86">src/videotilecontroller/DefaultVideoTileController.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L85">src/videotilecontroller/DefaultVideoTileController.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -537,7 +537,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L172">src/videotilecontroller/DefaultVideoTileController.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L171">src/videotilecontroller/DefaultVideoTileController.ts:171</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -573,7 +573,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L145">src/videotilecontroller/DefaultVideoTileController.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L144">src/videotilecontroller/DefaultVideoTileController.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +597,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L160">src/videotilecontroller/DefaultVideoTileController.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L159">src/videotilecontroller/DefaultVideoTileController.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -621,7 +621,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#sendtilestateupdate">sendTileStateUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L179">src/videotilecontroller/DefaultVideoTileController.ts:179</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L178">src/videotilecontroller/DefaultVideoTileController.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -705,7 +705,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotilecontroller.html">VideoTileController</a>.<a href="../interfaces/videotilecontroller.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L97">src/videotilecontroller/DefaultVideoTileController.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotilecontroller/DefaultVideoTileController.ts#L96">src/videotilecontroller/DefaultVideoTileController.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.8",
+  "version": "1.18.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.8",
+  "version": "1.18.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.18.8';
+    return '1.18.9';
   }
 
   /**

--- a/src/videotilecontroller/DefaultVideoTileController.ts
+++ b/src/videotilecontroller/DefaultVideoTileController.ts
@@ -75,7 +75,6 @@ export default class DefaultVideoTileController implements VideoTileController {
   removeLocalVideoTile(): void {
     if (this.currentLocalTile) {
       this.removeVideoTile(this.currentLocalTile.id());
-      this.audioVideoController.update();
     }
   }
 


### PR DESCRIPTION

This reverts commit f492bf28e0ebfddae75c59a062a43d1dc77c51a5.

**Issue #:**


**Description of changes:**
Revert changes that caused a bug when rstarting local video tile in safari desktop and ios.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? tested locally, made sure I can start/stop/start a local video tile
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
