### PR TITLE
Update README to add information about 'tileState.active'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+- [Documentation] Update README to add information about `tileState.active`
+
+### Removed
+
+### Fixed
+
 ## [1.20.0] - 2020-10-15
 ### Added
 - Add a Travis check to make sure version update

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const { v4: uuid } = require('uuid');
 
 // You must use "us-east-1" as the region for Chime API and set the endpoint.
 const chime = new AWS.Chime({ region: 'us-east-1' });
-chime.endpoint = new AWS.Endpoint('https://service.chime.aws.amazon.com/console');
+chime.endpoint = new AWS.Endpoint('https://service.chime.aws.amazon.com');
 
 const meetingResponse = await chime.createMeeting({
   ClientRequestToken: uuid(),
@@ -459,6 +459,7 @@ const observer = {
     }
 
     // videoTileDidUpdate is also invoked when you call startLocalVideoTile or tileState changes.
+    // The tileState.active can be false in poor Internet connection, when the user paused the video tile, or when the video tile first arrived.
     console.log(`If you called stopLocalVideoTile, ${tileState.active} is false.`);
     meetingSession.audioVideo.bindVideoElement(tileState.tileId, videoElement);
     localTileId = tileState.tileId;
@@ -954,8 +955,8 @@ const networkUDPFeedback = await meetingReadinessChecker.checkNetworkUDPConnecti
 console.log(`Feedback result: ${CheckNetworkUDPConnectivityFeedback[networkUDPFeedback]}`);
 
 // Tests for TCP network connectivity
-const networkUDPFeedback = await meetingReadinessChecker.checkNetworkTCPConnectivity();
-console.log(`Feedback result: ${CheckNetworkTCPConnectivityFeedback[networkUDPFeedback]}`);
+const networkTCPFeedback = await meetingReadinessChecker.checkNetworkTCPConnectivity();
+console.log(`Feedback result: ${CheckNetworkTCPConnectivityFeedback[networkTCPFeedback]}`);
 ```
 
 Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/docs/index.html
+++ b/docs/index.html
@@ -165,7 +165,7 @@
 
 <span class="hljs-comment">// You must use &quot;us-east-1&quot; as the region for Chime API and set the endpoint.</span>
 <span class="hljs-keyword">const</span> chime = <span class="hljs-keyword">new</span> AWS.Chime({ <span class="hljs-attr">region</span>: <span class="hljs-string">&#x27;us-east-1&#x27;</span> });
-chime.endpoint = <span class="hljs-keyword">new</span> AWS.Endpoint(<span class="hljs-string">&#x27;https://service.chime.aws.amazon.com/console&#x27;</span>);
+chime.endpoint = <span class="hljs-keyword">new</span> AWS.Endpoint(<span class="hljs-string">&#x27;https://service.chime.aws.amazon.com&#x27;</span>);
 
 <span class="hljs-keyword">const</span> meetingResponse = <span class="hljs-keyword">await</span> chime.createMeeting({
   <span class="hljs-attr">ClientRequestToken</span>: uuid(),
@@ -465,6 +465,7 @@ meetingSession.audioVideo.startLocalVideoTile();</code></pre>
     }
 
     <span class="hljs-comment">// videoTileDidUpdate is also invoked when you call startLocalVideoTile or tileState changes.</span>
+    <span class="hljs-comment">// The tileState.active can be false in poor Internet connection, when the user paused the video tile, or when the video tile first arrived.</span>
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`If you called stopLocalVideoTile, <span class="hljs-subst">${tileState.active}</span> is false.`</span>);
     meetingSession.audioVideo.bindVideoElement(tileState.tileId, videoElement);
     localTileId = tileState.tileId;
@@ -893,8 +894,8 @@ meetingSession.audioVideo.addObserver(observer);</code></pre>
 <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Feedback result: <span class="hljs-subst">${CheckNetworkUDPConnectivityFeedback[networkUDPFeedback]}</span>`</span>);
 
 <span class="hljs-comment">// Tests for TCP network connectivity</span>
-<span class="hljs-keyword">const</span> networkUDPFeedback = <span class="hljs-keyword">await</span> meetingReadinessChecker.checkNetworkTCPConnectivity();
-<span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Feedback result: <span class="hljs-subst">${CheckNetworkTCPConnectivityFeedback[networkUDPFeedback]}</span>`</span>);</code></pre>
+<span class="hljs-keyword">const</span> networkTCPFeedback = <span class="hljs-keyword">await</span> meetingReadinessChecker.checkNetworkTCPConnectivity();
+<span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Feedback result: <span class="hljs-subst">${CheckNetworkTCPConnectivityFeedback[networkTCPFeedback]}</span>`</span>);</code></pre>
 				<p>Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.</p>
 			</div>
 		</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** 

Update README to 
- Add information about 'tileState.active' variable
- Update AWS Chime's service endpoint to remove `/console` from it 
- Correct variable name on use case 31 for TCP feedback

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Documentation update. 

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
