### PR TITLE
Don't shift existing streams to new transceivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Demo] Fix serverless deploy script to not print out logs
 - [Test] Make sure to error out if failed to grab Sauce Lab sessions
 - Fixed deploy github action with correct keys
+- Fix transceiver reordering bug
 
 ## [1.21.0] - 2020-10-29
 ### Added

--- a/docs/classes/defaulttransceivercontroller.html
+++ b/docs/classes/defaulttransceivercontroller.html
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L244">src/transceivercontroller/DefaultTransceiverController.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L254">src/transceivercontroller/DefaultTransceiverController.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L258">src/transceivercontroller/DefaultTransceiverController.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L268">src/transceivercontroller/DefaultTransceiverController.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -550,7 +550,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L235">src/transceivercontroller/DefaultTransceiverController.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L245">src/transceivercontroller/DefaultTransceiverController.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>


### PR DESCRIPTION
**Issue #: https://github.com/aws/amazon-chime-sdk-js/issues/831**

**Description of changes:**

Rather than always shifting videos into available transceiver slots, only use previously available slots for *new* videos.

**Testing**

1. Have you successfully run `npm run build:release` locally? *Yes*
2. How did you test these changes? *Added a test for the specific use case*
3. Can these changes be tested using the demo application? *Should be testable via any app. Fixes the issue in our app*
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? *No*
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? *No*
