### PR TITLE
Validate metrics data while showing video WebRTC stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow Amazon Voice Focus code to load (but not function) in unsupported
   browsers that do not define `globalThis`.
 - Fix uncaught promise exception for bindAudioOutput API
+- [Demo] Validate metrics data while showing video WebRTC stats
 
 ## [2.1.0] - 2020-11-23
 

--- a/demos/browser/app/meetingV2/webrtcstatscollector/WebRTCStatsCollector.ts
+++ b/demos/browser/app/meetingV2/webrtcstatscollector/WebRTCStatsCollector.ts
@@ -205,7 +205,7 @@ export default class WebRTCStatsCollector {
     keyStatstoShow: { [key: string]: string },
     metricsData: SSRCToMetricsData
   ) => {
-    const streams = Object.keys(metricsData);
+    const streams = metricsData ? Object.keys(metricsData) : [];
     if (streams.length === 0) {
       return;
     }

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4982,9 +4982,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.797.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.797.0.tgz",
-      "integrity": "sha512-fFc/2Xr7NkSXlZ9+2rCOFovA9NO1OnIyEaJFVwMM9gaqzucwRAfNNT0Pa1Kua5dhWrcf/mX0Z4mCDnTBf0/5mA==",
+      "version": "2.802.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.802.0.tgz",
+      "integrity": "sha512-PfjBr5Ag4PdcEYPrfMclVWk85kFSJNe7qllZBE8RhYNu+K+Z2pveKfYkC5mqYoKEYIQyI9by9N47F+Tqm1GXtg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.797.0",
+    "aws-sdk": "^2.802.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
-  Fixes `undefined` or `null` check while showing video WebRTC stats.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? By running the demo locally and checking the console for the errors.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? The browser demo app.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
