### PR TITLE
Enabled termination protection for serverless demo cloudformation stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Test] Make sure to reset ready status between retries
 - No video after connection failure
 - Fix video track sometimes being removed and added on simulcast receive stream switch
+- Enabled termination protection for serverless demo cloudformation stack
 
 ## [1.19.0] - 2020-09-29
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.15",
+  "version": "1.19.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.15",
+  "version": "1.19.16",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -9,17 +9,17 @@ npm run build --app=meetingReadinessChecker
 cd $repo_path/demos/serverless
 
 echo "Deploying to alpha stage for canary"
-npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker
+npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -t
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker -t
 
 echo "Deploying to devo stage for canary that talks to gamma Chime endpoint"
 export AWS_ACCESS_KEY_ID=$DEVO_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$DEVO_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-devo-canary -s chime-sdk-demo-devo-canary -c $GAMMA_CHIME_ENDPOINT
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-devo-canary -s chime-sdk-meeting-readiness-checker-devo-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT
+npm run deploy -- -b chime-sdk-demo-devo-canary -s chime-sdk-demo-devo-canary -c $GAMMA_CHIME_ENDPOINT -t
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-devo-canary -s chime-sdk-meeting-readiness-checker-devo-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -t
 
 echo "Deploying to gamma stage for canary that talks to prod Chime endpoint"
 export AWS_ACCESS_KEY_ID=$GAMMA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$GAMMA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker
+npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -t
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -t

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -24,7 +24,7 @@ export default class Versioning {
     // to generate `version.ts` is absent, and will be until someone runs
     // `publish` in this new world.
     /* istanbul ignore next */
-    return VERSION.semverString || '1.19.14';
+    return VERSION.semverString || '1.19.15';
   }
 
   /**


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Update deploy script to enable termination protection for all cloudformation stacks for serverless demo.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tried running the deploy script locally and verifying the stack is being created and termination protection is enabled.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
