### PR TITLE
Remove fallback version string now that v1.19.14 has been tagged.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an optional parameter to the serverless demo deployment script to specify Chime endpoint, and deploy to a new devo stage that talks to gamma Chime endpoint for canary
 - Add extended debugging for saucelab sessions
 - Add data message throttle limits to documentation
-- Add audioSessionId to join frame to always drop when reconnecting
+- Add `audioSessionId` to join frame to always drop when reconnecting
 
 ### Changed
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests

--- a/docs/classes/versioning.html
+++ b/docs/classes/versioning.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L33">src/versioning/Versioning.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L28">src/versioning/Versioning.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L41">src/versioning/Versioning.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L36">src/versioning/Versioning.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -229,7 +229,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L49">src/versioning/Versioning.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/versioning/Versioning.ts#L44">src/versioning/Versioning.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/versioning/Versioning.ts
+++ b/src/versioning/Versioning.ts
@@ -19,12 +19,7 @@ export default class Versioning {
    * Return string representation of SDK version
    */
   static get sdkVersion(): string {
-    // This is a temporary hack to make the PR that adds this code build
-    // before we do our first tagged release -- the Git tag that we read
-    // to generate `version.ts` is absent, and will be until someone runs
-    // `publish` in this new world.
-    /* istanbul ignore next */
-    return VERSION.semverString || '1.19.15';
+    return VERSION.semverString;
   }
 
   /**

--- a/test/versioning/Versioning.test.ts
+++ b/test/versioning/Versioning.test.ts
@@ -13,7 +13,7 @@ const SHORT_SHA_RE = /^[a-f0-9]{5,40}$/;
 // * Released versions:                       1.19.14
 // * Unreleased versions:                     1.19.14+2.abcdefff
 // * Unreleased versions with local changes:  1.19.14+2.abcdefff.dirty.
-const VERSION_RE = /^[1-9]+\.[0-9]+\.[0-9]+(?:\+[1-9]+\.g[a-f0-9]{5,40}(?:\.dirty)?)?$/;
+const VERSION_RE = /^[1-9]+\.[0-9]+\.[0-9]+(?:\+[1-9][0-9]*\.g[a-f0-9]{5,40}(?:\.dirty)?)?$/;
 
 describe('Versioning', () => {
   describe('#buildSHA', () => {


### PR DESCRIPTION
**Issue #:**

None.

**Description of changes:**

This commit simply removes the fallback version string that I added to allow #772 to build prior to an admin tagging the previous release.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

Unit test, and checked version string in browser demo.

> 3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
