### PR TITLE
Update postpublish script to enable termination protection for prod canary stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- [Script] Update postpublish script to enable termination protection for prod canary stack.
+
 ## [2.0.0] - 2020-11-18
 ### Added
 - Add a constructor argument to `DefaultDeviceController` to specify whether Web Audio should be

--- a/script/postpublish
+++ b/script/postpublish
@@ -50,5 +50,5 @@ verbose('npm run build')
 verbose('npm run build --app=meetingReadinessChecker')
 
 Dir.chdir('../serverless/')
-verbose('npm run deploy -- -b chime-sdk-demo-prod-canary -s chime-sdk-demo-prod-canary -l')
-verbose('npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary -s chime-sdk-meeting-readiness-checker-prod-canary -a meetingReadinessChecker -l')
+verbose('npm run deploy -- -b chime-sdk-demo-prod-canary -s chime-sdk-demo-prod-canary -t -l')
+verbose('npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary -s chime-sdk-meeting-readiness-checker-prod-canary -a meetingReadinessChecker -t -l')


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Enable termination protection for the canary stack

**Testing**
Tried running the deployment command manually. And this has already been there in the [deploy-canary-demo](https://github.com/aws/amazon-chime-sdk-js/blob/master/script/deploy-canary-demo#L23-L24) script

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Yes.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA. This is already enabled in the stack. So nothing to test in any demo apps.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
