### PR TITLE
Fall back to a synthetic version number if built with no .git directory. (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Allow the build to complete in the absence of a Git checkout.
+
 
 ## [1.20.2] - 2020-10-20
 ### Added

--- a/script/generate-version.js
+++ b/script/generate-version.js
@@ -1,10 +1,31 @@
 #!/usr/bin/env node
 
-const { writeFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 const { gitDescribeSync } = require('git-describe');
 const path = require('path');
 
-const description = JSON.stringify(gitDescribeSync(), null, 2);
+let description;
+try {
+  description = JSON.stringify(gitDescribeSync(), null, 2);
+} catch (e) {
+  console.log(`Got error ${e} getting description of current version.`);
+  console.log('For an accurate version number, or for distribution, please use a full Git checkout of this repository.');
+
+  // Probably not a checkout. This is what you'll get if you use
+  // "Download ZIP" in the GitHub UI.
+  // Synthesize a version file
+  // from the current package.json.
+  const package = readFileSync(path.join(__dirname, '../package.json'));
+  const version = JSON.parse(package).version;
+  console.log(`Using synthetic build description with version ${version}.`)
+
+  description = JSON.stringify({
+    hash: 'gdeadbeef',
+    raw: 'v' + version,
+    semverString: version,
+    tag: 'v' + version,
+  });
+}
 
 console.log('Build description:', description);
 


### PR DESCRIPTION
**Issue #:**

#799.

**Description of changes:**

This commit makes it possible to build the `version.ts` file without the scaffolding of an actual Git checkout. The generated version number will be pulled from `package.json`. See code comments.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

Builds work.

> 3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
