### PR TITLE
Remove the "composite" setting from tsconfig.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Revert the "Create log stream before logging begins" commit
 - Revert "Fix unbinding video tile bug" commit
 - Revert "Fix issue with removeLocalVideoTile not removing video tile for remote attendees" commit
+- Remove "./guides/docs.ts" and the composite setting from tsconfig.json
 
 ### Fixed
 - Fix Maven installation script

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4877,9 +4877,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.760.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.760.0.tgz",
-      "integrity": "sha512-u1DhOXbN8/yLRaJ2sjY2ZmjiwEPl4KuGKafaM4oJXzEyOPo5Kwtvau62FgqeRSBVxkw9sipuA5sfYxdwLbq6vg==",
+      "version": "2.762.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.762.0.tgz",
+      "integrity": "sha512-9vpHJbV1n23at2XG+6PDqHsG4JggdosFlcO1glvpXhjuwk1x8NCOwf/ddeXs6YxD6+/Kfj3AP216UaLP0iYxUA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@types/jquery": "^3.5.1",
     "autoprefixer": "^9.6.4",
+    "awesome-typescript-loader": "^5.2.1",
     "css-loader": "^4.3.0",
     "file-loader": "^6.1.0",
     "html-webpack-inline-source-plugin": "^0.0.10",
@@ -32,7 +33,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.760.0",
+    "aws-sdk": "^2.762.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.10",
+  "version": "1.18.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.18.10",
+  "version": "1.18.11",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.18.10';
+    return '1.18.11';
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "./build"
   },
   "include": [


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Remove the `composite` setting from `tsconfig.json` that breaks the `build` folder structure
- Add `awesome-typescript-loader` back. We need to replace `awesome-typescript-loader` with `ts-loader` in the webpack config and test demo apps.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? I replaced the local file path with the `node_modules` path in demo apps for testing the generated `build` folder
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
