### PR TITLE
Fix a video flicker issue on simulcast stream change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Make sure integration test returns FAILED if there is error
 - No video after connection failure
+- Fix video track sometimes being removed and added on simulcast receive stream switch
 
 ## [1.19.0] - 2020-09-29
 ### Added

--- a/docs/classes/defaultvideostreamindex.html
+++ b/docs/classes/defaultvideostreamindex.html
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L275">src/videostreamindex/DefaultVideoStreamIndex.ts:275</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L284">src/videostreamindex/DefaultVideoStreamIndex.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -421,7 +421,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L380">src/videostreamindex/DefaultVideoStreamIndex.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L389">src/videostreamindex/DefaultVideoStreamIndex.ts:389</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -444,7 +444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L317">src/videostreamindex/DefaultVideoStreamIndex.ts:317</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L326">src/videostreamindex/DefaultVideoStreamIndex.ts:326</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -467,7 +467,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L338">src/videostreamindex/DefaultVideoStreamIndex.ts:338</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L347">src/videostreamindex/DefaultVideoStreamIndex.ts:347</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L328">src/videostreamindex/DefaultVideoStreamIndex.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L337">src/videostreamindex/DefaultVideoStreamIndex.ts:337</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L306">src/videostreamindex/DefaultVideoStreamIndex.ts:306</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L315">src/videostreamindex/DefaultVideoStreamIndex.ts:315</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -765,7 +765,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L289">src/videostreamindex/DefaultVideoStreamIndex.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L298">src/videostreamindex/DefaultVideoStreamIndex.ts:298</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -789,7 +789,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L282">src/videostreamindex/DefaultVideoStreamIndex.ts:282</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L291">src/videostreamindex/DefaultVideoStreamIndex.ts:291</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -846,7 +846,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L296">src/videostreamindex/DefaultVideoStreamIndex.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L305">src/videostreamindex/DefaultVideoStreamIndex.ts:305</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -881,7 +881,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L350">src/videostreamindex/DefaultVideoStreamIndex.ts:350</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L359">src/videostreamindex/DefaultVideoStreamIndex.ts:359</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/simulcastvideostreamindex.html
+++ b/docs/classes/simulcastvideostreamindex.html
@@ -378,7 +378,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L275">src/videostreamindex/DefaultVideoStreamIndex.ts:275</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L284">src/videostreamindex/DefaultVideoStreamIndex.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -755,7 +755,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L289">src/videostreamindex/DefaultVideoStreamIndex.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L298">src/videostreamindex/DefaultVideoStreamIndex.ts:298</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -780,7 +780,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L282">src/videostreamindex/DefaultVideoStreamIndex.ts:282</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L291">src/videostreamindex/DefaultVideoStreamIndex.ts:291</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -839,7 +839,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L296">src/videostreamindex/DefaultVideoStreamIndex.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L305">src/videostreamindex/DefaultVideoStreamIndex.ts:305</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.8';
+    return '1.19.9';
   }
 
   /**

--- a/src/videostreamindex/DefaultVideoStreamIndex.ts
+++ b/src/videostreamindex/DefaultVideoStreamIndex.ts
@@ -269,6 +269,15 @@ export default class DefaultVideoStreamIndex implements VideoStreamIndex {
         return source.groupId;
       }
     }
+
+    // If wasn't found in current index, then it could be in index used in last subscribe
+    if (!!this.indexForSubscribe) {
+      for (const source of this.indexForSubscribe.sources) {
+        if (source.streamId === streamId) {
+          return source.groupId;
+        }
+      }
+    }
     return undefined;
   }
 


### PR DESCRIPTION
**Issue #:**
NA

**Description of changes:**
Depending on timing of messages from the server, a simulcast
stream change may trigger a video track ended and a new video
track added.  This will result in a tile remove/add.

Fix is to check both current index and index from subscribe
to see if stream being requested is from the same sender.

**Testing**
Enabled simulcast and tested with varying number of participants
and network emulation to verify a simulcast stream switch didn't
cause a track ended and added.

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Added a unit test and manual testing
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
