### PR TITLE
Remove check for `/v2` in canary URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
+- [Test] Remove check for `/v2` in canary URL
 
 ### Fixed
 - [Script] Update postpublish script to enable termination protection for prod canary stack.

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -12,11 +12,6 @@ class SdkBaseTest extends KiteBaseTest {
   constructor(name, kiteConfig, testName) {
     super(name, kiteConfig);
     this.baseUrl = this.url;
-    if (this.url.endsWith('v2')) {
-      this.baseUrl = this.url.slice(0, -2);
-    } else {
-      this.baseUrl = this.url;
-    }
     if (testName === 'ContentShareOnlyAllowTwoTest') {
       this.url += '?max-content-share=true';
     }


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Revert the changes in https://github.com/aws/amazon-chime-sdk-js/pull/870/commits/90766dcac92f9ea9c9b5cc4b1c0204cb956f7826 as SDK 2.0 is released.

**Testing** This was a temporary fix applied for the prod canaries to succeed. Now since the SDK 2.0 is released, it's safe to removed. 

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
This is not required as the legacy screen-share canaries are removed and there is no need for this check

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
