### PR TITLE
Add demo video stats widget information to the guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Documentation] Add demo video stats widget information to the quality and bandwidth guide
 
 ### Changed
 

--- a/docs/modules/qualitybandwidth_connectivity.html
+++ b/docs/modules/qualitybandwidth_connectivity.html
@@ -193,6 +193,30 @@
 								<td>All</td>
 							</tr>
 					</tbody></table>
+					<blockquote>
+						<p>Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled. This is currently only implemented for Chrome.</p>
+						<p>You get the following WebRTC stats in the video stats widget:</p>
+						<p>Upstream video information: Resolution, Bitrate (kbps), Packets Sent, Frame Rate (fps).</p>
+						<p>Downstream video information: Resolution, Bitrate (kbps), Packet Loss (%), Frame Rate (fps).</p>
+						<p>You can check the implementation in the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts">demo app</a> to build your own custom widget (look for <code>getAndShowWebRTCStats</code> method in the demo). This video stats widget is built using the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideocontroller.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a> and the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L76">metricsDidReceive</a> APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.</p>
+					</blockquote>
+					<a href="#events-for-monitoring-currently-active-simulast-layers" id="events-for-monitoring-currently-active-simulast-layers" style="color: inherit; text-decoration: none;">
+						<h3>Events for monitoring currently active simulast layers</h3>
+					</a>
+					<table>
+						<thead>
+							<tr>
+								<th>Event</th>
+								<th>Notes</th>
+								<th>Browsers</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+								<td><a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></td>
+								<td>Called when simulcast is enabled and simulcast uplink encoding layers are changed. Check the <a href="https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html#receive-upstream-simulcast-layer-change-notification">simulcast guide</a> for more information on simulcast.</td>
+								<td>Chromium-based</td>
+							</tr>
+					</tbody></table>
 					<a href="#mitigations" id="mitigations" style="color: inherit; text-decoration: none;">
 						<h2>Mitigations</h2>
 					</a>

--- a/guides/04_Quality_Bandwidth_Connectivity.md
+++ b/guides/04_Quality_Bandwidth_Connectivity.md
@@ -55,6 +55,23 @@ The Amazon Chime SDK for JavaScript produces several kinds of events on the [Aud
 |------------ | ------------- | ------------- |
 |[metricsDidReceive](https://github.com/aws/amazon-chime-sdk-js/blob/bf6d01e236445684601e24f3e319dede728b5113/src/audiovideoobserver/AudioVideoObserver.ts#L76) | Exposes the WebRTC getStats metrics. There may be differences among browsers as to which metrics are reported. | All |
 
+> Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled. This is currently only implemented for Chrome.
+>
+> You get the following WebRTC stats in the video stats widget:
+>
+> Upstream video information: Resolution, Bitrate (kbps), Packets Sent, Frame Rate (fps).
+>
+> Downstream video information: Resolution, Bitrate (kbps), Packet Loss (%), Frame Rate (fps).
+>
+> You can check the implementation in the [demo app](https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts) to build your own custom widget (look for `getAndShowWebRTCStats` method in the demo). This video stats widget is built using the [getRTCPeerConnectionStats](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideocontroller.html#getrtcpeerconnectionstats) and the [metricsDidReceive](https://github.com/aws/amazon-chime-sdk-js/blob/bf6d01e236445684601e24f3e319dede728b5113/src/audiovideoobserver/AudioVideoObserver.ts#L76) APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.
+
+
+### Events for monitoring currently active simulast layers
+
+|Event | Notes | Browsers |
+|------------ | ------------- | ------------- |
+|[encodingSimulcastLayersDidChange](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#encodingsimulcastlayersdidchange) | Called when simulcast is enabled and simulcast uplink encoding layers are changed. Check the [simulcast guide](https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html#receive-upstream-simulcast-layer-change-notification) for more information on simulcast. | Chromium-based |
+
 ## Mitigations
 
 ### Automatic mitigations


### PR DESCRIPTION
**Issue #:**
NA

**Description of changes:**
- Add demo video stats widget information to the guide

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? NA, just a documentation update.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? NA
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA, no change.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA, no change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
