### PR TITLE
Increase roster check time for sip test

### DIFF
--- a/integration/js/SipCallTest.js
+++ b/integration/js/SipCallTest.js
@@ -1,5 +1,5 @@
-const {OpenAppStep, JoinMeetingStep, AuthenticateUserStep, GetSipUriForCallStep} = require('./steps');
-const {UserJoinedMeetingCheck, UserAuthenticationCheck, RemoteAudioCheck, RosterCheck} = require('./checks');
+const {OpenAppStep, JoinMeetingStep, AuthenticateUserStep, GetSipUriForCallStep, EndMeetingStep} = require('./steps');
+const {UserJoinedMeetingCheck, UserAuthenticationCheck, RemoteAudioCheck, RosterCheck, RosterCheckConfig} = require('./checks');
 const {AppPage} = require('./pages/AppPage');
 const {TestUtils} = require('./node_modules/kite-common');
 const SdkBaseTest = require('./utils/SdkBaseTest');
@@ -32,12 +32,13 @@ class SipCallTest extends SdkBaseTest {
     await sip_call_window.runCommands(async () => await GetSipUriForCallStep.executeStep(this, session, this.meetingTitle));
 
     const sipCallClient = new SipCallClient(this.payload.sipTestAssetPath, this.payload.resultPath);
-    const sipCall = sipCallClient.call(this.payload.voiceConnectorId, this.sipUri);
+    const sipCall = sipCallClient.call(this.payload.voiceConnectorId, this.sipUri, this.meetingTitle);
 
-    await test_window.runCommands(async () => await await RosterCheck.executeStep(this, session, 2));
+    await test_window.runCommands(async () => await await RosterCheck.executeStep(this, session, 2, new RosterCheckConfig(60, 500)));
     await test_window.runCommands(async () => await RemoteAudioCheck.executeStep(this, session, 'AUDIO_ON'));
+    await test_window.runCommands(async () => await EndMeetingStep.executeStep(this, session));
 
-    sipCallClient.end(sipCall);
+    // sipCallClient.end(sipCall);
 
     await this.waitAllSteps();
   }

--- a/integration/js/checks/RosterCheck.js
+++ b/integration/js/checks/RosterCheck.js
@@ -1,15 +1,18 @@
 const {KiteTestError, Status, TestUtils} = require('kite-common');
 const demo = require('../pages/AppPage');
 const AppTestStep = require('../utils/AppTestStep');
+const RosterCheckConfig = require('./RosterCheckConfig');
 
 class RosterCheck extends AppTestStep {
-  constructor(kiteBaseTest, sessionInfo, numberOfParticipant) {
+
+  constructor(kiteBaseTest, sessionInfo, numberOfParticipant, config) {
     super(kiteBaseTest, sessionInfo);
     this.numberOfParticipant = numberOfParticipant;
+    this.config = config;
   }
 
-  static async executeStep(KiteBaseTest, sessionInfo, numberOfParticipant) {
-    const step = new RosterCheck(KiteBaseTest, sessionInfo, numberOfParticipant);
+  static async executeStep(KiteBaseTest, sessionInfo, numberOfParticipant, config = new RosterCheckConfig()) {
+    const step = new RosterCheck(KiteBaseTest, sessionInfo, numberOfParticipant, config);
     await step.execute(KiteBaseTest);
   }
 
@@ -26,7 +29,7 @@ class RosterCheck extends AppTestStep {
   }
 
   async run() {
-    const rosterCheckPassed = await this.page.rosterCheck(this.numberOfParticipant);
+    const rosterCheckPassed = await this.page.rosterCheck(this.numberOfParticipant, this.config.checkCount, this.config.waitTimeMs);
     if (!rosterCheckPassed) {
       throw new KiteTestError(Status.FAILED, 'Participants are not present on the roster');
     }

--- a/integration/js/checks/RosterCheckConfig.js
+++ b/integration/js/checks/RosterCheckConfig.js
@@ -1,0 +1,9 @@
+
+class RosterCheckConfig {
+  constructor(checkCount = 10, waitTimeMs = 100){
+    this.checkCount = checkCount;
+    this.waitTimeMs = waitTimeMs;
+  }
+}
+
+module.exports = RosterCheckConfig;

--- a/integration/js/checks/index.js
+++ b/integration/js/checks/index.js
@@ -5,6 +5,7 @@ exports.UserAuthenticationCheck = require('./UserAuthenticationCheck');
 exports.RemoteAudioCheck = require('./RemoteAudioCheck');
 exports.MeetingJoinFailedCheck = require('./MeetingJoinFailedCheck');
 exports.RosterCheck = require('./RosterCheck');
+exports.RosterCheckConfig = require('./RosterCheckConfig');
 exports.ScreenViewingCheck = require('./ScreenViewingCheck');
 exports.ContentShareVideoCheck = require('./ContentShareVideoCheck');
 exports.DataMessageCheck = require('./DataMessageCheck');

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -1,5 +1,6 @@
 const {By, Key} = require('selenium-webdriver');
 const {TestUtils} = require('kite-common');
+const {performance} = require('perf_hooks');
 
 const elements = {
   meetingIdInput: By.id('inputMeeting'),
@@ -279,20 +280,24 @@ class AppPage {
     return await this.driver.findElement(elements.failedMeetingFlow).isDisplayed();
   }
 
-  async rosterCheck(numberOfParticipants) {
+  async rosterCheck(numberOfParticipants, checkCount = 10, waitTimeMs = 100) {
     let i = 0;
-    let timeout = 10;
-    while (i < timeout) {
+    let start = performance.now();
+    while (i < checkCount) {
       try {
         const participantCountOnRoster = await this.getNumberOfParticipantsOnRoster();
         if (participantCountOnRoster === numberOfParticipants) {
+          let end = performance.now();
+          console.log("Roster check completed successfully in : %i secs", (end - start)/1000);
           return true;
         }
       } catch (err) {
       }
-      await TestUtils.waitAround(10);
+      await TestUtils.waitAround(waitTimeMs);
       i++;
     }
+    let end = performance.now();
+    console.log("Roster check failed in : %i secs", (end - start)/1000);
     return false;
   }
 

--- a/integration/js/utils/SipCallClient.js
+++ b/integration/js/utils/SipCallClient.js
@@ -1,4 +1,5 @@
 const {exec} = require('child_process');
+const fs = require('fs');
 
 class SipCallClient {
 
@@ -7,14 +8,22 @@ class SipCallClient {
     this.resultPath = resultPath;
   }
 
-  call(voiceConnectorId, joinToken) {
-    return exec(`env PLAY_TONE=1 TONE_PATH=${this.sipTestAssetPath}/test_tone.wav SIP_DOMAIN="${voiceConnectorId}.voiceconnector.chime.aws;transport=tls;X-chime-join-token=${joinToken.split("X-joinToken=")[1]}" SIP_USER=29709308 SIP_PASSWD=Tz6cghdEgKA4 SIP_CALLER_ID=+12156901457 SIP_PUBLIC_IP_ADDR=3.227.216.243 ${this.sipTestAssetPath}/sipagent_tls +17035550122 12345 ${this.resultPath}/test.wav`, (error, stdout, stderr) => {
+  call(voiceConnectorId, joinToken, meetingTitle) {
+    return exec(`env TERMINATE_ON_BYE=1 DISABLE_DTMF=1 PLAY_TONE=1 TONE_PATH=${this.sipTestAssetPath}/test_tone.wav SIP_DOMAIN="${voiceConnectorId}.voiceconnector.chime.aws;transport=tls;X-chime-join-token=${joinToken.split("X-joinToken=")[1]}" SIP_USER=29709308 SIP_PASSWD=Tz6cghdEgKA4 SIP_CALLER_ID=+12156901457 SIP_PUBLIC_IP_ADDR=3.227.216.243 ${this.sipTestAssetPath}/sipagent_tls +17035550122 12345 ${this.resultPath}/test.wav`, (error, stdout, stderr) => {
       if (error) {
         console.error(`exec error: ${error}`);
         return;
       }
-      console.log(`stdout: ${stdout}`);
-      console.error(`stderr: ${stderr}`);
+      fs.writeFile(`${process.env.RUN_DIR}/sip_${meetingTitle}.log`, stdout, function(err) {
+        if(err) {
+          console.log("======================= SIP logs for call start =======================")
+          console.log(stdout);
+          console.log("======================= SIP logs for call end =======================")
+          return console.error(err);
+        }
+        console.log(`Wrote sip logs to ${process.env.RUN_DIR}/sip_${meetingTitle}.log`);
+      });
+      console.error(stderr);
     });
   }
 


### PR DESCRIPTION
Sip test is failing because roster timeouts. We need to increase the timeout as it could take some time for sip caller to join the call. Also fixing the ERROR log from the sip caller.