### PR TITLE
Restore the call to npm audit fix from prebuild.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Test] Make sure to reset ready status between retries
 - No video after connection failure
 - Fix video track sometimes being removed and added on simulcast receive stream switch
-- Enabled termination protection for serverless demo cloudformation stack
+- Enabled termination protection for serverless demo CloudFormation stack
 - Simulcast optimizations
 - Correct TypeScript build to generate correct artifacts in `build/`
 - Correct TypeScript configuration for demo app

--- a/script/prebuild
+++ b/script/prebuild
@@ -19,3 +19,7 @@ if changelog.length == 0
   STDERR.puts "No CHANGELOG.md entries since #{base}."
   exit 1
 end
+
+# Pull in package fixes automatically.
+verbose('npm audit fix')
+


### PR DESCRIPTION
This was inadvertently removed in an earlier PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
