### PR TITLE
Fix voice focus integration/canary test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `setSinkId`, and the demo will not log an error in these cases.
 - [Demo] The meeting readiness checker no longer re-initializes the device output list
   after the user picked a device.
+- [Test] Fix voice focus integration/canary test.
 
 ## [2.2.0] - 2020-12-04
 

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -103,7 +103,7 @@ class SdkBaseTest extends KiteBaseTest {
       this.io.emit("setup_test", this.baseUrl, this.attendeeId);
     } else {
       this.meetingTitle = uuidv4();
-      if (this.testName === 'ContentShareOnlyAllowTwoTest') {
+      if (this.originalURL.indexOf('?') !== -1) {
         this.url = this.originalURL + '&m=' + this.meetingTitle;
       } else {
         this.url = this.originalURL + '?m=' + this.meetingTitle;


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Fix voice focus canary/integration test to use `&m=<meeting-id>` instead of `?m=<meeting-id>` as there are already multiple other query params appended to the demo app URL for the voice focus tests.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Ran the integration tests for voice focus and content share locally and verified the tests succeed.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
NA. These are integration test changes. Can be verified by checking the results of integration/canary tests.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
