### PR TITLE
Update README to replace deprecated 'AudioCallEnded' with 'MeetingEnded'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Test] Updated browserstack URL formation to use HTTPS
 - Upgraded eslint to understand modern TypeScript syntax, including `import type`.
 - [Demo] change optional feature selection to be list of input box to allow combination
+- [Documentation] Update README to replace deprecated `AudioCallEnded` with `MeetingEnded`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -867,9 +867,10 @@ import { MeetingSessionStatusCode } from 'amazon-chime-sdk-js';
 const observer = {
   audioVideoDidStop: sessionStatus => {
     const sessionStatusCode = sessionStatus.statusCode();
-    if (sessionStatusCode === MeetingSessionStatusCode.AudioCallEnded) {
+    if (sessionStatusCode === MeetingSessionStatusCode.MeetingEnded) {
       /*
         - You (or someone else) have called the DeleteMeeting API action in your server application.
+        - You attempted to join a deleted meeting.
         - No audio connections are present in the meeting for more than five minutes.
         - Fewer than two audio connections are present in the meeting for more than 30 minutes.
         - Screen share viewer connections are inactive for more than 30 minutes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -821,9 +821,10 @@ meetingSession.audioVideo.stop();</code></pre>
 <span class="hljs-keyword">const</span> observer = {
   <span class="hljs-attr">audioVideoDidStop</span>: <span class="hljs-function"><span class="hljs-params">sessionStatus</span> =&gt;</span> {
     <span class="hljs-keyword">const</span> sessionStatusCode = sessionStatus.statusCode();
-    <span class="hljs-keyword">if</span> (sessionStatusCode === MeetingSessionStatusCode.AudioCallEnded) {
+    <span class="hljs-keyword">if</span> (sessionStatusCode === MeetingSessionStatusCode.MeetingEnded) {
       <span class="hljs-comment">/*
         - You (or someone else) have called the DeleteMeeting API action in your server application.
+        - You attempted to join a deleted meeting.
         - No audio connections are present in the meeting for more than five minutes.
         - Fewer than two audio connections are present in the meeting for more than 30 minutes.
         - Screen share viewer connections are inactive for more than 30 minutes.


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/766

**Description of changes:** Update README to replace deprecated 'AudioCallEnded' with 'MeetingEnded'

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Documentation update. Changes can be seen here https://github.com/aws/amazon-chime-sdk-js/tree/doc-update#stopping-a-session under `Use Case. 27`

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
