### PR TITLE
What happens when participants try to `startLocalVideoTile` when local video tile limit reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add continuous integration workflow support for contributions from forked repos
+- [Documentation] What happens when participants try to `startLocalVideoTile` when local video tile limit reached
+
+### Changed
+
+### Removed
+
+
+### Fixed
+
+
 ## [2.1.0] - 2020-11-23
 
 ### Added
-
 - [Documentation] Add demo video stats widget information to the quality and bandwidth guide
 - [Documentation] Updated migration document to add more information about `bindAudioDevice()` API behavior
 - Add APIs to create a messaging session with Amazon Chime SDK for Messaging
@@ -27,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add github actions fix to conditionally run integ tests
 
 ## [2.0.0] - 2020-11-18
-
 ### Added
 
 - Add a constructor argument to `DefaultDeviceController` to specify whether Web Audio should be
@@ -57,7 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using a transpiler like Babel, or split your application bundle into multiple files that can
   be conditionally loaded. Note that transpiling some parts of the SDK might result in ES5 code
   that does not work when run.
-
 - `DeviceController.createAnalyserNodeForAudioInput` now returns a `RemovableAnalyserNode` that
   knows how to unhook its own inputs. This allows you to correctly clean up, which avoids issues
   with Safari when used with Web Audio. The demo has been adjusted to do so.
@@ -83,16 +94,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct import in `NoOpAudioVideoController`.
 
 ## [1.22.0] - 2020-11-10
-
 ### Added
-
 - Add github actions continuous integration workflow and deploy workflow
 - Add simulcast uplink policy layer change notification methods and observer
 - Add `getRemoteVideoSources` method and `remoteVideoSourcesDidChange` observer
 - [Documentation] Add question to FAQ about android chrome bluetooth audio devices
 
 ### Changed
-
 - [Documentation] Updated HTTP to HTTPS in README URL links
 - [Documentation] Improved documentation for running integration tests locally
 - [Test] Updated browserstack URL formation to use HTTPS
@@ -106,7 +114,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Make the event controller optional in the AudioVideoController interface
 - Handle undefined attendeeId when calling `realtimeSetAttendeeIdPresence`
 - Fix `DefaultModality` base check
@@ -119,42 +126,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue with calling closeCurrentTest twice when timeout waiting for an attendee in integ test
 
 ## [1.21.0] - 2020-10-29
-
 ### Added
-
 - [Demo] Add default SSE to meeting notifications queue in CF template
 - Add meeting events
 
 ### Changed
 
 ### Removed
-
 - Removed check for `iceGatheringState` to be complete for bypassing gathering ice candidate again
 
 ### Fixed
-
 - Allow the build to complete in the absence of a Git checkout
 
 ## [1.20.2] - 2020-10-20
-
 ### Added
 
 ### Changed
-
 - [Documentation] Update README to add information about `tileState.active`
 - Update PR template to ask demo testing question
 
 ### Removed
 
 ### Fixed
-
 - Reduced sessionId resolution to 32 bits and removed Long dependency
 - Handle case where meeting or attendee response properties can accept null or undefined
 
+
 ## [1.20.0] - 2020-10-15
-
 ### Added
-
 - Add a Travis check to make sure version update
 - Add metrics for Selenium initialization metrics for integration tests
 - Create log stream before logging begins
@@ -167,7 +166,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add audioSessionId to join frame to always drop when reconnecting
 
 ### Changed
-
 - Update test results to Sauce Labs before emitting CloudWatch metrics for integration tests
 - Mark `AudioInternalServerError` and `SignalingInternalServerError` as non-terminal errors
 - Replace `awesome-typescript-loader` with `ts-loader`
@@ -181,7 +179,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Make sure integration test returns FAILED if there is error
 - [Test] Make sure to reset ready status between retries
 - No video after connection failure
@@ -192,13 +189,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct TypeScript configuration for demo app
 
 ## [1.19.0] - 2020-09-29
-
 ### Added
-
 - Add MeetingReadinessCheckerConfiguration to allow custom configuration for meeting readiness checker
 
 ### Changed
-
 - Update Travis config to improve PR build speed
 - Disable configs in saucelab capabilities
 - Use credentials sent via signaling connection JOIN_ACK to improve audio-video startup time.
@@ -209,31 +203,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix video tile with incorrect bound attendee ID and external User ID
 
 ### Removed
-
 - Revert the "Create log stream before logging begins" commit
 - Revert "Fix unbinding video tile bug" commit
 - Revert "Fix issue with removeLocalVideoTile not removing video tile for remote attendees" commit
 - Remove "./guides/docs.ts" and the composite setting from tsconfig.json
-- Reverted " Add continuous integration workflow support for contributions from forked repos"
 
 ### Fixed
-
 - Fix Maven installation script
 - Fix SIP integration test
 - Fixed v1 meeting bug related to bootstrap row class
 - Fix meeting readiness checker integration test
 
 ## [1.18.0] - 2020-09-22
-
 ### Added
-
 - Add meeting readiness checker integ tests to travis config
 - Add optional parameter `sourceId` to checkContentShareConnectivity API
 - Add getVideoInputQualitySettings to retrieve the current video settings
 - Add documentation for DefaultActiveSpeakerPolicy constructor
 
 ### Changed
-
 - Use pip to install aws sam cli for deployment script
 - Added meetings tags to serverless demo
 - Update PR template to add question about protocol and API change
@@ -248,14 +236,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Fixed bug related to unbinding a video element
 - Fix tone does not stop when calling MeetingReadinessChecker.checkAudioOutput multiple times
 - Fixed demo css format issue from updating to bootstrap 4.5.1
 - Fix a minor syntax in DefaultSessionStateController
 
 ## [1.17.2] - 2020-09-08
-
 ### Added
 
 ### Changed
@@ -263,18 +249,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Change default encode resolution back to 960x540
 
 ## [1.17.0] - 2020-09-04
-
 ### Added
-
 - Add npm login and logout as part of publish script
 - Add Meeting Readiness Checker APIs
 
 ### Changed
-
 - Change WebRTC semantics to Unified Plan by default for Chromium-based browsers
 - Update video simulcast guide doc
 - Update readme to include link to React components repo
@@ -282,7 +264,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Fixed removeLocalVideoTile so that the video tile is removed correctly for the user and attendees
 - Handle timing issue of receiving index during resubscribe
 - Mitigate Brew Sam installation issue
@@ -292,32 +273,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.16.0] - 2020-08-20
 
 ### Added
-
 - Added auth-token based npm login and logout scripts for npm package publishing
 - Update demo app with new regions CPT, MXP, BOM and ICN
 
 ### Changed
-
 - Update the dependency version for the singlejs demo
 
 ### Removed
-
-- Remove `device` demo from demos
+- Remove  `device` demo from demos
 
 ### Fixed
-
 - Fix and modify simulcast uplink policy to fix freezing and reduce switches
 - Exclude self content share video stream index
 
 ## [1.15.0] - 2020-08-10
 
 ### Added
-
 - Add comments for VideoTileState class and instructions in FAQ document
 - Add reference to CreateMeetingWithAttendees in FAQ
 
 ### Changed
-
 - Bump elliptic from 6.5.2 to 6.5.3 in /demos/device
 - Log info when stop pinging due to Websocket closed
 - Change the demo app to show content share video back to sharer
@@ -327,7 +302,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Ensure all simulcast stream resolution are 16-aligned to avoid pixel3(XL) encoder issue
 - Fix race condition in Chromium browsers when consecutive audio bind operations take place
 - Fix invalid constraints and disable Unified Plan in safari 12.0
@@ -336,19 +310,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.14.0] - 2020-07-28
 
 ### Added
-
 - Add content share video test integration test
 - Add function to query outbound WebRTC video stats in browser demo
 - Add error message for TaskFailed errors
 
 ### Changed
-
 - Return the screen capture media stream for startContentShareFromScreenCapture
 
 ### Removed
 
 ### Fixed
-
 - Fix exception thrown in Safari when multiple startVideoPreviewForVideoInput() are made
 
 ## [1.13.0] - 2020-07-21
@@ -356,13 +327,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
 - Use POST instead of GET for TURN control endpoint
 
 ### Removed
 
 ### Fixed
-
 - Fix demo app responsiveness issue
 - Fix content share test video in Firefox
 - Marking `TURNMeetingEnded` error as terminal to prevent session from reconnecting
@@ -370,7 +339,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.0] - 2020-07-17
 
 ### Added
-
 - Add device name for mobile integration tests
 - Added new FAQs and updated Readme to include new demos for PSTN calling and live events
 - Add test report URL for mobile integration tests
@@ -380,7 +348,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add device change observer events when the current audio/video input stream ended
 
 ### Changed
-
 - Fix title for FAQ guide
 - Change DefaultDeviceController video MediaTrackConstraint parameters to be "ideal" explicitly
 - Use a single instance of AudioContext
@@ -389,7 +356,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Fix typo in VideoStreamDescription when stream is disabled by WebRTC
 - Fix issue where audio input is not able to switch in Firefox
 - Fix handling WebRTC Track event with no associated streams
@@ -401,7 +367,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.11.0] - 2020-06-30
 
 ### Added
-
 - Add meeting demo parameter for broadcasting user
 - Add simulcast guide link in README and Quality Bandwidth Connectivity doc
 - Add a MediaDevices proxy to support the devicechange event in some Android Chrome browsers
@@ -409,11 +374,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
-
 - Remove browser demo optional feature HTMLSelectElement multiple attribute
 
 ### Fixed
-
 - Fix CloudWatch metrics for Linux and Android integration tests
 - Fix create meeting request for audio and video e2e integration tests
 - Fix multiple issues with integration tests
@@ -426,7 +389,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.10.0] - 2020-06-23
 
 ### Added
-
 - Add position in frame to attendee updates
 - Add stale-issue bot configuration
 - Add simulcast support and provides new uplink downlink policies
@@ -436,7 +398,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unit tests for source files previously excluded in test coverage
 
 ### Changed
-
 - Use GET instead of POST to obtain TURN credentials
 - Move integration tests to use meeting V2 demo
 - Update to add ability to run integration tests in mobile devices
@@ -444,7 +405,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Update cloudwatch log stream ID to have attendee_id
 - Fix Firefox 68 codec preference issues
 - Fix uplink max bitrate value calculation
@@ -454,34 +414,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
 - Bump websocket-extensions from 0.1.3 to 0.1.4
 - Update SignalingProtocol.proto and use SDK version in JoinFrame
 
 ### Removed
 
 ### Fixed
-
 - Fix duplicate tiles and error logs due to external id race condition
 - Suppress presence leave when attendee has already joined from another device (#427)
 
 ## [1.8.0] - 2020-06-05
 
 ### Added
-
 - Add an integration tests to check remote video when reconnecting
 - Add device controller tests
 - Add option to run integration tests in Sauce Labs headless
 
 ### Changed
-
 - Switch demo DDB table to on demand
 - Restart the session if an attendee is not present during initial connection
 
 ### Removed
 
 ### Fixed
-
 - Handle user revoking video input permission
 - Fix FinishGatheringICECandidatesTask when there are no turn credentials
 - Fix log line to print device constraints
@@ -494,7 +449,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.0] - 2020-05-23
 
 ### Added
-
 - Add connectionDidBecomeGood callback in AudioVideoObserver
 - Add an integration test for Data Message
 - Add the device selection to the "Starting a session" example
@@ -502,14 +456,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add 'dropped' boolean attribute to realtime interface to indicate attendee drop
 
 ### Changed
-
 - Support styling and Markdown for meeting demo chat
 - Update signaling protocol
 
 ### Removed
 
 ### Fixed
-
 - Fix Firefox version 76 missing/grey tiles
 - Fix data message integration tests
 - Fix several integration test name
@@ -520,20 +472,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.6.2] - 2020-05-18
 
 ### Fixed
-
 - Disable audio capture for Electron Screen Capture
 
 ## [1.6.0] - 2020-05-15
 
 ### Added
-
 - Allow option to skip device selection page in demo app.
 - Add demo hook for debugging media connections
 - Add github link to getNearestMediaRegion method in README.md
 - Add data message APIs
 
 ### Changed
-
 - Allow audio for screen capture in Chrome and Edge browsers
 - Decouple the get call request from the UI
 - Use getSettings if possible on MediaStream and move some info logs to debug level
@@ -542,13 +491,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-
 - Fix minor coding styles for data message APIs
 
 ## [1.5.0] - 2020-05-07
 
 ### Added
-
 - Add bandwidth policy to meeting session configuration to allow overriding default policies
 - Add more content sharing integration tests
 - Add gifs to read me file to show latest npm version and downloads
@@ -556,7 +503,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display meeting and attendee IDs in the demo
 
 ### Changed
-
 - Simplify meeting demos to leverage externalUserId in roster
 - Update PR template to add testing information
 - Support a mobile-friendly demo
@@ -564,11 +510,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update reconnection parameters in ConnectionHealthPolicyConfiguration
 
 ### Removed
-
 - Remove unused VideoAdaptiveSubscribePolicy
 
 ### Fixed
-
 - Fix serverless deploy script to work on Windows
 - Clean up and fix serverless package bundling
 - Do not mirror local video for rear-facing camera
@@ -581,32 +525,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the CloudWatch log handler
 
 ### Security
-
 - Bump package-lock.json jquery to 3.5.0 and yargs-parser to 18.1.3
 
 ## [1.4.0] - 2020-04-24
 
 ### Added
-
 - Expose an API for GetStats from RTCPeerConnection
 - Add BrowserBehavior test for supported video codecs
 - Expose ExternalUserID on videoTileDidUpdate
 
 ### Changed
-
 - Use getByteTimeDomainData to support iOS Safari in meeting demo
 - Update README to incorporate documentation feedback
 
 ### Removed
 
 ### Fixed
-
 - Fix broken link in GitHub main page README
 
 ## [1.3.0] - 2020-04-17
 
 ### Added
-
 - Enable the use of send-side bandwidth estimation
 - Add guide for content sharing
 - Display meeting id in the demo app
@@ -627,7 +566,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add link to Amazon Chime SDK Security in README
 
 ### Changed
-
 - Prevent prebuild from increase patch number when publishing to NPM
 - Change the cloudwatch log message format
 - Only run integration tests if files on watchlist were modified
@@ -637,13 +575,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the default video resolution comment in DeviceController
 
 ### Removed
-
 - Remove unimplemented callbacks remoteDidMuteAudio and remoteDidUnmuteAudio on AudioVideoObserver
 - Remove the minimal demo app
 - Remove incomplete demo and component directories
 
 ### Fixed
-
 - Fix retry logic for integration test
 - Update typedocs to 0.16 and re-generate doc files
 - Fix issue in Travis script that prevents integration tests from running
@@ -659,7 +595,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.1] - 2020-03-20
 
 ### Added
-
 - Add BITRATES in SdkSignalFrame Type and regenerate corresponding JS and TS protocol files.
 - Add new ContentShareController APIs
 - Add Getting Started guide
@@ -674,7 +609,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add an integration test that checks only 2 content share are allowed
 
 ### Changed
-
 - Add observer event for content sharing
 - Stop content share if the media stream end
 - Trap video sending SSRC change in two consecutive negotiation
@@ -692,7 +626,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Throw error in Travis if integration test failed
 
 ### Fixed
-
 - Remove line endings in the keyword when searching for connection attributes in SDP
 - Fix pause and resume video functionality
 - Fix DefaultTransceiverController async function signature
@@ -710,7 +643,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2020-02-04
 
 ### Added
-
 - Add browser support for Safari and Opera
 - Add CHANGELOG.md
 - Allow for pausing screen sharing
@@ -728,7 +660,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Write timestamp for latest canary completion time
 
 ### Changed
-
 - Enforce SDP to have candidates for FinishGatheringICECandidateTask to resolve
 - Add event listeners on peer connection to log state change
 - Add client metrics for Safari
@@ -754,12 +685,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make meeting V2 the default demo meeting app
 
 ### Removed
-
 - Remove SDP class withPlanBSimulcast method
 - Remove noSignalStatusReceived from ReconnectionHealthPolicy and remove SignalStrengthBarsConnectionHealthPolicy.
 
 ### Fixed
-
 - Add cleanup code for failed open screen sharing
 - Handle error in screen viewing send echo response
 - Fix several error handling issues

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -166,6 +166,10 @@
 					</a>
 					<p>Amazon Chime SDK limits are defined <a href="https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-limits">here</a>. The service supports up to 250 attendees and up to 16 video participants in a meeting (video limit is enforced separately). An attendee is considered active unless it has been explicitly removed using DeleteAttendee API call. Attendee limits cannot be changed.</p>
 					<p>If your use case requires more than 250 attendees, consider using a <a href="https://github.com/aws-samples/amazon-chime-meeting-broadcast-demo">broadcasting solution</a>.</p>
+					<a href="#what-happens-to-the-subsequent-participants-who-try-to-turn-on-the-local-video-while-16-participants-have-already-turned-on-the-local-video" id="what-happens-to-the-subsequent-participants-who-try-to-turn-on-the-local-video-while-16-participants-have-already-turned-on-the-local-video" style="color: inherit; text-decoration: none;">
+						<h3>What happens to the subsequent participants who try to turn on the local video while 16 participants have already turned on the local video?</h3>
+					</a>
+					<p>Once the limit of 16 is reached in a meeting, for all the subsequent participants who try to turn on the local video, the SDK sets the Meeting Session status code to <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L73">VideoCallSwitchToViewOnly = 10</a> which in turn triggers the observer &#39;<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videosenddidbecomeunavailable">videoSendDidBecomeUnavailable</a>&#39;.</p>
 					<a href="#can-i-schedule-amazon-chime-sdk-meetings-ahead-of-time" id="can-i-schedule-amazon-chime-sdk-meetings-ahead-of-time" style="color: inherit; text-decoration: none;">
 						<h3>Can I schedule Amazon Chime SDK meetings ahead of time?</h3>
 					</a>

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -106,6 +106,10 @@ Amazon Chime SDK limits are defined [here](https://docs.aws.amazon.com/chime/lat
 
 If your use case requires more than 250 attendees, consider using a [broadcasting solution](https://github.com/aws-samples/amazon-chime-meeting-broadcast-demo).
 
+### What happens to the subsequent participants who try to turn on the local video while 16 participants have already turned on the local video?
+
+Once the limit of 16 is reached in a meeting, for all the subsequent participants who try to turn on the local video, the SDK sets the Meeting Session status code to [VideoCallSwitchToViewOnly = 10](https://github.com/aws/amazon-chime-sdk-js/blob/bfc4c600fb7e68f2d358ecb6c7fd096d30b2d430/src/meetingsession/MeetingSessionStatusCode.ts#L73) which in turn triggers the observer '[videoSendDidBecomeUnavailable](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videosenddidbecomeunavailable)'.
+
 ### Can I schedule Amazon Chime SDK meetings ahead of time?
 
 The Amazon Chime SDK does not support scheduling meetings ahead of time. The moment [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) or 


### PR DESCRIPTION
**Issue #:**
Adding a FAQ section to let the developers know what happens when participants try to `startLocalVideoTile` when local video tile limit reached.

**Description of changes:**
Added a section in the FAQ

**Testing**
N/A

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
