### PR TITLE
Bump highlight.js from 10.2.0 to 10.4.1 and update guide files

### DIFF
--- a/docs/modules/amazonvoice_focus.html
+++ b/docs/modules/amazonvoice_focus.html
@@ -204,7 +204,7 @@ because <span class="hljs-keyword">it</span> violates <span class="hljs-keyword"
 					<p>By default this will also pre-load the model file and prepare Amazon Voice Focus for use. Failure to load necessary resources will result in <code>isSupported</code> returning <code>false</code>. If you do not want to pre-load resources — <em>e.g.</em>, if you would rather the download occur later, or you are not sure if the user will use noise suppression — pass the optional <code>preload</code> argument:</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">const</span> spec = {};
 <span class="hljs-keyword">const</span> options = {
-  preload: <span class="hljs-literal">false</span>,
+  <span class="hljs-attr">preload</span>: <span class="hljs-literal">false</span>,
   logger,
 };
 
@@ -212,7 +212,7 @@ transformer = <span class="hljs-keyword">await</span> VoiceFocusDeviceTransforme
 					<p>Check for both of these kinds of support prior to offering noise suppression to users. The ideal time to do so is during pre-meeting setup.</p>
 					<p>Your device controller must support Web Audio to use Amazon Voice Focus. If you do not wish to enable Web Audio universally, you can use your support check as a condition:</p>
 					<pre><code class="language-typescript"><span class="hljs-built_in">this</span>.deviceController = <span class="hljs-keyword">new</span> DefaultDeviceController({
-  enableWebAudio: isVoiceFocusSupported
+  <span class="hljs-attr">enableWebAudio</span>: isVoiceFocusSupported
 });</code></pre>
 					<a href="#adding-amazon-voice-focus-to-your-application" id="adding-amazon-voice-focus-to-your-application" style="color: inherit; text-decoration: none;">
 						<h2>Adding Amazon Voice Focus to your application</h2>
@@ -284,17 +284,17 @@ transformer = <span class="hljs-keyword">await</span> VoiceFocusDeviceTransforme
 					<p>If you specify a non-<code>auto</code> <code>executionPreference</code> and a <code>variant</code>, no estimation work will be done: the SDK will use the values you provide. If you additionally specify <code>simd</code>, the execution approach chosen is predictable and fixed, and no capability testing or estimation is required.</p>
 					<p>For example, to force the use of a high-quality model in an Electron application built with SIMD enabled:</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">const</span> spec: VoiceFocusSpec = {
-  variant: <span class="hljs-string">&#x27;c50&#x27;</span>,
-  executionPreference: <span class="hljs-string">&#x27;inline&#x27;</span>,
-  simd: <span class="hljs-string">&#x27;force&#x27;</span>,
+  <span class="hljs-attr">variant</span>: <span class="hljs-string">&#x27;c50&#x27;</span>,
+  <span class="hljs-attr">executionPreference</span>: <span class="hljs-string">&#x27;inline&#x27;</span>,
+  <span class="hljs-attr">simd</span>: <span class="hljs-string">&#x27;force&#x27;</span>,
 };
 
 <span class="hljs-keyword">const</span> transformer = VoiceFocusDeviceTransformer.create(spec, { logger });</code></pre>
 					<p>or to force the use of the highest quality model, which typically requires offload to a Web Worker:</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">const</span> spec: VoiceFocusSpec = {
-  variant: <span class="hljs-string">&#x27;c100&#x27;</span>,
-  executionPreference: <span class="hljs-string">&#x27;worker&#x27;</span>,
-  simd: <span class="hljs-string">&#x27;force&#x27;</span>,
+  <span class="hljs-attr">variant</span>: <span class="hljs-string">&#x27;c100&#x27;</span>,
+  <span class="hljs-attr">executionPreference</span>: <span class="hljs-string">&#x27;worker&#x27;</span>,
+  <span class="hljs-attr">simd</span>: <span class="hljs-string">&#x27;force&#x27;</span>,
 };
 
 <span class="hljs-keyword">const</span> transformer = VoiceFocusDeviceTransformer.create(spec, { logger });</code></pre>

--- a/docs/modules/meetingevents.html
+++ b/docs/modules/meetingevents.html
@@ -77,7 +77,7 @@
 					You can use meeting events to identify and troubleshoot the cause of device and meeting failures.</p>
 					<p>To receive meeting events, add an observer, and implement the <code>eventDidReceive</code> observer method.</p>
 					<pre><code class="language-js"><span class="hljs-keyword">const</span> observer = {
-  eventDidReceive(name, attributes) {
+  <span class="hljs-function"><span class="hljs-title">eventDidReceive</span>(<span class="hljs-params">name, attributes</span>)</span> {
     <span class="hljs-comment">// Handle a meeting event.</span>
   }
 }
@@ -86,7 +86,7 @@ meetingSession.audioVideo.addObserver(observer);</code></pre>
 					<p>In the <code>eventDidReceive</code> observer method, we recommend that you handle each meeting event so that
 					you don&#39;t have to worry about how your event processing would scale when the later versions of Chime SDK introduce new meeting events.</p>
 					<p>For example, the code outputs error information for four failure events at the &quot;error&quot; log level.</p>
-					<pre><code class="language-js">eventDidReceive(name, attributes) {
+					<pre><code class="language-js"><span class="hljs-function"><span class="hljs-title">eventDidReceive</span>(<span class="hljs-params">name, attributes</span>)</span> {
   <span class="hljs-keyword">switch</span> (name) {
     <span class="hljs-keyword">case</span> <span class="hljs-string">&#x27;audioInputFailed&#x27;</span>:
       <span class="hljs-built_in">console</span>.error(<span class="hljs-string">`Failed to choose microphone: <span class="hljs-subst">${attributes.audioInputErrorMessage}</span> in `</span>, attributes);
@@ -106,7 +106,7 @@ meetingSession.audioVideo.addObserver(observer);</code></pre>
 					<p>Ensure that you are familiar with the attributes you want to use. See the following two examples.</p>
 					<p>The code logs the last 5 minutes of the <code>meetingHistory</code> attribute when a failure event occurs.
 					It&#39;s helpful to reduce the amount of data sent to your server application or analytics tool.</p>
-					<pre><code class="language-js">eventDidReceive(name, attributes) {
+					<pre><code class="language-js"><span class="hljs-function"><span class="hljs-title">eventDidReceive</span>(<span class="hljs-params">name, attributes</span>)</span> {
   <span class="hljs-keyword">const</span> { meetingHistory, ...otherAttributes } = attributes;
   <span class="hljs-keyword">const</span> recentMeetingHistory = meetingHistory.filter(<span class="hljs-function">(<span class="hljs-params">{ timestampMs }</span>) =&gt;</span> {
     <span class="hljs-keyword">return</span> <span class="hljs-built_in">Date</span>.now() - timestampMs &lt; <span class="hljs-number">5</span> * <span class="hljs-number">60</span> * <span class="hljs-number">1000</span>;
@@ -128,7 +128,7 @@ meetingSession.audioVideo.addObserver(observer);</code></pre>
 }</code></pre>
 					<p>This example prints out the <code>meetingStatus</code> attribute if it&#39;s available.
 					See the &quot;Included in&quot; column in the meeting and device attribute tables below for more information.</p>
-					<pre><code class="language-js">eventDidReceive(name, attributes) {
+					<pre><code class="language-js"><span class="hljs-function"><span class="hljs-title">eventDidReceive</span>(<span class="hljs-params">name, attributes</span>)</span> {
   <span class="hljs-keyword">if</span> (attributes.hasOwnProperty(<span class="hljs-string">&#x27;meetingStatus&#x27;</span>)) {
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`The meeting ended with the status: <span class="hljs-subst">${attributes.meetingStatus}</span> in `</span>, attributes);
   }

--- a/docs/modules/migrationto_2_0.html
+++ b/docs/modules/migrationto_2_0.html
@@ -115,7 +115,7 @@ configuration.enableWebAudio = <span class="hljs-literal">true</span>;
 					<p>change it to</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">const</span> configuration = <span class="hljs-keyword">new</span> MeetingSessionConfiguration(…);
 …
-<span class="hljs-keyword">const</span> deviceController = <span class="hljs-keyword">new</span> DefaultDeviceController(logger, { enableWebAudio: <span class="hljs-literal">true</span> });
+<span class="hljs-keyword">const</span> deviceController = <span class="hljs-keyword">new</span> DefaultDeviceController(logger, { <span class="hljs-attr">enableWebAudio</span>: <span class="hljs-literal">true</span> });
 <span class="hljs-built_in">this</span>.meetingSession = <span class="hljs-keyword">new</span> DefaultMeetingSession(configuration, logger, deviceController);
 <span class="hljs-built_in">this</span>.audioVideo = <span class="hljs-built_in">this</span>.meetingSession.audioVideo;</code></pre>
 					<p>If your code looked like this:</p>
@@ -154,14 +154,14 @@ bindAudioStream(stream: MediaStream): <span class="hljs-built_in">Promise</span>
 bindAudioDevice(device: MediaDeviceInfo | <span class="hljs-literal">null</span>): <span class="hljs-built_in">Promise</span>&lt;<span class="hljs-built_in">void</span>&gt;;</code></pre>
 					<p>Additionally, <code>AudioMixController</code>&#39;s constructor now takes an additional optional <code>logger</code> parameter.
 					If the <code>logger</code> is passed, it will log the errors for any of the operations in <code>AudioMixController</code>.</p>
-					<pre><code class="language-typescript"><span class="hljs-keyword">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> logger?: Logger</span>) {}</code></pre>
+					<pre><code class="language-typescript"><span class="hljs-function"><span class="hljs-title">constructor</span>(<span class="hljs-params"><span class="hljs-keyword">private</span> logger?: Logger</span>)</span> {}</code></pre>
 					<p>If your code looked like this</p>
-					<pre><code class="language-typescript">audioMixController.bindAudioDevice({ deviceId: sinkId });
+					<pre><code class="language-typescript">audioMixController.bindAudioDevice({ <span class="hljs-attr">deviceId</span>: sinkId });
 audioMixController.bindAudioElement(<span class="hljs-keyword">new</span> Audio());
 audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
 					<p>change it to</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">try</span> {
-  <span class="hljs-keyword">await</span> audioMixController.bindAudioDevice({ deviceId: <span class="hljs-built_in">this</span>.sinkId });
+  <span class="hljs-keyword">await</span> audioMixController.bindAudioDevice({ <span class="hljs-attr">deviceId</span>: <span class="hljs-built_in">this</span>.sinkId });
 } <span class="hljs-keyword">catch</span> (e) {
   <span class="hljs-built_in">console</span>.error(<span class="hljs-string">&#x27;Failed to bind audio device&#x27;</span>, e);
 }
@@ -188,7 +188,7 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
 					<p>Because <code>chooseAudioInputDevice</code> and <code>chooseVideoInputDevice</code> now have new type signatures, if
 					you implement the related interfaces (<code>AudioVideoFacade</code> or <code>DeviceController</code>) yourself, you will need to adjust your code.</p>
 					<p>If you have an implementation like:</p>
-					<pre><code class="language-typescript"><span class="hljs-keyword">class</span> MyDeviceController <span class="hljs-keyword">implements</span> DeviceController {
+					<pre><code class="language-typescript"><span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyDeviceController</span> <span class="hljs-title">implements</span> <span class="hljs-title">DeviceController</span> </span>{
   <span class="hljs-keyword">async</span> chooseAudioInputDevice(device: Device): <span class="hljs-built_in">Promise</span>&lt;<span class="hljs-built_in">void</span>&gt; {
     <span class="hljs-comment">// device must be a string, stream, constraints, or null.</span>
     <span class="hljs-comment">// …</span>
@@ -201,7 +201,7 @@ audioMixController.bindAudioStream(destinationStream.stream);</code></pre>
   isAudioTransformDevice,
 } <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;amazon-chime-sdk-js&#x27;</span>;
 
-<span class="hljs-keyword">class</span> MyDeviceController <span class="hljs-keyword">implements</span> DeviceController {
+<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyDeviceController</span> <span class="hljs-title">implements</span> <span class="hljs-title">DeviceController</span> </span>{
   <span class="hljs-keyword">async</span> chooseAudioInputDevice(device: AudioInputDevice): <span class="hljs-built_in">Promise</span>&lt;<span class="hljs-built_in">void</span>&gt; {
     <span class="hljs-keyword">if</span> (isAudioTransformDevice(device)) {
       <span class="hljs-comment">// Handle transform devices, should you need to.</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.0.tgz",
-      "integrity": "sha512-OryzPiqqNCfO/wtFo619W+nPYALM6u7iCQkum4bqRmmlcTikOkmlL06i009QelynBPAlNByTQU6cBB2cOBQtCw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
       "dev": true
     },
     "html-escaper": {


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Update the `highlight.js` library from 10.2.0 to 10.4.1. Amazon Chime SDK for JavaScript depends on the `typedoc` library for generating documents from TypeScript. The `typedoc` library is using `highlight.js`.
- Some guide files were automatically updated with the `highlight.js` 10.4.1. The embedded code is injected into a span element.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? `npm run build:release` includes the document generation using the `typedoc` library. This PR doesn't affect source code.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
