### PR TITLE
Add a Travis check to verify version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ jobs:
     #Build and unit tests
     - stage: build
       if: type = pull_request
-      script: npm run build:release
+      script:
+        - script/travis-pr-check || travis_terminate 1;
+        - npm run build:release
       addons: skip
     #Integration tests
     - stage: integ_group_1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add a Travis check to make sure version update
+
+### Changed
+
+### Removed
+
+### Fixed
 
 ## [1.19.0] - 2020-09-29
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/travis-pr-check
+++ b/script/travis-pr-check
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '..')))
+
+base = File.read('.base-branch').strip
+commits = `git rev-list #{base}..`.strip.split("\n")
+
+if commits.size == 1
+  commit = commits[0]
+elsif commits.size == 2
+  commit = commits[1]
+end
+
+commit_files = `git diff-tree --no-commit-id --name-only -r #{commit}`.strip.split("\n")
+
+if commit_files.include?('src/versioning/Versioning.ts') and
+  commit_files.include?('package.json') and
+  commit_files.include?('package-lock.json')
+  puts "OK: branch contains version update"
+else
+  STDERR.puts "Error: Does not contain version update in the commit #{commit}"
+  exit 1
+end

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.0';
+    return '1.19.1';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
Add a Travis check to verify that we have include Versioning.ts, package.js and package-lock.js in a commit in case developers forget to run npm run build:release

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Verify in Travis
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
