### PR TITLE
Fix generate version script for forked repo PRs

### DIFF
--- a/integration/js/script/run-test
+++ b/integration/js/script/run-test
@@ -83,7 +83,7 @@ do
 done
 
 echo 'Requires integ tests:' $requires_integration_test
-if ![[ $requires_integration_test ]]
+if [[ ! $requires_integration_test ]]
 then
    exit 0
 fi

--- a/script/generate-version.js
+++ b/script/generate-version.js
@@ -2,19 +2,15 @@
 
 const { readFileSync, writeFileSync } = require('fs');
 const { gitDescribeSync } = require('git-describe');
+const exec = require('child_process').execSync;
 const path = require('path');
 
-let description;
-try {
-  description = JSON.stringify(gitDescribeSync(), null, 2);
-} catch (e) {
-  console.log(`Got error ${e} getting description of current version.`);
-  console.log('For an accurate version number, or for distribution, please use a full Git checkout of this repository.');
-
+function manuallyCreateDescription() {
   // Probably not a checkout. This is what you'll get if you use
   // "Download ZIP" in the GitHub UI.
   // Synthesize a version file
   // from the current package.json.
+
   const package = readFileSync(path.join(__dirname, '../package.json'));
   const version = JSON.parse(package).version;
   console.log(`Using synthetic build description with version ${version}.`)
@@ -25,6 +21,20 @@ try {
     semverString: version,
     tag: 'v' + version,
   });
+}
+try {
+  exec(`git fetch --tags https://github.com/aws/amazon-chime-sdk-js`);
+} catch (e) {
+  console.error(`Unable to fetch tags from the master branch: ${e}`);
+}
+
+let description;
+try {
+  description = JSON.stringify(gitDescribeSync(), null, 2);
+} catch (e) {
+  console.log(`Got error ${e} getting description of current version.`);
+  console.log('For an accurate version number, or for distribution, please use a full Git checkout of this repository.');
+  manuallyCreateDescription();
 }
 
 console.log('Build description:', description);


### PR DESCRIPTION

**Description of changes:**
If a forked repo submits a PR to this repo, doing just a checkout of this repo is not enough. It needs to add the upstream remote repo, fetch down the tags, and then gitDescribeSync will return the correct version. Or we can just create it manually, like we do here. 

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? Forked the repo and ran generate-version
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n/a
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
