### PR TITLE
Fix serverless deploy script to not print out logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle undefined attendeeId when calling `realtimeSetAttendeeIdPresence`
 - Fix `DefaultModality` base check
 - [Test] Fix a typo in integ tests
+- [Demo] Fix serverless deploy script to not print out logs
 
 ## [1.21.0] - 2020-10-29
 ### Added

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -9,17 +9,17 @@ npm run build --app=meetingReadinessChecker
 cd $repo_path/demos/serverless
 
 echo "Deploying to alpha stage for canary"
-npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -t
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker -t
+npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -t -l
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker -t -l
 
 echo "Deploying to devo stage for canary that talks to gamma Chime endpoint"
 export AWS_ACCESS_KEY_ID=$DEVO_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$DEVO_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-devo-canary -s chime-sdk-demo-devo-canary -c $GAMMA_CHIME_ENDPOINT -t
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-devo-canary -s chime-sdk-meeting-readiness-checker-devo-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -t
+npm run deploy -- -b chime-sdk-demo-devo-canary -s chime-sdk-demo-devo-canary -c $GAMMA_CHIME_ENDPOINT -t -l
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-devo-canary -s chime-sdk-meeting-readiness-checker-devo-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -t -l
 
 echo "Deploying to gamma stage for canary that talks to prod Chime endpoint"
 export AWS_ACCESS_KEY_ID=$GAMMA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$GAMMA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -t
-npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -t
+npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -t -l
+npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -t -l

--- a/script/postpublish
+++ b/script/postpublish
@@ -29,7 +29,6 @@ verbose('git reset --hard origin/master')
 verbose('git clean -ffxd .')
 
 verbose("git checkout tags/amazon-chime-sdk-js@#{npm_version} -b deploy-to-prod")
-
 Dir.chdir('demos/browser/')
 verbose('npm uninstall amazon-chime-sdk-js')
 verbose("npm install amazon-chime-sdk-js@#{npm_version}")
@@ -54,5 +53,5 @@ verbose('npm run build')
 verbose('npm run build --app=meetingReadinessChecker')
 
 Dir.chdir('../serverless/')
-verbose('npm run deploy -- -b chime-sdk-demo-prod-canary -s chime-sdk-demo-prod-canary')
-verbose('npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary -s chime-sdk-meeting-readiness-checker-prod-canary -a meetingReadinessChecker')
+verbose('npm run deploy -- -b chime-sdk-demo-prod-canary -s chime-sdk-demo-prod-canary -l')
+verbose('npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary -s chime-sdk-meeting-readiness-checker-prod-canary -a meetingReadinessChecker -l')


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
- Update serverless deploy script to add option to avoid printing logs.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tested by deploying the changes locally. Verified it does not print logs.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Its a change in the deploy script. So can be tested with any serverless app.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
