### PR TITLE
Removed check for iceGatheringState to be complete for bypassing gathering ice candidate again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Demo] Add default SSE to meeting notifications queue in CF template
 
 ### Changed
+- Removed check for iceGatheringState to be complete for bypassing gathering ice candidate again
 
 ### Removed
 

--- a/src/task/FinishGatheringICECandidatesTask.ts
+++ b/src/task/FinishGatheringICECandidatesTask.ts
@@ -76,9 +76,14 @@ export default class FinishGatheringICECandidatesTask extends BaseTask {
       );
     }
 
-    // To bypass waiting for events, it is required that "icegatheringstate" to be complete and sdp to have candidate
+    /*
+     * To bypass waiting for events, it is required that "icegatheringstate" to be complete and sdp to have candidate
+     * For Firefox, it takes long for iceGatheringState === 'complete'
+     * Ref: https://github.com/aws/amazon-chime-sdk-js/issues/609
+     */
     if (
-      this.context.peer.iceGatheringState === 'complete' &&
+      (this.context.browserBehavior.hasFirefoxWebRTC() ||
+        this.context.peer.iceGatheringState === 'complete') &&
       new DefaultSDP(this.context.peer.localDescription.sdp).hasCandidates()
     ) {
       this.context.logger.info(


### PR DESCRIPTION
**Issue #:** 
- https://github.com/aws/amazon-chime-sdk-js/issues/609
- https://github.com/aws/amazon-chime-sdk-js/issues/705

**Description of changes:**
In Firefox, the process of ICE Candidate Gathering was taking a long time to go to the `complete` state. In the JS SDK, there was a check to see if previous ICE Candidate Gathering request was complete or not in order to make a decision whether to bypass the new ICE Candidate Gathering request. We decided to remove this check as it was not making any difference since the SDK was not having any actions if any ICE Candidate arrived at a later point in time. It's all handled by the browser. 

Old: 
```
    if (
      this.context.peer.iceGatheringState === 'complete' &&
      new DefaultSDP(this.context.peer.localDescription.sdp).hasCandidates()
    )
```

New: 
```
if (new DefaultSDP(this.context.peer.localDescription.sdp).hasCandidates())
```

This delay in iceGatheringState to be marked as complete in Firefox was resulting in the delay in showing up the sender's video to remote participants.

**Result:**
Old:
```
FinishGatheringICECandidatesTask took 201 ms
FinishGatheringICECandidatesTask took 10045 ms
FinishGatheringICECandidatesTask took 2 ms
```

New:
```
FinishGatheringICECandidatesTask took 206 ms 
FinishGatheringICECandidatesTask took 0 ms 
FinishGatheringICECandidatesTask took 1 ms
```


**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tested using the demo app (locally & deployed the serverless app) to see any issues. (Specially in Safari). Did not see any issues.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No. Internal working is modified.

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No. This is a change in how SDK works internally and have verified it with multiple members of the Video team.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
