### PR TITLE
Show video WebRTC stats and attendeeId on video tile hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add a Travis check to make sure version update
 - Add metrics for Selenium initialization metrics for integration tests
+- [Demo] Show video WebRTC stats and attendeeId on video tile hover
 
 ### Changed
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -282,6 +282,9 @@
             </div>
           </div>
         </div>
+        <button id="button-video-stats" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Toggle video WebRTC stats display" data-toggle="button" aria-pressed="false" autocomplete="off">
+          ${require('../../node_modules/open-iconic/svg/signal.svg').default}
+        </button>
       </div>
       <div class="col-4 col-lg-3 order-3 order-lg-3 text-right text-lg-right">
         <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4" title="Leave meeting">
@@ -310,86 +313,103 @@
         <div id="tile-area" class="v-grid">
           <div id="tile-0" class="video-tile">
             <video id="video-0" class="video-tile-video"></video>
+            <div id="attendeeid-0" class="video-tile-attendeeid"></div>
             <div id="nameplate-0" class="video-tile-nameplate"></div>
             <button id="video-pause-0" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-1" class="video-tile">
             <video id="video-1" class="video-tile-video"></video>
+            <div id="attendeeid-1" class="video-tile-attendeeid"></div>
             <div id="nameplate-1" class="video-tile-nameplate"></div>
             <button id="video-pause-1" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-2" class="video-tile">
             <video id="video-2" class="video-tile-video"></video>
+            <div id="attendeeid-2" class="video-tile-attendeeid"></div>
             <div id="nameplate-2" class="video-tile-nameplate"></div>
             <button id="video-pause-2" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-3" class="video-tile">
             <video id="video-3" class="video-tile-video"></video>
+            <div id="attendeeid-3" class="video-tile-attendeeid"></div>
             <div id="nameplate-3" class="video-tile-nameplate"></div>
             <button id="video-pause-3" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-4" class="video-tile">
             <video id="video-4" class="video-tile-video"></video>
+            <div id="attendeeid-4" class="video-tile-attendeeid"></div>
             <div id="nameplate-4" class="video-tile-nameplate"></div>
             <button id="video-pause-4" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-5" class="video-tile">
             <video id="video-5" class="video-tile-video"></video>
+            <div id="attendeeid-5" class="video-tile-attendeeid"></div>
             <div id="nameplate-5" class="video-tile-nameplate"></div>
             <button id="video-pause-5" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-6" class="video-tile">
             <video id="video-6" class="video-tile-video"></video>
+            <div id="attendeeid-6" class="video-tile-attendeeid"></div>
             <div id="nameplate-6" class="video-tile-nameplate"></div>
             <button id="video-pause-6" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-7" class="video-tile">
             <video id="video-7" class="video-tile-video"></video>
+            <div id="attendeeid-7" class="video-tile-attendeeid"></div>
             <div id="nameplate-7" class="video-tile-nameplate"></div>
             <button id="video-pause-7" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-8" class="video-tile">
             <video id="video-8" class="video-tile-video"></video>
+            <div id="attendeeid-8" class="video-tile-attendeeid"></div>
             <div id="nameplate-8" class="video-tile-nameplate"></div>
             <button id="video-pause-8" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-9" class="video-tile">
             <video id="video-9" class="video-tile-video"></video>
+            <div id="attendeeid-9" class="video-tile-attendeeid"></div>
             <div id="nameplate-9" class="video-tile-nameplate"></div>
             <button id="video-pause-9" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-10" class="video-tile">
             <video id="video-10" class="video-tile-video"></video>
+            <div id="attendeeid-10" class="video-tile-attendeeid"></div>
             <div id="nameplate-10" class="video-tile-nameplate"></div>
             <button id="video-pause-10" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-11" class="video-tile">
             <video id="video-11" class="video-tile-video"></video>
+            <div id="attendeeid-11" class="video-tile-attendeeid"></div>
             <div id="nameplate-11" class="video-tile-nameplate"></div>
             <button id="video-pause-11" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-12" class="video-tile">
             <video id="video-12" class="video-tile-video"></video>
+            <div id="attendeeid-12" class="video-tile-attendeeid"></div>
             <div id="nameplate-12" class="video-tile-nameplate"></div>
             <button id="video-pause-12" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-13" class="video-tile">
             <video id="video-13" class="video-tile-video"></video>
+            <div id="attendeeid-13" class="video-tile-attendeeid"></div>
             <div id="nameplate-13" class="video-tile-nameplate"></div>
             <button id="video-pause-13" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-14" class="video-tile">
             <video id="video-14" class="video-tile-video"></video>
+            <div id="attendeeid-14" class="video-tile-attendeeid"></div>
             <div id="nameplate-14" class="video-tile-nameplate"></div>
             <button id="video-pause-14" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-15" class="video-tile">
             <video id="video-15" class="video-tile-video"></video>
+            <div id="attendeeid-15" class="video-tile-attendeeid"></div>
             <div id="nameplate-15" class="video-tile-nameplate"></div>
             <button id="video-pause-15" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-16" class="video-tile">
             <video id="video-16" class="video-tile-video"></video>
+            <div id="attendeeid-16" class="video-tile-attendeeid"></div>
             <div id="nameplate-16" class="video-tile-nameplate"></div>
             <button id="video-pause-16" class="video-tile-pause" class="btn">Pause</button>
           </div>

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -64,6 +64,7 @@ $list-group-hover-bg: $gray-200;
 $list-group-disabled-bg: $gray-200;
 $close-color: $white;
 $close-text-shadow: none;
+$overlay-z-index: 10;
 
 @import 'node_modules/bootstrap/scss/bootstrap';
 
@@ -796,4 +797,39 @@ a.markdown:active {
   letter-spacing: 0.1em;
   outline: none;
   background: none;
+}
+
+.stats-info {
+  position: absolute;
+  background-color: rgba($color: #000000, $alpha: 0.5);
+  color: white;
+  font-size: 10px;
+  bottom: 3rem;
+  left: 0;
+  z-index: $overlay-z-index;
+  padding: 0.5rem;
+  transition: display 0.5s;
+  display: none;
+
+  .stats-table {
+    width: 15rem;
+    & tr:first-child {
+      border-bottom: 1px dotted $white;
+    }
+  }
+}
+
+#tile-area video[id^='video-']:hover + .stats-info {
+  display: block;
+}
+
+.video-tile-attendeeid {
+  display: none;
+  position: absolute;
+  color: $white;
+  padding: 1rem;
+}
+
+.video-tile.active:hover .video-tile-attendeeid {
+  display: block;
 }

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4876,10 +4876,131 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "awesome-typescript-loader": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-5.2.1.tgz",
+      "integrity": "sha512-slv66OAJB8orL+UUaTI3pKlLorwIvS4ARZzYR9iJJyGsEgOqueMfOMdKySWzZ73vIkEe3fcwFgsKMg4d8zyb1g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.3",
+        "webpack-log": "^1.2.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "aws-sdk": {
-      "version": "2.762.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.762.0.tgz",
-      "integrity": "sha512-9vpHJbV1n23at2XG+6PDqHsG4JggdosFlcO1glvpXhjuwk1x8NCOwf/ddeXs6YxD6+/Kfj3AP216UaLP0iYxUA==",
+      "version": "2.764.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.764.0.tgz",
+      "integrity": "sha512-0asgRwAI3WxUyOjlx2fL7pPHEZajFbAVRerE2h0xX649123PwdhIiJ2HM7lWwn/f+mX7IagYjOCn9dIyvCHBVQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -5876,6 +5997,16 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6197,6 +6328,38 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -6299,6 +6462,23 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "dev": true,
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -7659,6 +7839,25 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "loglevelnext": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+      "dev": true,
+      "requires": {
+        "es6-symbol": "^3.1.1",
+        "object.assign": "^4.1.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -7957,6 +8156,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -10567,6 +10772,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -11275,6 +11486,18 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "webpack-log": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+      "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
       }
     },
     "webpack-sources": {

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.762.0",
+    "aws-sdk": "^2.764.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.2';
+    return '1.19.3';
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
NA

**Description of changes:**
- Additions to demo browser app to show WebRTC video stats and attendeeId for upstream and downstream which will help QA team while testing simulcast changes.
- For the upstream, I could not found a way to calculate `packet loss` since I could only find `packetsSent` but not `packetsLost`.
- Similarly for downstream, I could not find `framesPerSecond` will check for other metrics and add later.
- Stats are shown only when using Chrome.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Locally in chrome, checked other browsers no errors but the simulcast resolutions will be empty 
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
