### PR TITLE
Reuse transceiver for existing remote videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Demo] Fix serverless deploy script to not print out logs
 - [Test] Make sure to error out if failed to grab Sauce Lab sessions
 - Fixed deploy github action with correct keys
+- Remote video may switch transceivers/videoTiles on simulcast change or camera toggle
 
 ## [1.21.0] - 2020-10-29
 ### Added

--- a/docs/classes/defaulttransceivercontroller.html
+++ b/docs/classes/defaulttransceivercontroller.html
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L244">src/transceivercontroller/DefaultTransceiverController.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L254">src/transceivercontroller/DefaultTransceiverController.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -434,7 +434,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L258">src/transceivercontroller/DefaultTransceiverController.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L268">src/transceivercontroller/DefaultTransceiverController.ts:268</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -550,7 +550,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L235">src/transceivercontroller/DefaultTransceiverController.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/transceivercontroller/DefaultTransceiverController.ts#L245">src/transceivercontroller/DefaultTransceiverController.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>


### PR DESCRIPTION

**Issue #:**
831

**Description of changes:**
During a simulcast stream switch or remote video enable/disable
a different transceiver, and video tile, may be used for the same
remote participant.  Ensure the same transceiver is used for existing
remote videos.

**Testing**
Verified expected behavior through unit test and through demo app with simulcast
enabled and constrained network.  Also tested against start/stop of remote camera.

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Unit test and local server
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, meetingV2
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NO

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
