### PR TITLE
Change optional features as list of input boxes in demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [Documentation] Updated HTTP to HTTPS in README URL links
 - [Test] Updated browserstack URL formation to use HTTPS
+- [Demo] change optional feature selection to be list of input box to allow combination
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -48,12 +48,21 @@
       </div>
       <div class="row mt-3">
         <div class="col-12">
-          <label for="optional-features">Optional Features</label>
-          <select id="optional-features" class="custom-select" style="width:100%">
-            <option value="" selected>None</option>
-            <option value="simulcast">Enable Simulcast For Chrome</option>
-            <option value="webaudio">Use WebAudio</option>
-          </select>
+          <fieldset>
+            <legend>Choose your optional features</legend>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="webaudio" class="custom-control-input">
+              <label for="webaudio" class="custom-control-label">Use WebAudio</label>
+            </div>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="simulcast" class="custom-control-input">
+              <label for="simulcast" class="custom-control-label">Enable Simulcast for Chrome</label>
+            </div>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="planB" class="custom-control-input">
+              <label for="planB" class="custom-control-label">Disable Unified Plan for Chrome</label>
+            </div>
+          </fieldset>
         </div>
       </div>
       <div class="row mt-3">

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -37,7 +37,7 @@ const elements = {
 
   meetingAudio: By.id('meeting-audio'),
   sipUri: By.id('sip-uri'),
-  optionalFeatures: By.id('optional-features'),
+  simulcastFeature: By.id('simulcast'),
 };
 
 const SessionStatus = {
@@ -78,8 +78,12 @@ class AppPage {
   }
 
   async chooseUseSimulcast() {
-    let featureSelection = await this.driver.findElement(elements.optionalFeatures);
-    await featureSelection.sendKeys('simulcast');
+    let simulcastFeature = await this.driver.findElement(elements.simulcastFeature);
+    if (simulcastFeature.isSelected()) {
+      console.log('simulcast is selected');
+    } else {
+      await simulcastFeature.click();
+    }
   }
 
   async joinMeeting() {


### PR DESCRIPTION
**Issue #:**

#765  to allow selection of combination of optional features

**Description of changes:**

Change selection box to list of input boxes to allow selection of combination of optional features.
Also change the simulcast integration test based on the change.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? demo 
3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no change to JS SDK source
4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no

In firefox and safari, demo join page looks like

![Screen Shot 2020-10-26 at 11 08 00 AM](https://user-images.githubusercontent.com/46945302/97211332-1fb0dc00-177c-11eb-88b4-4a36fd49a26e.png)

In chrome, demo join page looks like 
![Screen Shot 2020-10-26 at 11 12 44 AM](https://user-images.githubusercontent.com/46945302/97211393-3b1be700-177c-11eb-8b90-73a8fd35c1be.png)

Checked it also works in android and iOS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
