### PR TITLE
Fix meeting readiness checker speaker test failing in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow Amazon Voice Focus code to load (but not function) in unsupported
   browsers that do not define `globalThis`.
+- Fix meeting readiness checker speaker test failing in Safari
 - Fix uncaught promise exception for bindAudioOutput API
 
 ## [2.1.0] - 2020-11-23

--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
@@ -86,16 +86,19 @@
       <tr>
         <td class="text-left">Speaker</td>
         <td id="speaker-row">
-          <span id="speaker-test" class="badge badge-secondary">Not Started</span>
+          <button id="speakertest-button" type="button" class="btn btn-sm btn-secondary" title="Play tone">
+            Play Tone
+          </button>
+          <span id="speaker-test" class="badge badge-secondary" style="display:none">Not Started</span>
           <span id="speaker-user-feedback" style="display:none">
-                <span>Can you hear a sound?</span>
-                <label>
-                    <input type="radio" id="speaker-yes" name="user-feedback-reply" value="yes"/>Yes
-                </label>
-                <label>
-                    <input type="radio" id="speaker-no" name="user-feedback-reply" value="no"/>No
-                </label>
-              </span>
+            <span>Can you hear a sound?</span>
+            <label>
+                <input type="radio" id="speaker-yes" name="user-feedback-reply" value="yes"/>Yes
+            </label>
+            <label>
+                <input type="radio" id="speaker-no" name="user-feedback-reply" value="no"/>No
+            </label>
+          </span>
         </td>
       </tr>
       <tr>

--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -173,7 +173,14 @@ export class DemoMeetingApp {
     return device;
   };
 
+  speakerTest = async () => {
+    const button = document.getElementById('speakertest-button') as HTMLButtonElement;
+    button.disabled = false;
+  }
+
   audioTest = async () => {
+    const speakerTestResult = document.getElementById('speaker-test');
+    speakerTestResult.style.display = 'inline-block';
     this.createReadinessHtml('speaker-test', 'spinner-border');
     const audioOutput = await this.getAudioOutputDevice();
     let speakerUserFeedbackHtml = document.getElementById('speaker-user-feedback');
@@ -296,6 +303,17 @@ export class DemoMeetingApp {
     return networkUdpResp;
   };
 
+  continueTestExecution = async () => {
+    await this.micTest();
+    await this.videoTest();
+    await this.cameraTest();
+    await this.networkUdpTest();
+    await this.networkTcpTest();
+    await this.audioConnectivityTest();
+    await this.videoConnectivityTest();
+    await this.contentShareTest();
+  }
+
   createReadinessHtml(id: string, textToDisplay: string): void {
     const readinessElement = document.getElementById(id) as HTMLElement;
     readinessElement.innerHTML = '';
@@ -325,6 +343,14 @@ export class DemoMeetingApp {
       this.canHear = false;
     });
 
+    const speakerTestButton = document.getElementById('speakertest-button') as HTMLButtonElement;
+    speakerTestButton.addEventListener('click', async () => {
+      speakerTestButton.style.display = 'none';
+      await this.audioTest();
+      speakerTestButton.disabled = true;
+      await this.continueTestExecution();
+    });
+
     const contentShareButton = document.getElementById('contentshare-button') as HTMLButtonElement;
     contentShareButton.addEventListener('click', async () => {
       contentShareButton.style.display = 'none';
@@ -347,15 +373,7 @@ export class DemoMeetingApp {
         (document.getElementById('sdk-version') as HTMLSpanElement).innerText =
           'amazon-chime-sdk-js@' + Versioning.sdkVersion;
         this.createReadinessHtml('readiness-header', 'Readiness tests underway...');
-        await this.audioTest();
-        await this.micTest();
-        await this.videoTest();
-        await this.cameraTest();
-        await this.networkUdpTest();
-        await this.networkTcpTest();
-        await this.audioConnectivityTest();
-        await this.videoConnectivityTest();
-        await this.contentShareTest();
+        await this.speakerTest();
         this.createReadinessHtml('readiness-header', 'Readiness tests complete!');
       }
     });

--- a/integration/js/checks/MeetingReadinessCheckerAudioOutputCheck.js
+++ b/integration/js/checks/MeetingReadinessCheckerAudioOutputCheck.js
@@ -20,6 +20,7 @@ class MeetingReadinessCheckerAudioOutputCheck extends AppTestStep {
   }
 
   async run() {
+    await this.page.startSpeakerTest();
     const status = await this.page.checkSpeakerTestSucceed();
     this.logger('MeetingReadinessCheckerAudioOutputCheck: ' + (status ? 'Succeeded' : 'Failed'));
     if (!status) {

--- a/integration/js/pages/MeetingReadinessCheckerPage.js
+++ b/integration/js/pages/MeetingReadinessCheckerPage.js
@@ -3,6 +3,7 @@ const {TestUtils} = require('kite-common');
 
 const elements = {
   authenticateButton: By.id('authenticate'),
+  speakerTestButton: By.id('speakertest-button'),
   speakerTest: By.id('speaker-test'),
   speakerFeedbackYes: By.id('speaker-yes'),
   speakerFeedbackNo: By.id('speaker-no'),
@@ -45,6 +46,11 @@ class MeetingReadinessCheckerPage {
   async startContentShareConnectivityCheck() {
     let contentShareConnectivityCheckButton = await this.driver.findElement(elements.contentShareConnectivityTestButton);
     await contentShareConnectivityCheckButton.click();
+  }
+
+  async startSpeakerTest() {
+    let speakerTestButton = await this.driver.findElement(elements.speakerTestButton);
+    await speakerTestButton.click();
   }
 
   async speakerCheckFeedbackYes() {


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** In Safari, we cannot play a tone without having a user interaction. This was causing the speaker test in the meeting-readiness-checker app to not work as expected. To resolve this issue, we added a button to initiate the speaker test and play the tone.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Deployed the app and tested it works in Desktop Chrome, Chrome on Android, Firefox, Firefox on Android, Samsung browser on Android & Desktop Safari browser. 

Also ran the meeting readiness checker integration test and it succeeded.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes. Meeting readiness checker app.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
