### PR TITLE
[Test] Make sure to reset ready status between retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Make sure integration test returns FAILED if there is error
+- [Test] Make sure to reset ready status between retries
 - No video after connection failure
 - Fix video track sometimes being removed and added on simulcast receive stream switch
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.13",
+  "version": "1.19.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.19.13",
+  "version": "1.19.14",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -18,7 +18,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    return '1.19.13';
+    return '1.19.14';
   }
 
   /**


### PR DESCRIPTION
**Description of changes:**
- Make sure to reset ready status between retries so audio and video E2E tests are not out of sync when retrying.
- Logging the attendee Id in audio and video E2E tests to help debugging.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run audio tests and verify
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
