### PR TITLE
Correct meeting readiness checker output device selection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Binding audio elements will no longer throw an error unless calling code is
   trying to choose an output device in a browser that does not support
   `setSinkId`, and the demo will not log an error in these cases.
+- [Demo] The meeting readiness checker no longer re-initializes the device output list
+  after the user picked a device.
 
 ## [2.2.0] - 2020-12-04
 

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4982,9 +4982,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.804.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.804.0.tgz",
-      "integrity": "sha512-a02pZdjL06MunElAZPPEjpghOp/ZA+16f+t4imh1k9FCDpsNVQrT23HRq/PMvRADA5uZZRkYwX8r9o6oH/1RlA==",
+      "version": "2.805.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.805.0.tgz",
+      "integrity": "sha512-mnIiHWp541pappZPJs+P6bx18yIcJTTr4eu2n0aF9+MY4UteuFWRu0fGLssYnDwCHvtzN7/j776Pd/1QXy9hqg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.804.0",
+    "aws-sdk": "^2.805.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
Rebase of #934.

**Description of changes:**

The checker calls `populateAllDeviceLists` twice, once in `initParameters` and once in `initializeMeetingSession`.

That re-lists the output devices, and blows away the selection list for output devices, so each time you try to test speakers, it will only test the built-in device.

As far as I can tell, the only reason for this is so that we can change the logger once we know where the log stream should go. This commit implements a swappable logger, initializing the device controller only once, and switching out the logger when we have the meeting configuration.

N.B., this PR is on top of #930 to avoid having to rebase the changelog.


**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

Manually in Chrome.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

This change only affects the readiness checker demo.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
