### PR TITLE
Correctly provide context in mocked nodes.

### DIFF
--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -972,7 +972,9 @@ export default class DOMMockBuilder {
 
       createAnalyser(): AnalyserNode {
         // @ts-ignore
-        return {};
+        return {
+          context: (this as unknown) as BaseAudioContext,
+        };
       }
 
       createBufferSource(): AudioBufferSourceNode {
@@ -982,6 +984,7 @@ export default class DOMMockBuilder {
       createGain(): GainNode {
         // @ts-ignore
         return {
+          context: (this as unknown) as BaseAudioContext,
           // @ts-ignore
           connect(_destinationParam: AudioParam, _output?: number): void {},
           // @ts-ignore
@@ -1000,6 +1003,7 @@ export default class DOMMockBuilder {
       createOscillator(): OscillatorNode {
         // @ts-ignore
         return {
+          context: (this as unknown) as BaseAudioContext,
           // @ts-ignore
           start(_when?: number): void {},
           stop(): void {},


### PR DESCRIPTION
Test and application code that relies on the presence of `.context`

https://developer.mozilla.org/en-US/docs/Web/API/AudioNode/context

will behave incorrectly with these mocks.

This commit fixes this omission.

Test-only commit, so no CHANGELOG or version bump.

**Issue #:**

None.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes, as part of larger changes. Travis will run anyway.

> 2. How did you test these changes?

Test-only.

> 3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
