### PR TITLE
Replace `awesome-typescript-loader` with `ts-loader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests
-- Mark `AudioInternalServerError` and `SignalingInternalServerError` as non-teminal errors
+- Mark `AudioInternalServerError` and `SignalingInternalServerError` as non-terminal errors
+- Replace `awesome-typescript-loader` with `ts-loader`
 
 ### Removed
 

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "@types/jquery": "^3.5.1",
     "autoprefixer": "^9.6.4",
-    "awesome-typescript-loader": "^5.2.1",
     "css-loader": "^4.3.0",
     "file-loader": "^6.1.0",
     "html-webpack-inline-source-plugin": "^0.0.10",

--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = env => {
         },
         {
           test: /\.tsx?$/,
-          loader: 'awesome-typescript-loader',
+          loader: 'ts-loader',
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.5';
+    return '1.19.6';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Replace `awesome-typescript-loader` with `ts-loader` in webpack config

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Ran the serverless demo app locally to test for any failures. 

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
