### PR TITLE
Additional best practices around choosing audio output devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `setSinkId`, and the demo will not log an error in these cases.
 - [Demo] The meeting readiness checker no longer re-initializes the device output list
   after the user picked a device.
+- [Demo] Additional best practices around choosing audio output devices.
 
 ## [2.2.0] - 2020-12-04
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -133,11 +133,13 @@ class TestSound {
     gainNode.gain.linearRampToValueAtTime(0, startTime + this.rampSec * 2 + this.durationSec);
     oscillatorNode.start();
     const audioMixController = new DefaultAudioMixController(this.logger);
-    try {
-      // @ts-ignore
-      await audioMixController.bindAudioDevice({ deviceId: this.sinkId });
-    } catch (e) {
-      this.logger?.error(`Failed to bind audio device: ${e}`);
+    if (new DefaultBrowserBehavior().supportsSetSinkId()) {
+      try {
+        // @ts-ignore
+        await audioMixController.bindAudioDevice({ deviceId: this.sinkId });
+      } catch (e) {
+        this.logger?.error(`Failed to bind audio device: ${e}`);
+      }
     }
     try {
       await audioMixController.bindAudioElement(new Audio());
@@ -1626,11 +1628,13 @@ export class DemoMeetingApp implements
   }
 
   async openAudioOutputFromSelection(): Promise<void> {
-    const audioOutput = document.getElementById('audio-output') as HTMLSelectElement;
-    try {
-      await this.audioVideo.chooseAudioOutputDevice(audioOutput.value);
-    } catch (e) {
-      this.log('failed to chooseAudioOutputDevice', e);
+    if (this.defaultBrowserBehaviour.supportsSetSinkId()) {
+      try {
+        const audioOutput = document.getElementById('audio-output') as HTMLSelectElement;
+        await this.audioVideo.chooseAudioOutputDevice(audioOutput.value);
+      } catch (e) {
+        this.log('failed to chooseAudioOutputDevice', e);
+      }
     }
     const audioMix = document.getElementById('meeting-audio') as HTMLAudioElement;
     try {

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4982,9 +4982,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.805.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.805.0.tgz",
-      "integrity": "sha512-mnIiHWp541pappZPJs+P6bx18yIcJTTr4eu2n0aF9+MY4UteuFWRu0fGLssYnDwCHvtzN7/j776Pd/1QXy9hqg==",
+      "version": "2.806.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.806.0.tgz",
+      "integrity": "sha512-kCrGfZyzZiS56qblXEzznkTi64ZbzhQGlbyEjDI9cIUjX4dA9IyqvNWUdJvUQoZmiEnObbuXMVrv7blJzT8uhQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.805.0",
+    "aws-sdk": "^2.806.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
**Description of changes:**

In testing I noticed two places in the demo app that were missing `setSinkId` guards. Might as well fix those.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

No. This is a demo-only change.

> 2. How did you test these changes?

Meeting demo in Chrome and Safari.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

See above.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
