### PR TITLE
Set automated integ test coverage on recent version of browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Log error if pass undefined device when calling choose input device
-- Doing typecheck for MediaDeviceInfo 
+- Doing typecheck for MediaDeviceInfo
+- Set automated integ test coverage on recent version of browsers
 
 ### Removed
 

--- a/integration/configs/app_quit_audio_test.config.json
+++ b/integration/configs/app_quit_audio_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "app_quit_audio_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "App Quit Audio Test %ts",
@@ -23,12 +22,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/app_quit_content_share_test.config.json
+++ b/integration/configs/app_quit_content_share_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "app_quit_content_share_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "App Quit Content Share Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/app_quit_video_test.config.json
+++ b/integration/configs/app_quit_video_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_end_video_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "App Quit Video Test %ts",
@@ -23,7 +22,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/audio_test.config.json
+++ b/integration/configs/audio_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "audio_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Audio Test %ts",
@@ -20,12 +19,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_join_later_test.config.json
+++ b/integration/configs/content_share_join_later_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "content_share_join_later_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Content Share Join Later Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_only_allow_two_test.config.json
+++ b/integration/configs/content_share_only_allow_two_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "content_share_only_allow_two_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Content Share Only Allow Two Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_screen_capture_test.config.json
+++ b/integration/configs/content_share_screen_capture_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "content_share_screen_capture_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Content Share Screen Capture %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_video_test.config.json
+++ b/integration/configs/content_share_video_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "content_share_video_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Content Share Video Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/data_message_test.config.json
+++ b/integration/configs/data_message_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "data_message_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Data Message %ts",
@@ -23,12 +22,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_end_test.config.json
+++ b/integration/configs/meeting_end_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_end_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Meeting End Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_audio_test.config.json
+++ b/integration/configs/meeting_leave_audio_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_leave_audio_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Meeting Leave Audio Test %ts",
@@ -23,12 +22,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_content_share_test.config.json
+++ b/integration/configs/meeting_leave_content_share_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_leave_content_share_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Meeting Leave Content Share Test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_video_test.config.json
+++ b/integration/configs/meeting_leave_video_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_end_video_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Meeting Leave Video Test %ts",
@@ -23,7 +22,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_readiness_checker_test.config.json
+++ b/integration/configs/meeting_readiness_checker_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "meeting_readiness_checker_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Meeting readiness checker all checks pass test %ts",
@@ -19,12 +18,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/messaging_session_test.config.json
+++ b/integration/configs/messaging_session_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "messaging_session_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Messaging Session Test %ts",
@@ -20,7 +19,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/reconnection_test.config.json
+++ b/integration/configs/reconnection_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "reconnection_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Reconnection Test %ts",
@@ -23,7 +22,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/video_test.config.json
+++ b/integration/configs/video_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "video_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Video Test %ts",
@@ -20,7 +19,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/video_test_simulcast.config.json
+++ b/integration/configs/video_test_simulcast.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "video_test_simulcast.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Video Test Simulcast %ts",
@@ -21,7 +20,7 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/voice_focus_test.config.json
+++ b/integration/configs/voice_focus_test.config.json
@@ -1,8 +1,7 @@
 {
   "`": 1,
   "name": "voice_focus_test.config.json %ts",
-  "grids": [
-  ],
+  "grids": [],
   "tests": [
     {
       "name": "Voice Focus Offered Test %ts",
@@ -32,12 +31,12 @@
   "clients": [
     {
       "browserName": "chrome",
-      "version": "78",
+      "version": "latest",
       "platform": "MAC"
     },
     {
       "browserName": "firefox",
-      "version": "76",
+      "version": "latest",
       "platform": "MAC"
     }
   ]


### PR DESCRIPTION
**Issue #:**  Chime SDK Team has an operation gap with no automated coverage on recent versions of Chrome, Firefox and Safari

**Description of changes:**  Config all test cases to be tested using latest version of Chrome/FF/Safari browsers. 

**Testing**

1. Have you successfully run `npm run build:release` locally?  Yes
2. How did you test these changes?  Tested against SauceLabs and verified it used the latest browsers. 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
