### PR TITLE
Fix readiness checker canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow Amazon Voice Focus code to load (but not function) in unsupported
   browsers that do not define `globalThis`.
-- Fix meeting readiness checker speaker test failing in Safari
+- [Demo] Fix meeting readiness checker speaker test failing in Safari
 - Fix uncaught promise exception for bindAudioOutput API
 - [Demo] Validate metrics data while showing video WebRTC stats
 

--- a/integration/js/pages/MeetingReadinessCheckerPage.js
+++ b/integration/js/pages/MeetingReadinessCheckerPage.js
@@ -49,8 +49,11 @@ class MeetingReadinessCheckerPage {
   }
 
   async startSpeakerTest() {
-    let speakerTestButton = await this.driver.findElement(elements.speakerTestButton);
-    await speakerTestButton.click();
+    let spekerTestButtonExists = await this.driver.findElements(elements.speakerTestButton).size > 0;
+    if (spekerTestButtonExists) {
+      let speakerTestButton = await this.driver.findElement(elements.speakerTestButton);
+      await speakerTestButton.click();
+    }
   }
 
   async speakerCheckFeedbackYes() {


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Added a check to first verify speaker test button exists before clicking.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Ran the integ tests manually.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA. Only integ test changes

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
