### PR TITLE
What happens when participants try to `startLocalVideoTile` when local video tile limit reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Documentation] What happens when participants try to `startLocalVideoTile` when local video tile limit reached
 
 ### Changed
 

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -166,6 +166,10 @@
 					</a>
 					<p>Amazon Chime SDK limits are defined <a href="https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-limits">here</a>. The service supports up to 250 attendees and up to 16 video participants in a meeting (video limit is enforced separately). An attendee is considered active unless it has been explicitly removed using DeleteAttendee API call. Attendee limits cannot be changed.</p>
 					<p>If your use case requires more than 250 attendees, consider using a <a href="https://github.com/aws-samples/amazon-chime-meeting-broadcast-demo">broadcasting solution</a>.</p>
+					<a href="#what-happens-to-the-subsequent-participants-who-try-to-turn-on-the-local-video-while-16-participants-have-already-turned-on-the-local-video" id="what-happens-to-the-subsequent-participants-who-try-to-turn-on-the-local-video-while-16-participants-have-already-turned-on-the-local-video" style="color: inherit; text-decoration: none;">
+						<h3>What happens to the subsequent participants who try to turn on the local video while 16 participants have already turned on the local video?</h3>
+					</a>
+					<p>Once the limit of 16 is reached in a meeting, for all the subsequent participants who try to turn on the local video, the SDK sets the Meeting Session status code to <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L73">VideoCallSwitchToViewOnly = 10</a> which in turn triggers the observer &#39;<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videosenddidbecomeunavailable">videoSendDidBecomeUnavailable</a>&#39;.</p>
 					<a href="#can-i-schedule-amazon-chime-sdk-meetings-ahead-of-time" id="can-i-schedule-amazon-chime-sdk-meetings-ahead-of-time" style="color: inherit; text-decoration: none;">
 						<h3>Can I schedule Amazon Chime SDK meetings ahead of time?</h3>
 					</a>

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -106,6 +106,10 @@ Amazon Chime SDK limits are defined [here](https://docs.aws.amazon.com/chime/lat
 
 If your use case requires more than 250 attendees, consider using a [broadcasting solution](https://github.com/aws-samples/amazon-chime-meeting-broadcast-demo).
 
+### What happens to the subsequent participants who try to turn on the local video while 16 participants have already turned on the local video?
+
+Once the limit of 16 is reached in a meeting, for all the subsequent participants who try to turn on the local video, the SDK sets the Meeting Session status code to [VideoCallSwitchToViewOnly = 10](https://github.com/aws/amazon-chime-sdk-js/blob/bfc4c600fb7e68f2d358ecb6c7fd096d30b2d430/src/meetingsession/MeetingSessionStatusCode.ts#L73) which in turn triggers the observer '[videoSendDidBecomeUnavailable](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideoobserver.html#videosenddidbecomeunavailable)'.
+
 ### Can I schedule Amazon Chime SDK meetings ahead of time?
 
 The Amazon Chime SDK does not support scheduling meetings ahead of time. The moment [CreateMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeeting.html) or 


### PR DESCRIPTION
**Issue #:**
Adding a FAQ section to let the developers know what happens when participants try to `startLocalVideoTile` when local video tile limit reached.

**Description of changes:**
Added a section in the FAQ

**Testing**
N/A

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
