### PR TITLE
Adjust usage of `globalThis` in Amazon Voice Focus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- Allow Amazon Voice Focus code to load (but not function) in unsupported
+  browsers that do not define `globalThis`.
+
 ## [2.1.0] - 2020-11-23
 
 ### Added

--- a/libs/voicefocus/decider.js
+++ b/libs/voicefocus/decider.js
@@ -274,7 +274,7 @@ const estimateAndFeatureCheck = (forceSIMD, fetchConfig, estimatorBudget, logger
         estimator.stop();
     }
 });
-exports.measureAndDecideExecutionApproach = (spec, fetchConfig, logger, thresholds = PERFORMANCE_THRESHOLDS) => __awaiter(void 0, void 0, void 0, function* () {
+const measureAndDecideExecutionApproach = (spec, fetchConfig, logger, thresholds = PERFORMANCE_THRESHOLDS) => __awaiter(void 0, void 0, void 0, function* () {
     let executionPreference = spec.executionPreference;
     const { usagePreference, variantPreference, simdPreference, estimatorBudget, } = spec;
     if (usagePreference === 'interactivity' && executionPreference !== 'inline') {
@@ -299,6 +299,8 @@ exports.measureAndDecideExecutionApproach = (spec, fetchConfig, logger, threshol
     }
     return decideExecutionApproach(Object.assign(Object.assign({}, supports), { simdPreference, executionPreference, variantPreference }), thresholds, logger);
 });
-exports.decideModel = ({ category, name, variant, simd }) => {
+exports.measureAndDecideExecutionApproach = measureAndDecideExecutionApproach;
+const decideModel = ({ category, name, variant, simd }) => {
     return `${category}-${name}-${variant}-v1${simd ? '_simd' : ''}`;
 };
+exports.decideModel = decideModel;

--- a/libs/voicefocus/loader.js
+++ b/libs/voicefocus/loader.js
@@ -9,7 +9,7 @@ const WORKER_FETCH_OPTIONS = {
     redirect: 'follow',
     referrerPolicy: 'no-referrer',
 };
-exports.loadWorker = (workerURL, name, fetchBehavior, logger) => {
+const loadWorker = (workerURL, name, fetchBehavior, logger) => {
     logger === null || logger === void 0 ? void 0 : logger.debug(`Loading ${name} worker from ${workerURL}.`);
     let workerURLIsSameOrigin = false;
     try {
@@ -30,3 +30,4 @@ exports.loadWorker = (workerURL, name, fetchBehavior, logger) => {
         throw new Error('Fetch failed.');
     });
 };
+exports.loadWorker = loadWorker;

--- a/libs/voicefocus/support.js
+++ b/libs/voicefocus/support.js
@@ -11,7 +11,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isOldChrome = exports.supportsWASMStreaming = exports.supportsSharedArrayBuffer = exports.supportsWASM = exports.supportsAudioWorklet = exports.supportsWorker = exports.supportsVoiceFocusWorker = void 0;
 const loader_js_1 = require("./loader.js");
-exports.supportsVoiceFocusWorker = (scope = globalThis, fetchConfig, logger) => __awaiter(void 0, void 0, void 0, function* () {
+const supportsVoiceFocusWorker = (scope = globalThis, fetchConfig, logger) => __awaiter(void 0, void 0, void 0, function* () {
     if (!exports.supportsWorker(scope, logger)) {
         return false;
     }
@@ -31,7 +31,8 @@ exports.supportsVoiceFocusWorker = (scope = globalThis, fetchConfig, logger) => 
         return false;
     }
 });
-exports.supportsWorker = (scope = globalThis, logger) => {
+exports.supportsVoiceFocusWorker = supportsVoiceFocusWorker;
+const supportsWorker = (scope = globalThis, logger) => {
     try {
         return !!scope.Worker;
     }
@@ -40,7 +41,8 @@ exports.supportsWorker = (scope = globalThis, logger) => {
         return false;
     }
 };
-exports.supportsAudioWorklet = (scope = globalThis, logger) => {
+exports.supportsWorker = supportsWorker;
+const supportsAudioWorklet = (scope = globalThis, logger) => {
     try {
         return !!scope.AudioWorklet && !!scope.AudioWorkletNode;
     }
@@ -49,7 +51,8 @@ exports.supportsAudioWorklet = (scope = globalThis, logger) => {
         return false;
     }
 };
-exports.supportsWASM = (scope = globalThis, logger) => {
+exports.supportsAudioWorklet = supportsAudioWorklet;
+const supportsWASM = (scope = globalThis, logger) => {
     try {
         return !!scope.WebAssembly;
     }
@@ -58,7 +61,8 @@ exports.supportsWASM = (scope = globalThis, logger) => {
         return false;
     }
 };
-exports.supportsSharedArrayBuffer = (scope = globalThis, window = globalThis, logger) => {
+exports.supportsWASM = supportsWASM;
+const supportsSharedArrayBuffer = (scope = globalThis, window = globalThis, logger) => {
     try {
         return !!scope.SharedArrayBuffer && (!!window.chrome || !!scope.crossOriginIsolated);
     }
@@ -67,7 +71,8 @@ exports.supportsSharedArrayBuffer = (scope = globalThis, window = globalThis, lo
         return false;
     }
 };
-exports.supportsWASMStreaming = (scope = globalThis, logger) => {
+exports.supportsSharedArrayBuffer = supportsSharedArrayBuffer;
+const supportsWASMStreaming = (scope = globalThis, logger) => {
     var _a;
     try {
         return !!((_a = scope.WebAssembly) === null || _a === void 0 ? void 0 : _a.compileStreaming);
@@ -77,7 +82,8 @@ exports.supportsWASMStreaming = (scope = globalThis, logger) => {
         return false;
     }
 };
-exports.isOldChrome = (global = globalThis, logger) => {
+exports.supportsWASMStreaming = supportsWASMStreaming;
+const isOldChrome = (global = globalThis, logger) => {
     try {
         if (!global.chrome) {
             return false;
@@ -92,3 +98,4 @@ exports.isOldChrome = (global = globalThis, logger) => {
     }
     return true;
 };
+exports.isOldChrome = isOldChrome;

--- a/libs/voicefocus/types.js
+++ b/libs/voicefocus/types.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.VoiceFocusAudioWorkletNode = void 0;
-class VoiceFocusAudioWorkletNode extends (globalThis['AudioWorkletNode'] || class Sadness {
-}) {
+class VoiceFocusAudioWorkletNode extends ((typeof globalThis !== 'undefined' && globalThis['AudioWorkletNode']) ||
+    class Sadness {
+    }) {
 }
 exports.VoiceFocusAudioWorkletNode = VoiceFocusAudioWorkletNode;

--- a/libs/voicefocus/voicefocus.js
+++ b/libs/voicefocus/voicefocus.js
@@ -97,6 +97,9 @@ class VoiceFocus {
     }
     static isSupported(spec, options) {
         const { fetchBehavior, logger } = options || {};
+        if (typeof globalThis === 'undefined') {
+            return Promise.resolve(false);
+        }
         if (!support_js_1.supportsAudioWorklet(globalThis, logger) || !support_js_1.supportsWASMStreaming(globalThis, logger)) {
             return Promise.resolve(false);
         }
@@ -243,10 +246,11 @@ class VoiceFocus {
     }
 }
 exports.VoiceFocus = VoiceFocus;
-exports.createAudioContext = (contextHint = DEFAULT_CONTEXT_HINT) => {
+const createAudioContext = (contextHint = DEFAULT_CONTEXT_HINT) => {
     return new (window.AudioContext || window.webkitAudioContext)(contextHint);
 };
-exports.getAudioInput = (context, inputOptions, voiceFocusOptions) => __awaiter(void 0, void 0, void 0, function* () {
+exports.createAudioContext = createAudioContext;
+const getAudioInput = (context, inputOptions, voiceFocusOptions) => __awaiter(void 0, void 0, void 0, function* () {
     var _a, _b;
     const { constraints, spec, delegate, preload = true, options } = inputOptions;
     const { logger } = voiceFocusOptions;
@@ -260,3 +264,4 @@ exports.getAudioInput = (context, inputOptions, voiceFocusOptions) => __awaiter(
     const input = yield window.navigator.mediaDevices.getUserMedia(mungeConstraints(constraints, agc));
     return factory.applyToStream(input, context, options).then(result => result.stream);
 });
+exports.getAudioInput = getAudioInput;


### PR DESCRIPTION
**Issue #:**

#908.

**Description of changes:**

This commit allows built SDK code to load in unsupported browsers that
don't include `globalThis`, and also adds an explicit support check to
reject those environments when evaluating support for Amazon Voice Focus.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

No.

> 2. How did you test these changes?

Running Voice Focus's own test suite. Integration tests will catch the rest.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

"Test" is a weird word here.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
