### PR TITLE
Add default SSE to meeting notifications queue in CF template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- [Demo] Add default SSE to meeting notifications queue in CF template
+
+### Changed
+
+### Removed
+
+### Fixed
+
 ## [1.20.2] - 2020-10-20
 ### Added
 

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -89,6 +89,8 @@ Resources:
         Enabled: true
   MeetingNotificationsQueue:
     Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: 'alias/aws/sqs'
   ChimeSdkIndexLambda:
     Type: 'AWS::Serverless::Function'
     Properties:


### PR DESCRIPTION
**Issue #:**
- Security review needs the SQS queue used in CF template to have SSE.
- We currently do not have any SSE added [here](https://github.com/aws/amazon-chime-sdk-js/blob/cda638c9aa186dd15e7af9c7a3555fd99c733224/demos/serverless/template.yaml#L85).

**Description of changes:**
- Add default SSE to meeting notifications queue in `demo/serverless` CF template.
- Needed as part of the security review.

**Testing**

1. Have you successfully run `npm run build:release` locally? 
Yes
2. How did you test these changes? 
- I deployed the meeting app with this template change and observed default SSE added to the queue created by the CF template in my local account.
- Tested joining, re-joining, ending and leaving, video on/off.
- Earlier there was no SSE existing after the CF creation completes.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
