### PR TITLE
Add installation instructions to migration guide. Clean up.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 
 ### Changed
 
 ### Removed
+
 - [Test] Remove check for `/v2` in canary URL
 
 ### Fixed
+
 - [Script] Update postpublish script to enable termination protection for prod canary stack.
 
 ## [2.0.0] - 2020-11-18
 ### Added
+
 - Add a constructor argument to `DefaultDeviceController` to specify whether Web Audio should be
   supported. Use this instead of `enableWebAudio`.
 - Add an `AudioTransformDevice` type that can be supplied to `chooseAudioInputDevice`, allowing the
@@ -34,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Demo] Add audio quality settings to meeting demo.
 
 ### Changed
+
 - The project now produces ES2015 output, rather than ES5 output that refers to ES2015
   features. The SDK supports only modern browsers, and is increasingly dependent on ES2015
   features. This change leads to more compact bundles and aligns the supported JavaScript
@@ -53,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DevicePermission`.
 
 ### Removed
+
 - Remove `enableWebAudio` from `DeviceController` and related types. Use the constructor argument
   instead.
 - Remove V1 meeting app. The V2 meeting app is now the only meeting app deployed. Do not supply /V2/
@@ -61,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `DevicePermission`.
 
 ### Fixed
+
 - Fix Github Actions CI workflow to include all integ tests.
 - Update the clicking sound answer in FAQs.
 - [Test] Make sure to remove v2 from URL when trying to create meeting

--- a/docs/modules/migrationto_2_0.html
+++ b/docs/modules/migrationto_2_0.html
@@ -73,18 +73,27 @@
 							<h1>Migration from SDK v1 to SDK v2</h1>
 						</a>
 					</div>
+					<a href="#installation" id="installation" style="color: inherit; text-decoration: none;">
+						<h2>Installation</h2>
+					</a>
+					<p>Installation involves adjusting your <code>package.json</code> to depend on version <code>2.0.0</code>.</p>
+					<pre><code class="language-shell">npm install --save amazon-chime-sdk-js@2</code></pre>
+					<a href="#interface-changes" id="interface-changes" style="color: inherit; text-decoration: none;">
+						<h2>Interface changes</h2>
+					</a>
 					<p>Version 2 of the Amazon Chime SDK for JavaScript makes a small number of interface
 					changes, as well as removing some deprecated interfaces.</p>
-					<p>In many cases you should not need to adjust your application code at all. This will be the case
-					if:</p>
+					<p>In many cases you should not need to adjust your application code at all. This will be the case if:</p>
 					<ul>
 						<li>You do not implement <code>AudioVideoFacade</code> or <code>DeviceController</code> yourself.</li>
 						<li>You do not explicitly call <code>enableWebAudio</code> on any instances of <code>DeviceController</code> or
 						<code>AudioVideoFacade</code>, or use the <code>MeetingSessionConfiguration</code> field <code>enableWebAudio</code>.</li>
+						<li>You already handle errors in <code>chooseAudioInputDevice</code> with <code>catch</code>.</li>
+						<li>You neither directly call, nor implement, the <code>bindAudio*</code> methods on <code>AudioMixController</code>.</li>
 					</ul>
-					<p>If you do, read on.</p>
+					<p>If your application does not meet all four criteria, read on.</p>
 					<a href="#removing-enablewebaudio" id="removing-enablewebaudio" style="color: inherit; text-decoration: none;">
-						<h2>Removing <code>enableWebAudio</code></h2>
+						<h3>Removing <code>enableWebAudio</code></h3>
 					</a>
 					<p>The <code>enableWebAudio</code> method on <code>DefaultDeviceController</code> would produce unexpected results if
 						called after the first audio device was selected, and as a synchronous API it was not possible
@@ -128,7 +137,7 @@ deviceController.enableWebAudio(enableWebAudio);</code></pre>
 …</code></pre>
 					<hr>
 					<a href="#update-bindaudioelement-to-return-promiseltvoidgt-instead-of-boolean" id="update-bindaudioelement-to-return-promiseltvoidgt-instead-of-boolean" style="color: inherit; text-decoration: none;">
-						<h2>Update <code>bindAudioElement()</code> to return <code>Promise&lt;void&gt;</code> instead of <code>boolean</code></h2>
+						<h3>Update <code>bindAudioElement()</code> to return <code>Promise&lt;void&gt;</code> instead of <code>boolean</code></h3>
 					</a>
 					<p>The <code>bindAudioElement()</code> API in <code>AudioMixControllerFacade</code> was previously a synchronous function which used to return <code>boolean</code>.
 						Under the hood, it used to call <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId"><code>setSinkId()</code></a>
@@ -145,7 +154,7 @@ bindAudioStream(stream: MediaStream): <span class="hljs-built_in">Promise</span>
 bindAudioDevice(device: MediaDeviceInfo | <span class="hljs-literal">null</span>): <span class="hljs-built_in">Promise</span>&lt;<span class="hljs-built_in">void</span>&gt;;</code></pre>
 					<p>Additionally, <code>AudioMixController</code>&#39;s constructor now takes an additional optional <code>logger</code> parameter.
 					If the <code>logger</code> is passed, it will log the errors for any of the operations in <code>AudioMixController</code>.</p>
-					<pre><code><span class="hljs-function"><span class="hljs-keyword">constructor</span><span class="hljs-params">(<span class="hljs-keyword">private</span> logger?: Logger)</span> <span class="hljs-comment">{}</span></span></code></pre>
+					<pre><code class="language-typescript"><span class="hljs-keyword">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> logger?: Logger</span>) {}</code></pre>
 					<p>If your code looked like this</p>
 					<pre><code class="language-typescript">audioMixController.bindAudioDevice({ deviceId: sinkId });
 audioMixController.bindAudioElement(<span class="hljs-keyword">new</span> Audio());
@@ -164,7 +173,7 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
 <span class="hljs-keyword">await</span> audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
 					<hr>
 					<a href="#introducing-audioinputdevice-and-videoinputdevice" id="introducing-audioinputdevice-and-videoinputdevice" style="color: inherit; text-decoration: none;">
-						<h2>Introducing <code>AudioInputDevice</code> and <code>VideoInputDevice</code></h2>
+						<h3>Introducing <code>AudioInputDevice</code> and <code>VideoInputDevice</code></h3>
 					</a>
 					<p>These two types describe <code>DeviceController</code>&#39;s methods for selecting audio and
 						video inputs respectively. They both include the space of <code>Device</code>s, which are the &#39;intrinsic&#39;
@@ -199,22 +208,25 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
     <span class="hljs-comment">// …</span>
   }
 }</code></pre>
-					<p>At present <code>VideoInputDevice</code> is identical to <code>Device</code>, and so the only change you need to make is to change the parameter type of <code>chooseVideoInputDevice</code> from <code>Device</code> to <code>VideoInputDevice</code>.</p>
+					<p>A similar adjustment is needed for <code>VideoInputDevice</code>. v2.0 does not include any
+					<code>VideoTransformDevice</code>s.</p>
 					<p>If you use the type <code>Device</code> for a field or variable and pass that value to
 					<code>choose{Audio,Video}InputDevice</code>, your code should continue to work without changes.</p>
 					<hr>
-					<a href="#introducing-getusermediaerror-type" id="introducing-getusermediaerror-type" style="color: inherit; text-decoration: none;">
-						<h2>Introducing <code>GetUserMediaError</code> type</h2>
+					<a href="#introducing-the-getusermediaerror-type" id="introducing-the-getusermediaerror-type" style="color: inherit; text-decoration: none;">
+						<h3>Introducing the <code>GetUserMediaError</code> type</h3>
 					</a>
-					<p>With version 2.0, we are introducing new error types which will be thrown in case of any failures in <code>chooseAudioInputDevice</code> and <code>chooseVideoInputDevice</code> APIs in the <code>DeviceController</code>.</p>
+					<p>v2.0 introduces new error types which will be thrown in case of any failures in <code>chooseAudioInputDevice</code> and <code>chooseVideoInputDevice</code> APIs in the <code>DeviceController</code>.</p>
 					<p>Here is the list of new error classes introduced in version 2.0:</p>
 					<ul>
-						<li><code>GetUserMediaError</code></li>
-						<li><code>NotFoundError</code></li>
-						<li><code>NotReadableError</code></li>
-						<li><code>OverconstrainedError</code></li>
-						<li><code>PermissionDeniedError</code></li>
-						<li><code>TypeError</code></li>
+						<li><code>GetUserMediaError</code><ul>
+								<li><code>NotFoundError</code></li>
+								<li><code>NotReadableError</code></li>
+								<li><code>OverconstrainedError</code></li>
+								<li><code>PermissionDeniedError</code></li>
+								<li><code>TypeError</code></li>
+							</ul>
+						</li>
 					</ul>
 					<p>Here is an example of handling <code>PermissionDeniedError</code>:</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">try</span> {
@@ -225,10 +237,10 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
   }
 }</code></pre>
 					<hr>
-					<a href="#introducing-supportssetsinkid-api-in-defaultbrowserbehavior" id="introducing-supportssetsinkid-api-in-defaultbrowserbehavior" style="color: inherit; text-decoration: none;">
-						<h2>Introducing <code>supportsSetSinkId()</code> API in <code>DefaultBrowserBehavior</code></h2>
+					<a href="#introducing-supportssetsinkid-in-defaultbrowserbehavior" id="introducing-supportssetsinkid-in-defaultbrowserbehavior" style="color: inherit; text-decoration: none;">
+						<h3>Introducing <code>supportsSetSinkId()</code> in <code>DefaultBrowserBehavior</code></h3>
 					</a>
-					<p>This new helper API returns a boolean <code>true</code> if the browser supports <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId"><code>setSinkId()</code></a> otherwise returning <code>false</code>.</p>
+					<p>This new helper API returns a boolean <code>true</code> if the browser supports <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId"><code>setSinkId()</code></a>, otherwise returning <code>false</code>.</p>
 					<p>Here is how the code would look like:</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">if</span> (!<span class="hljs-built_in">this</span>.browserBehavior.supportsSetSinkId()) {
   <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(
@@ -239,7 +251,7 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
 }</code></pre>
 					<hr>
 					<a href="#deprecating-legacy-screen-share" id="deprecating-legacy-screen-share" style="color: inherit; text-decoration: none;">
-						<h2>Deprecating legacy screen share</h2>
+						<h3>Deprecating legacy screen share</h3>
 					</a>
 					<p>From version 2.0 onwards, the Amazon Chime SDK for JavaScript will no longer include the deprecated screen share API identified by <code>ScreenShareFacade</code> and <code>ScreenShareViewFacade</code> and all related code.
 					Customers should use our Video Based Content Sharing detailed in our <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/02_Content_Share.md">Content Share guide</a>.</p>


### PR DESCRIPTION
The deprecation notice points to the migration guide, so we should add upgrade/installation instructions here, too.

This commit also fixes a few lint complaints in the CHANGELOG in order to bypass that warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
