### PR TITLE
Handle case where meeting or attendee response property can accept null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Reduced sessionId resolution to 32 bits and removed Long dependency
+- Handle case where meeting or attendee response properties can accept null or undefined
+
 
 ## [1.20.0] - 2020-10-15
 ### Added

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -206,6 +206,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
           try {
             chimeMeetingId = await this.authenticate();
           } catch (error) {
+            console.error(error);
             const httpErrorMessage = 'UserMedia is not allowed in HTTP sites. Either use HTTPS or enable media capture on insecure sites.';
             (document.getElementById(
               'failed-meeting'

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4878,9 +4878,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.771.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.771.0.tgz",
-      "integrity": "sha512-fqNGusCwkdemx3yFqvQbU1+xq/PB2wGq7EQIrrTZx/zxfXUp+7+PnrHzXtViCRghN0tylLghBfWYD4VcVcqi7g==",
+      "version": "2.775.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.775.0.tgz",
+      "integrity": "sha512-rlej1sgHmfhl+PJqpQ2qOOsbHEEnLBIKBmanMTUNGiEAfuS0MpFjXECXTpJIOrbUzl3OZuAYrGuBkg2qrBwRbQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.771.0",
+    "aws-sdk": "^2.775.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/src/meetingsession/MeetingSessionConfiguration.ts
+++ b/src/meetingsession/MeetingSessionConfiguration.ts
@@ -177,7 +177,9 @@ export default class MeetingSessionConfiguration {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private toLowerCasePropertyNames(input: any): any {
-    if (typeof input !== 'object') {
+    if (input === null) {
+      return null;
+    } else if (typeof input !== 'object') {
       return input;
     } else if (Array.isArray(input)) {
       return input.map(this.toLowerCasePropertyNames);

--- a/test/meetingsession/MeetingSessionConfiguration.test.ts
+++ b/test/meetingsession/MeetingSessionConfiguration.test.ts
@@ -17,6 +17,104 @@ describe('MeetingSessionConfiguration', () => {
       expect(configuration.urls).to.be.null;
     });
 
+    it('any attribute except mediaplacement can be null', () => {
+      const configuration = new MeetingSessionConfiguration(
+        {
+          MeetingId: 'meeting-id',
+          ExternalMeetingId: null,
+          MediaPlacement: {
+            AudioHostUrl: 'audio-host-url',
+            ScreenDataUrl: null,
+            ScreenSharingUrl: 'screen-sharing-url',
+            ScreenViewingUrl: 'screen-viewing-url',
+            SignalingUrl: 'signaling-url',
+            TurnControlUrl: 'turn-control-url',
+          },
+        },
+        {
+          AttendeeId: 'attendee-id',
+          JoinToken: 'join-token',
+          ExternalUserId: null,
+        }
+      );
+      expect(configuration.meetingId).to.eq('meeting-id');
+      expect(configuration.urls.audioHostURL).to.eq('audio-host-url');
+      expect(configuration.credentials.externalUserId).to.eq(null);
+    });
+
+    it('any attribute can be empty string', () => {
+      const configuration = new MeetingSessionConfiguration(
+        {
+          MeetingId: '',
+          ExternalMeetingId: '',
+          MediaPlacement: '',
+        },
+        {
+          AttendeeId: '',
+          JoinToken: '',
+        }
+      );
+      expect(configuration.meetingId).to.eq('');
+      expect(configuration.urls.audioHostURL).to.eq(undefined);
+      expect(configuration.credentials.attendeeId).to.eq('');
+      expect(configuration.credentials.externalUserId).to.eq(undefined);
+    });
+
+    it('attributes can be undefined', () => {
+      const configuration = new MeetingSessionConfiguration(
+        {
+          MeetingId: 'meeting-id',
+          ExternalMeetingId: null,
+          MediaPlacement: {
+            AudioHostUrl: 'audio-host-url',
+            ScreenDataUrl: null,
+            ScreenSharingUrl: 'screen-sharing-url',
+            ScreenViewingUrl: 'screen-viewing-url',
+            SignalingUrl: 'signaling-url',
+            TurnControlUrl: 'turn-control-url',
+          },
+          Region: { RegionPrimary: '', RegionSecondary: [null, undefined] },
+        },
+        {
+          AttendeeId: 'attendee-id',
+          JoinToken: 'join-token',
+        }
+      );
+      expect(configuration.meetingId).to.eq('meeting-id');
+      expect(configuration.urls.audioHostURL).to.eq('audio-host-url');
+      expect(configuration.urls.screenDataURL).to.eq(null);
+      expect(configuration.credentials.externalUserId).to.eq(undefined);
+    });
+
+    it('can let MediaPlacement have null attributes', () => {
+      const configuration = new MeetingSessionConfiguration(
+        {
+          MeetingId: 'meeting-id',
+          MediaPlacement: {
+            AudioHostUrl: 'audio-host-url',
+            ScreenDataUrl: null,
+            ScreenSharingUrl: 'screen-sharing-url',
+            ScreenViewingUrl: 'screen-viewing-url',
+            SignalingUrl: 'signaling-url',
+            TurnControlUrl: 'turn-control-url',
+          },
+        },
+        {
+          AttendeeId: 'attendee-id',
+          JoinToken: 'join-token',
+        }
+      );
+      expect(configuration.meetingId).to.eq('meeting-id');
+      expect(configuration.urls.audioHostURL).to.eq('audio-host-url');
+      expect(configuration.urls.screenDataURL).to.eq(null);
+      expect(configuration.urls.screenSharingURL).to.eq('screen-sharing-url');
+      expect(configuration.urls.screenViewingURL).to.eq('screen-viewing-url');
+      expect(configuration.urls.signalingURL).to.eq('signaling-url');
+      expect(configuration.urls.turnControlURL).to.eq('turn-control-url');
+      expect(configuration.credentials.attendeeId).to.eq('attendee-id');
+      expect(configuration.credentials.joinToken).to.eq('join-token');
+    });
+
     it('can take a CreateMeeting and CreateAttendee response object', () => {
       const configuration = new MeetingSessionConfiguration(
         {


### PR DESCRIPTION
**Issue #:**
In typescript, null is also treated as an object. So the check [this line](https://github.com/aws/amazon-chime-sdk-js/commit/cfcf723552d949a506237465598f7c1fdd824689#diff-1571e62a3f2170289ce6edb2c4853ae210629ff52e8d7f6e28e8640b5aa611a4R180) would turn false and the execution continued.
So, in the current scenario, we do not handle case where meeting or attendee response property is null.

**Description of changes:**
1) We are adding an explicit check to see if a meeting or attendee response attribute is null or not.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Manually, was able to login to the meeting app
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
Yes
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
