### PR TITLE
Add optional features as list of input boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Documentation] Improved documentation for running integration tests locally
 - [Test] Updated browserstack URL formation to use HTTPS
 - Upgraded eslint to understand modern TypeScript syntax, including `import type`.
+- [Demo] change optional feature selection to be list of input box to allow combination
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -48,12 +48,21 @@
       </div>
       <div class="row mt-3">
         <div class="col-12">
-          <label for="optional-features">Optional Features</label>
-          <select id="optional-features" class="custom-select" style="width:100%">
-            <option value="" selected>None</option>
-            <option value="simulcast">Enable Simulcast For Chrome</option>
-            <option value="webaudio">Use WebAudio</option>
-          </select>
+          <fieldset>
+            <legend>Choose your optional features</legend>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="webaudio" class="custom-control-input">
+              <label for="webaudio" class="custom-control-label">Use WebAudio</label>
+            </div>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="simulcast" class="custom-control-input">
+              <label for="simulcast" class="custom-control-label">Enable Simulcast for Chrome</label>
+            </div>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="planB" class="custom-control-input">
+              <label for="planB" class="custom-control-label">Disable Unified Plan for Chrome</label>
+            </div>
+          </fieldset>
         </div>
       </div>
       <div class="row mt-3">

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -133,7 +133,7 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
   audioVideo: AudioVideoFacade | null = null;
   tileOrganizer: DemoTileOrganizer = new DemoTileOrganizer();
   canStartLocalVideo: boolean = true;
-  defaultBrowserBehaviour: DefaultBrowserBehavior;
+  defaultBrowserBehaviour: DefaultBrowserBehavior = new DefaultBrowserBehavior();;
   // eslint-disable-next-line
   roster: any = {};
   tileIndexToTileId: { [id: number]: number } = {};
@@ -194,15 +194,27 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
     } else {
       (document.getElementById('inputMeeting') as HTMLInputElement).focus();
     }
-    this.defaultBrowserBehaviour = new DefaultBrowserBehavior();
   }
 
   initEventListeners(): void {
+    if (!this.defaultBrowserBehaviour.hasChromiumWebRTC()) {
+      (document.getElementById('simulcast') as HTMLInputElement).disabled = true;
+      (document.getElementById('planB') as HTMLInputElement).disabled = true;
+    }
+    
     document.getElementById('form-authenticate').addEventListener('submit', e => {
       e.preventDefault();
       this.meeting = (document.getElementById('inputMeeting') as HTMLInputElement).value;
       this.name = (document.getElementById('inputName') as HTMLInputElement).value;
       this.region = (document.getElementById('inputRegion') as HTMLInputElement).value;
+      this.enableSimulcast = (document.getElementById('simulcast') as HTMLInputElement).checked;
+      if (this.enableSimulcast) {
+        const videoInputQuality = document.getElementById('video-input-quality') as HTMLSelectElement;
+        videoInputQuality.value = '720p';
+      }
+      this.enableWebAudio = (document.getElementById('webaudio') as HTMLInputElement).checked;
+      // js sdk default to enable unified plan, equivalent to "Disable Unified Plan" default unchecked
+      this.enableUnifiedPlanForChromiumBasedBrowsers = !(document.getElementById('planB') as HTMLInputElement).checked;
       new AsyncScheduler().start(
         async (): Promise<void> => {
           let chimeMeetingId: string = '';
@@ -315,28 +327,6 @@ export class DemoMeetingApp implements AudioVideoObserver, DeviceChangeObserver,
         await this.openVideoInputFromSelection(videoInput.value, true);
       } catch (err) {
         this.log('no video input device selected');
-      }
-    });
-
-    const optionalFeatures = document.getElementById('optional-features') as HTMLSelectElement;
-    optionalFeatures.addEventListener('change', async (_ev: Event) => {
-      const collections = optionalFeatures.selectedOptions;
-      this.enableSimulcast = false;
-      this.enableWebAudio = false;
-      this.enableUnifiedPlanForChromiumBasedBrowsers = true;
-      this.log("Feature lists:");
-      for (let i = 0; i < collections.length; i++) {
-        // hard code magic
-        if (collections[i].value === 'simulcast') {
-          this.enableSimulcast = true;
-          this.log('attempt to enable simulcast');
-          const videoInputQuality = document.getElementById('video-input-quality') as HTMLSelectElement;
-          videoInputQuality.value = '720p';
-        }
-        if (collections[i].value === 'webaudio') {
-          this.enableWebAudio = true;
-          this.log('attempt to enable webaudio');
-        }
       }
     });
 

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -37,7 +37,11 @@ const elements = {
 
   meetingAudio: By.id('meeting-audio'),
   sipUri: By.id('sip-uri'),
-  optionalFeatures: By.id('optional-features'),
+  
+  simulcastFeature: By.id('simulcast'),
+  simulcastFeatureLabel: By.css('label[for="simulcast"]'),
+  webAudioFeature: By.id('webaudio'),
+  webAudioFeatureLabel: By.css('label[for="webaudio"]'),
 };
 
 const SessionStatus = {
@@ -77,9 +81,24 @@ class AppPage {
     await authenticateButton.click();
   }
 
+  async chooseUseWebAudio() {
+    let webAudioFeature = await this.driver.findElement(elements.webAudioFeature);
+    let webAudioFeatureLabel = await this.driver.findElement(elements.webAudioFeatureLabel);
+    if (await webAudioFeature.isSelected()) {
+      console.log('Web Audio is selected');
+    } else {
+      await webAudioFeatureLabel.click();
+    }
+  }
+
   async chooseUseSimulcast() {
-    let featureSelection = await this.driver.findElement(elements.optionalFeatures);
-    await featureSelection.sendKeys('simulcast');
+    let simulcastFeature = await this.driver.findElement(elements.simulcastFeature);
+    let simulcastFeatureLabel = await this.driver.findElement(elements.simulcastFeatureLabel);
+    if (await simulcastFeature.isSelected()) {
+      console.log('simulcast is selected');
+    } else {
+      await simulcastFeatureLabel.click();
+    }
   }
 
   async joinMeeting() {


### PR DESCRIPTION
**Issue #:**
additional fix for 

https://github.com/aws/amazon-chime-sdk-js/pull/815 

**Description of changes:**

Change selection box to list of input boxes to allow selection of combination of optional features.
Also change the simulcast integration test based on the change.


**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? 

1). manual testing with demo page
2) local grid and KITE auto testing - box is checked and log show simulcast is selected.
 - ```$KITE_HOME/scripts/mac/path/r configs/video_test_simulcast.config.json```

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
