### PR TITLE
[Test] Make sure to remove v2 from URL when trying to create meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix Github Actions CI workflow to include all integ tests.
 - Update the clicking sound answer in FAQs.
+- [Test] Make sure to remove v2 from URL when trying to create meeting
 
 ## [1.22.0] - 2020-11-10
 ### Added

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -12,6 +12,11 @@ class SdkBaseTest extends KiteBaseTest {
   constructor(name, kiteConfig, testName) {
     super(name, kiteConfig);
     this.baseUrl = this.url;
+    if (this.url.endsWith('v2')) {
+      this.baseUrl = this.url.slice(0, -2);
+    } else {
+      this.baseUrl = this.url;
+    }
     if (testName === 'ContentShareOnlyAllowTwoTest') {
       this.url += '?max-content-share=true';
     }


### PR DESCRIPTION
**Description of changes:**
Make sure to remove v2 from URL when trying to create meeting for audio and video E2E tests.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Run test manually 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? 
N/A. This is not SDK changes.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
