### PR TITLE
Mark InvalidSequenceTokenExceptions as warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add metrics for Selenium initialization metrics for integration tests
 - Create log stream before logging begins
 - Make AWS SDK for Java camelCased meeting-attendee response compatible with Chime SDK for JavaScript
+- Mark InvalidSequenceTokenExceptions as warning
 
 ### Changed
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -136,7 +136,7 @@ exports.logs = async (event, context) => {
     await cloudWatchClient.putLogEvents(putLogEventsInput).promise();
   } catch (error) {
     const errorMessage = `Failed to put CloudWatch log events with error ${error} and params ${JSON.stringify(putLogEventsInput)}`;
-    if (error.code === 'DataAlreadyAcceptedException' || error.code === 'InvalidSequenceToken') {
+    if (error.code === 'InvalidSequenceTokenException' || error.code === 'DataAlreadyAcceptedException') {
       console.warn(errorMessage);
     } else {
       console.error(errorMessage);


### PR DESCRIPTION
**Issue #:**
We InvalidSequenceTokenExceptions on Log stream. In the past, we separated log stream to handle each meeting session uniquely based on the meetingId and the attendeeId.

**Description of changes:**
We mark the InvalidSequenceTokenExceptions as warning

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Creating an exception explicitly and then trying to catch it using error.code

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
