### PR TITLE
fix: rename tcp feedback result name

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,8 +954,8 @@ const networkUDPFeedback = await meetingReadinessChecker.checkNetworkUDPConnecti
 console.log(`Feedback result: ${CheckNetworkUDPConnectivityFeedback[networkUDPFeedback]}`);
 
 // Tests for TCP network connectivity
-const networkUDPFeedback = await meetingReadinessChecker.checkNetworkTCPConnectivity();
-console.log(`Feedback result: ${CheckNetworkTCPConnectivityFeedback[networkUDPFeedback]}`);
+const networkTCPFeedback = await meetingReadinessChecker.checkNetworkTCPConnectivity();
+console.log(`Feedback result: ${CheckNetworkTCPConnectivityFeedback[networkTCPFeedback]}`);
 ```
 
 Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
**Issue #:**
Wrong name on use case 31 for TCP feedback

**Description of changes:**
Rename TCP feedback result name

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Is a change on the readme
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
