### PR TITLE
assert attendeeId defined when setting presence from volume indicator adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix realtimeSetAttendeeIdPresence being called with undefined attendeeId
 
 ## [1.20.0] - 2020-10-15
 ### Added

--- a/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
+++ b/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
@@ -72,7 +72,7 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
             break;
           }
         }
-        if (!attendeeHasNewStreamId) {
+        if (!attendeeHasNewStreamId && !!attendeeId) {
           this.realtimeController.realtimeSetAttendeeIdPresence(
             attendeeId,
             false,


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/793

**Description of changes:**
calling `realtimeSetAttendeeIdPresence` when `attendeeId` is undefined will cause a fatal `RealtimeApiError` for all connected clients, [as documented in the issue](https://github.com/aws/amazon-chime-sdk-js/issues/793). 

This PR simply asserts `attendeeId` is defined in the case where `attendeeId` could not be directly inferred from the audio stream before calling `realtimeSetAttendeeIdPresence` (within `DefaultVolumeIndicatorAdapter::sendRealtimeUpdatesForAudioStreamIdInfo`)

**Testing**
1. Have you successfully run `npm run build:release` locally?
yes
2. How did you test these changes?
* `npm run build && npm run test`
* ran `browser` demo locally 
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.