### PR TITLE
Added deprecation message for 'enableWebAudio' API in DeviceController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Demo] change optional feature selection to be list of input box to allow combination
 - [Documentation] Update README to replace deprecated `AudioCallEnded` with `MeetingEnded`
 - [Documentation] Update few `VideoTileController` and `VideoTile` APIs documentation
+- [Documentation] Added deprecation message for `enableWebAudio` API in DeviceController
 
 ### Removed
 

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -530,12 +530,17 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L148">src/devicecontroller/DeviceController.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
+									<p>Deprecated. enableWebAudio will be removed in v2.0.0.
+										This API method will removed entirely, along with the corresponding field on MeetingSessionConfiguration.
+										The MeetingSession will no longer call enableWebAudio on the corresponding DeviceController.
+										Applications should instead use the constructor argument added to DefaultDeviceConfiguration
+										which will be added in v2.0.0 to enable Web Audio at point of construction.
+									Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/devicecontroller.html
+++ b/docs/interfaces/devicecontroller.html
@@ -335,12 +335,17 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L148">src/devicecontroller/DeviceController.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
+									<p>Deprecated. enableWebAudio will be removed in v2.0.0.
+										This API method will removed entirely, along with the corresponding field on MeetingSessionConfiguration.
+										The MeetingSession will no longer call enableWebAudio on the corresponding DeviceController.
+										Applications should instead use the constructor argument added to DefaultDeviceConfiguration
+										which will be added in v2.0.0 to enable Web Audio at point of construction.
+									Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/devicecontrollerbasedmediastreambroker.html
+++ b/docs/interfaces/devicecontrollerbasedmediastreambroker.html
@@ -429,12 +429,17 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="devicecontroller.html">DeviceController</a>.<a href="devicecontroller.html#enablewebaudio">enableWebAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L143">src/devicecontroller/DeviceController.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DeviceController.ts#L148">src/devicecontroller/DeviceController.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
+									<p>Deprecated. enableWebAudio will be removed in v2.0.0.
+										This API method will removed entirely, along with the corresponding field on MeetingSessionConfiguration.
+										The MeetingSession will no longer call enableWebAudio on the corresponding DeviceController.
+										Applications should instead use the constructor argument added to DefaultDeviceConfiguration
+										which will be added in v2.0.0 to enable Web Audio at point of construction.
+									Sets the flag in <a href="devicecontroller.html">DeviceController</a> on whether to enable WebAudio-based device management.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DeviceController.ts
+++ b/src/devicecontroller/DeviceController.ts
@@ -138,6 +138,11 @@ export default interface DeviceController {
   getVideoInputQualitySettings(): VideoQualitySettings | null;
 
   /**
+   * Deprecated. enableWebAudio will be removed in v2.0.0.
+   * This API method will removed entirely, along with the corresponding field on MeetingSessionConfiguration.
+   * The MeetingSession will no longer call enableWebAudio on the corresponding DeviceController.
+   * Applications should instead use the constructor argument added to DefaultDeviceConfiguration
+   * which will be added in v2.0.0 to enable Web Audio at point of construction.
    * Sets the flag in [[DeviceController]] on whether to enable WebAudio-based device management.
    */
   enableWebAudio(flag: boolean): void;


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Added deprecation message for `enableWebAudio` API in DeviceController

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Documentation change.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
