### PR TITLE
Add a tsconfig.json to browser demo to specify a custom root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update meeting readiness checker demo app with new regions CPT, MXP, BOM and ICN
 - Update meeting readiness checker demo app to create meeting after the checker starts
 - Alter the versioning script to require less ritual
-- Correct TypeScript build to generate correct artifacts in `build/`
 
 ### Removed
 
@@ -36,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix video track sometimes being removed and added on simulcast receive stream switch
 - Enabled termination protection for serverless demo cloudformation stack
 - Simulcast optimizations
+- Correct TypeScript build to generate correct artifacts in `build/`
+- Correct TypeScript configuration for demo app
 
 ## [1.19.0] - 2020-09-29
 ### Added

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -274,6 +274,7 @@
       "requires": {
         "@types/dom-mediacapture-record": "^1.0.4",
         "detect-browser": "^5.1.0",
+        "long": "^4.0.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0"
       },

--- a/demos/browser/tsconfig.json
+++ b/demos/browser/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "../.."
+  },
+  "include": [
+    "./app/**/*"
+  ]
+}


### PR DESCRIPTION
**Issue #:**

Fixing the build output broke the demo build.

**Description of changes:**

This adds a root to a new `tsconfig.json` in the demo repo, allowing all of the source to be loaded.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

No. Fingers crossed.

> 2. How did you test these changes?

Browser demo now runs.

> 3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
