### PR TITLE
[Demo] Show video WebRTC stats and attendeeId on video tile hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- [Demo] Show video WebRTC stats and attendeeId on video tile hover
+
+### Changed
+
+### Removed
+
+### Fixed
+
 ## [1.22.0] - 2020-11-10
 ### Added
 - Add github actions continuous integration workflow and deploy workflow

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -291,6 +291,9 @@
             </div>
           </div>
         </div>
+        <button id="button-video-stats" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Toggle video WebRTC stats display" data-toggle="button" aria-pressed="false" autocomplete="off">
+          ${require('../../node_modules/open-iconic/svg/signal.svg').default}
+        </button>
       </div>
       <div class="col-4 col-lg-3 order-3 order-lg-3 text-right text-lg-right">
         <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4" title="Leave meeting">
@@ -319,86 +322,103 @@
         <div id="tile-area" class="v-grid">
           <div id="tile-0" class="video-tile">
             <video id="video-0" class="video-tile-video"></video>
+            <div id="attendeeid-0" class="video-tile-attendeeid"></div>
             <div id="nameplate-0" class="video-tile-nameplate"></div>
             <button id="video-pause-0" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-1" class="video-tile">
             <video id="video-1" class="video-tile-video"></video>
+            <div id="attendeeid-1" class="video-tile-attendeeid"></div>
             <div id="nameplate-1" class="video-tile-nameplate"></div>
             <button id="video-pause-1" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-2" class="video-tile">
             <video id="video-2" class="video-tile-video"></video>
+            <div id="attendeeid-2" class="video-tile-attendeeid"></div>
             <div id="nameplate-2" class="video-tile-nameplate"></div>
             <button id="video-pause-2" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-3" class="video-tile">
             <video id="video-3" class="video-tile-video"></video>
+            <div id="attendeeid-3" class="video-tile-attendeeid"></div>
             <div id="nameplate-3" class="video-tile-nameplate"></div>
             <button id="video-pause-3" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-4" class="video-tile">
             <video id="video-4" class="video-tile-video"></video>
+            <div id="attendeeid-4" class="video-tile-attendeeid"></div>
             <div id="nameplate-4" class="video-tile-nameplate"></div>
             <button id="video-pause-4" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-5" class="video-tile">
             <video id="video-5" class="video-tile-video"></video>
+            <div id="attendeeid-5" class="video-tile-attendeeid"></div>
             <div id="nameplate-5" class="video-tile-nameplate"></div>
             <button id="video-pause-5" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-6" class="video-tile">
             <video id="video-6" class="video-tile-video"></video>
+            <div id="attendeeid-6" class="video-tile-attendeeid"></div>
             <div id="nameplate-6" class="video-tile-nameplate"></div>
             <button id="video-pause-6" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-7" class="video-tile">
             <video id="video-7" class="video-tile-video"></video>
+            <div id="attendeeid-7" class="video-tile-attendeeid"></div>
             <div id="nameplate-7" class="video-tile-nameplate"></div>
             <button id="video-pause-7" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-8" class="video-tile">
             <video id="video-8" class="video-tile-video"></video>
+            <div id="attendeeid-8" class="video-tile-attendeeid"></div>
             <div id="nameplate-8" class="video-tile-nameplate"></div>
             <button id="video-pause-8" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-9" class="video-tile">
             <video id="video-9" class="video-tile-video"></video>
+            <div id="attendeeid-9" class="video-tile-attendeeid"></div>
             <div id="nameplate-9" class="video-tile-nameplate"></div>
             <button id="video-pause-9" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-10" class="video-tile">
             <video id="video-10" class="video-tile-video"></video>
+            <div id="attendeeid-10" class="video-tile-attendeeid"></div>
             <div id="nameplate-10" class="video-tile-nameplate"></div>
             <button id="video-pause-10" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-11" class="video-tile">
             <video id="video-11" class="video-tile-video"></video>
+            <div id="attendeeid-11" class="video-tile-attendeeid"></div>
             <div id="nameplate-11" class="video-tile-nameplate"></div>
             <button id="video-pause-11" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-12" class="video-tile">
             <video id="video-12" class="video-tile-video"></video>
+            <div id="attendeeid-12" class="video-tile-attendeeid"></div>
             <div id="nameplate-12" class="video-tile-nameplate"></div>
             <button id="video-pause-12" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-13" class="video-tile">
             <video id="video-13" class="video-tile-video"></video>
+            <div id="attendeeid-13" class="video-tile-attendeeid"></div>
             <div id="nameplate-13" class="video-tile-nameplate"></div>
             <button id="video-pause-13" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-14" class="video-tile">
             <video id="video-14" class="video-tile-video"></video>
+            <div id="attendeeid-14" class="video-tile-attendeeid"></div>
             <div id="nameplate-14" class="video-tile-nameplate"></div>
             <button id="video-pause-14" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-15" class="video-tile">
             <video id="video-15" class="video-tile-video"></video>
+            <div id="attendeeid-15" class="video-tile-attendeeid"></div>
             <div id="nameplate-15" class="video-tile-nameplate"></div>
             <button id="video-pause-15" class="video-tile-pause">Pause</button>
           </div>
           <div id="tile-16" class="video-tile">
             <video id="video-16" class="video-tile-video"></video>
+            <div id="attendeeid-16" class="video-tile-attendeeid"></div>
             <div id="nameplate-16" class="video-tile-nameplate"></div>
             <button id="video-pause-16" class="video-tile-pause" class="btn">Pause</button>
           </div>

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -64,6 +64,7 @@ $list-group-hover-bg: $gray-200;
 $list-group-disabled-bg: $gray-200;
 $close-color: $white;
 $close-text-shadow: none;
+$overlay-z-index: 10;
 
 @import 'node_modules/bootstrap/scss/bootstrap';
 
@@ -796,4 +797,39 @@ a.markdown:active {
   letter-spacing: 0.1em;
   outline: none;
   background: none;
+}
+
+.stats-info {
+  position: absolute;
+  background-color: rgba($color: #000000, $alpha: 0.5);
+  color: white;
+  font-size: 10px;
+  bottom: 3rem;
+  left: 0;
+  z-index: $overlay-z-index;
+  padding: 0.5rem;
+  transition: display 0.5s;
+  display: none;
+
+  .stats-table {
+    width: 15rem;
+    & tr:first-child {
+      border-bottom: 1px dotted $white;
+    }
+  }
+}
+
+#tile-area video[id^='video-']:hover + .stats-info {
+  display: block;
+}
+
+.video-tile-attendeeid {
+  display: none;
+  position: absolute;
+  color: $white;
+  padding: 1rem;
+}
+
+.video-tile.active:hover .video-tile-attendeeid {
+  display: block;
 }

--- a/demos/browser/app/meetingV2/webrtcstatscollector/WebRTCStatsCollector.ts
+++ b/demos/browser/app/meetingV2/webrtcstatscollector/WebRTCStatsCollector.ts
@@ -1,0 +1,263 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type MetricsData = { [key: string]: number };
+
+interface CurrentAndPreviousMetrics {
+  current: MetricsData;
+  previous: MetricsData;
+}
+
+enum StreamDirection {
+  'Downstream' = 'Downstream',
+  'Upstream' = 'Upstream',
+};
+
+type SSRCToMetricsData = { [key: string]: CurrentAndPreviousMetrics };
+
+const getCurrentUpstreamMetrics = (report: any, timestamp: number): MetricsData => {
+  const currentMetrics: { [key: string]: number } = {};
+  const { frameHeight, frameWidth, bytesSent, packetsSent, framesEncoded } = report;
+  currentMetrics['frameHeight'] = frameHeight;
+  currentMetrics['frameWidth'] = frameWidth;
+  currentMetrics['framesEncoded'] = framesEncoded;
+  currentMetrics['bytesSent'] = bytesSent;
+  currentMetrics['packetsSent'] = packetsSent;
+  currentMetrics['timestamp'] = timestamp;
+  return currentMetrics;
+}
+
+const getCurrentDownstreamMetrics = (report: any, timestamp: number): MetricsData => {
+  const currentMetrics: { [key: string]: number } = {};
+  const { bytesReceived, packetsLost, packetsReceived, framesDecoded } = report;
+  currentMetrics['bytesReceived'] = bytesReceived;
+  currentMetrics['packetsLost'] = packetsLost;
+  currentMetrics['packetsReceived'] = packetsReceived;
+  currentMetrics['framesDecoded'] = framesDecoded;
+  const totalPackets = packetsReceived + packetsLost;
+  currentMetrics['packetLossPercent'] = totalPackets ? Math.trunc(packetsLost * 100 / (packetsReceived + packetsLost)) : 0;
+  currentMetrics['timestamp'] = timestamp;
+  return currentMetrics;
+}
+
+const bitsPerSecond = (metricName: string, metricMap: CurrentAndPreviousMetrics): number => {
+  const previousTimestamp = metricMap.previous.timestamp;
+  if (!previousTimestamp) {
+    return 0;
+  }
+  const currentTimestamp = metricMap.current.timestamp;
+  let intervalSeconds = (currentTimestamp - previousTimestamp) / 1000;
+  if (intervalSeconds <= 0) {
+    return 0;
+  }
+  const diff =
+    (metricMap.current[metricName] - (metricMap.previous[metricName] || 0)) *
+    8;
+  if (diff <= 0) {
+    return 0;
+  }
+  return Math.trunc((diff / intervalSeconds) / 1000);
+};
+
+const countPerSecond = (metricName: string, metricMap: CurrentAndPreviousMetrics) => {
+  const previousTimestamp = metricMap.previous.timestamp;
+  if (!previousTimestamp) {
+    return 0;
+  }
+  const currentTimestamp = metricMap.current.timestamp;
+  let intervalSeconds = (currentTimestamp - previousTimestamp) / 1000;
+  if (intervalSeconds <= 0) {
+    return 0;
+  }
+  const diff = metricMap.current[metricName] - (metricMap.previous[metricName] || 0);
+  if (diff <= 0) {
+    return 0;
+  }
+  return Math.trunc(diff / intervalSeconds);
+}
+
+export default class WebRTCStatsCollector {
+  static MAX_UPSTREAMS_COUNT = 2;
+  static MAX_DOWNSTREAMS_COUNT = 1;
+  static CLEANUP_INTERVAL = 1500; // In milliseconds.
+  // Map SSRC to WebRTC metrics.
+  upstreamMetrics: SSRCToMetricsData = {};
+  static upstreamMetricsKeyStatsToShow: { [key: string]: string } = {
+    'resolution': 'Resolution',
+    'bitrate': 'Bitrate (kbps)',
+    'packetsSent': 'Packets Sent',
+    'framesEncodedPerSecond': 'Frame Rate',
+  };
+
+  downstreamTileIndexToTrackId: { [key: string]: string } = {};
+  // Map tile index to SSRC to WebRTC metrics.
+  downstreamMetrics: { [key: string]: SSRCToMetricsData } = {};
+  static downstreamMetricsKeyStatsToShow: { [key: string]: string } = {
+    'resolution': 'Resolution',
+    'bitrate': 'Bitrate (kbps)',
+    'packetLossPercent': 'Packet Loss (%)',
+    'framesDecodedPerSecond': 'Frame Rate',
+  };
+
+  cleanUpStaleUpstreamMetricsData = () => {
+    const timestamp = Date.now();
+    const ssrcsToRemove: string[] = [];
+    for (const ssrc of Object.keys(this.upstreamMetrics)) {
+      if ((timestamp - this.upstreamMetrics[ssrc].current.timestamp) >= WebRTCStatsCollector.CLEANUP_INTERVAL) {
+        ssrcsToRemove.push(ssrc);
+      }
+    }
+    ssrcsToRemove.forEach((ssrc) => delete this.upstreamMetrics[ssrc]);
+  }
+
+  processWebRTCStatReportForTileIndex = (rtcStatsReport: RTCStatsReport, tileIndex: number) => {
+    this.cleanUpStaleUpstreamMetricsData();
+    const timestamp = Date.now();
+    let ssrcNum = 0;
+    rtcStatsReport.forEach((report) => {
+      if (report.ssrc) {
+        ssrcNum = Number(report.ssrc);
+      }
+
+      if (report.kind && report.kind === 'video') {
+        if (report.type === 'outbound-rtp' &&
+            report.bytesSent &&
+            report.frameHeight &&
+            report.frameWidth
+          ) { 
+          // Collect and process upstream stats.
+          if (!this.upstreamMetrics.hasOwnProperty(ssrcNum)) {
+            if (Object.keys(this.upstreamMetrics).length === WebRTCStatsCollector.MAX_UPSTREAMS_COUNT) {
+              this.upstreamMetrics = {};
+            }
+            this.upstreamMetrics[ssrcNum] = {
+              current: {},
+              previous: {}
+            };
+          } else {
+            this.upstreamMetrics[ssrcNum].previous = this.upstreamMetrics[ssrcNum].current;
+          }
+          this.upstreamMetrics[ssrcNum].current = getCurrentUpstreamMetrics(report, timestamp);
+          this.upstreamMetrics[ssrcNum].current['framesEncodedPerSecond'] = countPerSecond('framesEncoded', this.upstreamMetrics[ssrcNum]);
+          this.upstreamMetrics[ssrcNum].current['bitrate'] = bitsPerSecond('bytesSent', this.upstreamMetrics[ssrcNum]);
+        } else {
+          if (report.type === 'inbound-rtp' && report.bytesReceived) { 
+            // Collect and process downstream stats.
+            const { trackId } = report;
+            if (!this.downstreamMetrics.hasOwnProperty(tileIndex)) {
+              this.downstreamMetrics[tileIndex] = {};
+            }
+            if (!this.downstreamMetrics[tileIndex].hasOwnProperty(ssrcNum)) {
+              if (Object.keys(this.downstreamMetrics[tileIndex]).length === WebRTCStatsCollector.MAX_DOWNSTREAMS_COUNT) {
+                this.downstreamMetrics[tileIndex] = {};
+              }
+              this.downstreamMetrics[tileIndex][ssrcNum] = {
+                current: {},
+                previous: {}
+              };
+              // Store trackId to later map frameHeight and frameWidth when WebRTC 'track' report is received for downstream videos.
+              this.downstreamTileIndexToTrackId[tileIndex] = trackId;
+            } else {
+              this.downstreamMetrics[tileIndex][ssrcNum].previous = this.downstreamMetrics[tileIndex][ssrcNum].current;
+            }
+            this.downstreamMetrics[tileIndex][ssrcNum].current = getCurrentDownstreamMetrics(report, timestamp);
+            this.downstreamMetrics[tileIndex][ssrcNum].current['bitrate'] = bitsPerSecond('bytesReceived', this.downstreamMetrics[tileIndex][ssrcNum]);
+            this.downstreamMetrics[tileIndex][ssrcNum].current['framesDecodedPerSecond'] = countPerSecond('framesDecoded', this.downstreamMetrics[tileIndex][ssrcNum]);
+          } else if (report.type === 'track' && this.downstreamTileIndexToTrackId[tileIndex] && this.downstreamTileIndexToTrackId[tileIndex] === report.id) {
+            // Collect and process frame height and width stats for downstream.
+            // Process frameHeight and frameWidth separately from track report as we do not have these stats in WebRTC 'inbound-rtp' report.
+            const { frameHeight, frameWidth } = report;
+            this.downstreamMetrics[tileIndex][ssrcNum].current.frameHeight = frameHeight;
+            this.downstreamMetrics[tileIndex][ssrcNum].current.frameWidth = frameWidth;
+          }
+        }
+      }
+    });
+  }
+
+  resetStats = () => {
+    this.upstreamMetrics = {};
+    this.downstreamMetrics = {};
+    this.downstreamTileIndexToTrackId = {};
+  }
+
+  showUpstreamStats(tileIndex: number) {
+    this.showStats(
+      tileIndex,
+      StreamDirection.Upstream,
+      WebRTCStatsCollector.upstreamMetricsKeyStatsToShow,
+      this.upstreamMetrics
+    );
+  }
+
+  showDownstreamStats(tileIndex: number) {
+    this.showStats(
+      tileIndex,
+      StreamDirection.Downstream,
+      WebRTCStatsCollector.downstreamMetricsKeyStatsToShow,
+      this.downstreamMetrics[tileIndex]
+    );
+  }
+
+  showStats = (
+    tileIndex: number,
+    streamDirection: StreamDirection,
+    keyStatstoShow: { [key: string]: string },
+    metricsData: SSRCToMetricsData
+  ) => {
+    const streams = Object.keys(metricsData);
+    if (streams.length === 0) {
+      return;
+    }
+
+    let statsInfo: HTMLDivElement = document.getElementById(`stats-info-${tileIndex}`) as HTMLDivElement;
+    if (!statsInfo) {
+      statsInfo = document.createElement('div');
+      statsInfo.setAttribute('id', `stats-info-${tileIndex}`);
+      statsInfo.setAttribute('class', `stats-info`);
+    }
+
+    const statsInfoTableId = `stats-table-${tileIndex}`;
+    let statsInfoTable = document.getElementById(statsInfoTableId) as HTMLTableElement;
+    if (statsInfoTable) {
+      statsInfo.removeChild(statsInfoTable);
+    }
+    statsInfoTable = document.createElement('table') as HTMLTableElement;
+    statsInfoTable.setAttribute('id', statsInfoTableId);
+    statsInfoTable.setAttribute('class', 'stats-table');
+    statsInfo.appendChild(statsInfoTable);
+
+    const videoEl = document.getElementById(`video-${tileIndex}`) as HTMLVideoElement;
+    videoEl.insertAdjacentElement('afterend', statsInfo);
+    const header = statsInfoTable.insertRow(-1);
+    let cell = header.insertCell(-1);
+    cell.innerHTML = 'Video Metrics';
+    for (let cnt = 0; cnt < streams.length; cnt++) {
+      cell = header.insertCell(-1);
+      cell.innerHTML = `${streamDirection} ${cnt + 1}`;
+    }
+
+    for (const [key, value] of Object.entries(keyStatstoShow)) {
+      const row = statsInfoTable.insertRow(-1);
+      row.setAttribute('id', `${streamDirection}-${key}-${tileIndex}`);
+      cell = row.insertCell(-1);
+      cell.innerHTML = value;
+    }
+
+    for (const ssrc of streams) {
+      const { frameHeight, frameWidth, ...restStatsToShow } = metricsData[ssrc].current;
+      if (frameHeight && frameWidth) {
+        const row = document.getElementById(`${streamDirection}-resolution-${tileIndex}`) as HTMLTableRowElement;
+        cell = row.insertCell(-1);
+        cell.innerHTML = `${frameWidth} &#x2715; ${frameHeight}`;
+      }
+      for (const [metricName, value] of Object.entries(restStatsToShow)) {
+        if (keyStatstoShow[metricName]) {
+          const row = document.getElementById(`${streamDirection}-${metricName}-${tileIndex}`) as HTMLTableRowElement;
+          cell = row.insertCell(-1);
+          cell.innerHTML = `${value}`;
+        }
+      }
+    }
+  }
+}

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4889,9 +4889,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.781.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.781.0.tgz",
-      "integrity": "sha512-y+Xd+DJJyNgZdPLZytJA8LRR79spD/zXOt0G9Uk68UC9tRDEB8aQysuxWKYEybYCexRqJtTZLCrR3ikYwU099g==",
+      "version": "2.790.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.790.0.tgz",
+      "integrity": "sha512-L278KsE+g/LsXIjLhpdtbvMcEZzZ/5dTBLIh6VIcNF0z63xlnDJQ4IWTDZ3Op5fK9B6vwQxlPT7XD5+egu+qoA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.781.0",
+    "aws-sdk": "^2.790.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Adds WebRTC stats collection and parsing to get required stats to show on video tile hover along with the `attendeeId` information.
Upstream Information: Resolution, Bitrate (kbps), Packets Sent, Frame Rate (fps) 
Downstream Information: Resolution, Bitrate (kbps), Packet Loss (%), Frame Rate (fps)
> Note: packet loss percent is not available to show for upstream video (could not find `packetLost` metric using `getPeerConnectionStats` method in Chrome, could only find `packetSent`).

- Adds a separate `WebRTCStatsCollector` class in the demo app to do the WebRTC stats collection and processing.
- Currently this is enabled for only chromium based browsers, for other browsers stats collection may vary due to varying stats variables in WebRTC stats report.
- Adds a UI button to toggle the stats show on the video hover.
- Adds CSS to show all the stats in table format on the video tiles.

**Testing**

1. Have you successfully run `npm run build:release` locally? 
Yes.
2. How did you test these changes? 
Manually in the demo app on Chrome only, by hovering on video tiles. Checked firefox for any errors not found but some stats will not show up. Have not tested extensively on browsers other than Chrome.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
You can test this using the demo meetingV2 app.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
