### PR TITLE
Call emitMetric asyncronously to prevent canary timeout failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed deploy github action with correct keys
 - Remote video may switch transceivers/videoTiles on simulcast change or camera toggle
 - Fix github actions deploy workflow
+- Fix issue with calling closeCurrentTest twice when timeout waiting for an attendee in integ test
 
 ## [1.21.0] - 2020-10-29
 ### Added

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -157,7 +157,7 @@ class SdkBaseTest extends KiteBaseTest {
         throw(e);
       }
     }
-    await emitMetric('Common', this.capabilities, 'SeleniumInit', 1);
+    emitMetric('Common', this.capabilities, 'SeleniumInit', 1);
     return true;
   }
 
@@ -203,7 +203,7 @@ class SdkBaseTest extends KiteBaseTest {
           if (!this.testReady) {
             this.io.emit('test_ready', false);
             console.log('[OTHER_PARTICIPANT] failed to be ready');
-            await this.closeCurrentTest(false);
+            this.remoteFailed = true;
             return;
           }
         }
@@ -214,7 +214,7 @@ class SdkBaseTest extends KiteBaseTest {
       } catch (e) {
         console.error(e);
         this.failedTest = true;
-        await SetTestBrokenStep.executeStep(this, 'Error exception when runing test');
+        await SetTestBrokenStep.executeStep(this, 'Error exception when running test');
       } finally {
         await this.closeCurrentTest(!this.failedTest && !this.remoteFailed);
       }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Right now, if our session fails to connect with the other participant, it calls closeCurrentTest twice, and the second call will fail. Removing one call to closeCurrentTest since we call it immediately afterwards anyways.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? n/a
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n/a
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
