### PR TITLE
Add fatal error catching to the demo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Demo] Fatal errors in the demo will now cause a fatal screen if `fatal=1` is present in the
+  URL, or if the demo is running locally.
+
 ### Changed
 
 ### Removed

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -8,8 +8,16 @@
 </head>
 <body>
 
-<!-- Initial meeting authentication screen with meeting and name inputs -->
+<div id="flow-fatal" class="flow">
+  <div style="vertical-align: middle; text-align: left; width: 40%; margin: 10em 30% 10em 30%;">
+  <h1>Fatal error</h1>
+  <p>An error was thrown that should not occur in ordinary use. This should be considered a fatal error for testing and canary purposes.</p>
+  <p>This error will ordinarily be muffled, but you should consider removing this code if you are building an app based on this demo.</p>
+  <code id="stack"></code>
+  </div>
+</div>
 
+<!-- Initial meeting authentication screen with meeting and name inputs -->
 <div id="flow-authenticate" class="flow text-center p-2">
   <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="sdk-version"></div>
   <div class="container">

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -392,6 +392,23 @@ svg {
   visibility: hidden;
 }
 
+#flow-fatal {
+  width: 100%;
+  height: 100%;
+  vertical-align: middle;
+  background-color: darkred;
+}
+
+#flow-fatal h1 {
+  color: ghostwhite;
+  -webkit-text-stroke: white 1px;
+  text-shadow: 0 0 1px $gray-900;
+}
+
+#flow-fatal p {
+  color: ghostwhite;
+}
+
 #flow-meeting {
   min-width: 320px;
 }

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4982,9 +4982,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.806.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.806.0.tgz",
-      "integrity": "sha512-kCrGfZyzZiS56qblXEzznkTi64ZbzhQGlbyEjDI9cIUjX4dA9IyqvNWUdJvUQoZmiEnObbuXMVrv7blJzT8uhQ==",
+      "version": "2.807.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.807.0.tgz",
+      "integrity": "sha512-C8eJlA/Sqwowbz4NupphwS5xFbaGkBCJetHzu+VjtmTPfg2AMpfh0Uqp5hG9qiiC1UjVlqlut99l5W9ZBGGj/w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.806.0",
+    "aws-sdk": "^2.807.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
This change introduces the Red Screen of Death, which will be shown if
an unexpected error is thrown during execution, even if that error would
otherwise have been caught by code in the demo app.

<img width="832" alt="Screen Shot 2020-12-09 at Dec 9 11 41 20 " src="https://user-images.githubusercontent.com/40039049/101681325-d6a8a480-3a16-11eb-8736-74bec3aef7ae.png">

This is largely manual: each time you add a catch block that *should
never be hit*, add a call to `fatal(err)`. Catch blocks that catch
routine failures (e.g., the browser not supporting Voice Focus) should
not add a call to `fatal`.

However, this change also adds a top-level unhandled promise rejection
listener, and a top-level error listener. These will cause fatal errors
to be detected in e.g., async tasks.

You can test this with something like:

```
setTimeout(() => Promise.reject(new Error('oh no')), 2000)
```

This change should be sufficient to alert developers and integration
tests to new programming errors.

This commit adds the following URL query params to the demo:

* `testfatal=1`: if provided, this will show the fatal error page.
* `fatal=0`: if provided, fatal errors will be ignored, even for
  localhost.
* `fatal=1`: if provided, fatal errors will cause a Red Screen of Death,
  even when not testing locally.

The default is for the Red Screen of Death to be shown if loading from
`127.0.0.1:8080` only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
