### PR TITLE
Add fatal error catching to the demo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Demo] Fatal errors in the demo will now cause a fatal screen if `fatal=1` is present in the
+  URL, or if the demo is running locally.
+
 ### Changed
 
 ### Removed

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -8,8 +8,16 @@
 </head>
 <body>
 
-<!-- Initial meeting authentication screen with meeting and name inputs -->
+<div id="flow-fatal" class="flow">
+  <div style="vertical-align: middle; text-align: left; width: 40%; margin: 10em 30% 10em 30%;">
+  <h1>Fatal error</h1>
+  <p>An error was thrown that should not occur in ordinary use. This should be considered a fatal error for testing and canary purposes.</p>
+  <p>This error will ordinarily be muffled, but you should consider removing this code if you are building an app based on this demo.</p>
+  <code id="stack"></code>
+  </div>
+</div>
 
+<!-- Initial meeting authentication screen with meeting and name inputs -->
 <div id="flow-authenticate" class="flow text-center p-2">
   <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="sdk-version"></div>
   <div class="container">

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -46,7 +46,17 @@ import {
   VoiceFocusTransformDevice,
   isAudioTransformDevice,
 } from '../../../../src/index';
+
 import WebRTCStatsCollector from './webrtcstatscollector/WebRTCStatsCollector';
+
+const SHOULD_DIE_ON_FATALS = (() => {
+  const isLocal = document.location.host === '127.0.0.1:8080';
+  const fatalYes = document.location.search.includes('fatal=1');
+  const fatalNo = document.location.search.includes('fatal=0');
+  return fatalYes || (isLocal && !fatalNo);
+})();
+
+let fatal: (e: Error) => void;
 
 class DemoTileOrganizer {
   // this is index instead of length
@@ -138,12 +148,14 @@ class TestSound {
         // @ts-ignore
         await audioMixController.bindAudioDevice({ deviceId: this.sinkId });
       } catch (e) {
+        fatal(e);
         this.logger?.error(`Failed to bind audio device: ${e}`);
       }
     }
     try {
       await audioMixController.bindAudioElement(new Audio());
     } catch (e) {
+      fatal(e);
       this.logger?.error(`Failed to bind audio element: ${e}`);
     }
     await audioMixController.bindAudioStream(destinationStream.stream);
@@ -248,6 +260,18 @@ export class DemoMeetingApp implements
   constructor() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).app = this;
+
+    fatal = this.fatal.bind(this);
+
+    // Listen for unhandled errors, too.
+    window.addEventListener('error', (event) => { fatal(event.error); });
+    window.onunhandledrejection = (event: PromiseRejectionEvent) => { fatal(event.reason); };
+
+    if (document.location.search.includes('testfatal=1')) {
+      this.fatal(new Error('Testing fatal.'));
+      return;
+    }
+
     (document.getElementById('sdk-version') as HTMLSpanElement).innerText =
       "amazon-chime-sdk-js@" + Versioning.sdkVersion;
     this.initEventListeners();
@@ -266,6 +290,24 @@ export class DemoMeetingApp implements
     } else {
       this.switchToFlow('flow-authenticate');
     }
+  }
+
+  /**
+   * We want to make it abundantly clear at development and testing time
+   * when an unexpected error occurs.
+   * If we're running locally, or we passed a `fatal=1` query parameter, fail hard.
+   */
+  fatal(e: Error): void {
+    // Muffle mode: let the `try-catch` do its job.
+    if (!SHOULD_DIE_ON_FATALS) {
+      console.info('Ignoring fatal', e);
+      return;
+    }
+
+    console.error('Fatal error: this was going to be caught, but should not have been thrown.', e);
+    document.getElementById('stack').innerText = e.message + '\n' + e.stack?.toString();
+
+    this.switchToFlow('flow-fatal');
   }
 
   initParameters(): void {
@@ -376,6 +418,7 @@ export class DemoMeetingApp implements
               true
             );
           } catch (err) {
+            fatal(err);
             this.log('no video input device selected');
           }
           await this.openAudioOutputFromSelection();
@@ -458,6 +501,7 @@ export class DemoMeetingApp implements
       try {
         await this.openVideoInputFromSelection(videoInput.value, true);
       } catch (err) {
+        fatal(err);
         this.log('no video input device selected');
       }
     });
@@ -479,6 +523,7 @@ export class DemoMeetingApp implements
       try {
         await this.openVideoInputFromSelection(videoInput.value, true);
       } catch (err) {
+        fatal(err);
         this.log('no video input device selected');
       }
     });
@@ -543,6 +588,7 @@ export class DemoMeetingApp implements
             await this.openVideoInputFromSelection(camera, false);
             this.audioVideo.startLocalVideoTile();
           } catch (err) {
+            fatal(err);
             this.log('no video input device selected');
           }
         } else {
@@ -586,6 +632,7 @@ export class DemoMeetingApp implements
               'meeting-audio'
             ) as HTMLAudioElement);
           } catch (e) {
+            fatal(e);
             this.log('Failed to bindAudioElement', e);
           }
         } else {
@@ -700,6 +747,7 @@ export class DemoMeetingApp implements
           }
           (document.getElementById('inputRegion') as HTMLInputElement).value = nearestMediaRegion;
         } catch (error) {
+          fatal(error);
           this.log('Default media region selected: ' + error.message);
         }
       });
@@ -888,6 +936,7 @@ export class DemoMeetingApp implements
         console.log('[DEMO] log stream created');
       }
     } catch (error) {
+      fatal(error);
       this.log(error.message);
     }
   }
@@ -1480,6 +1529,7 @@ export class DemoMeetingApp implements
         try {
           await this.openVideoInputFromSelection(name, false);
         } catch (err) {
+          fatal(err);
           this.log('no video input device selected');
         }
       }
@@ -1514,6 +1564,7 @@ export class DemoMeetingApp implements
         try {
           await this.audioVideo.chooseAudioOutputDevice(name);
         } catch (e) {
+          fatal(e);
           this.log('Failed to chooseAudioOutputDevice', e)
         }
       }
@@ -1534,6 +1585,7 @@ export class DemoMeetingApp implements
     try {
       await this.audioVideo.chooseAudioInputDevice(device);
     } catch (e) {
+      fatal(e);
       this.log(`failed to choose audio input device ${device}`, e);
     }
     this.updateVoiceFocusDisplayState();
@@ -1633,6 +1685,7 @@ export class DemoMeetingApp implements
         const audioOutput = document.getElementById('audio-output') as HTMLSelectElement;
         await this.audioVideo.chooseAudioOutputDevice(audioOutput.value);
       } catch (e) {
+        fatal(e);
         this.log('failed to chooseAudioOutputDevice', e);
       }
     }
@@ -1640,6 +1693,7 @@ export class DemoMeetingApp implements
     try {
       await this.audioVideo.bindAudioElement(audioMix);
     } catch (e) {
+      fatal(e);
       this.log('failed to bindAudioElement', e);
     }
   }
@@ -1664,6 +1718,7 @@ export class DemoMeetingApp implements
       try {
         await this.audioVideo.chooseVideoInputDevice(device);
       } catch (e) {
+        fatal(e);
         this.log(`failed to chooseVideoInputDevice ${device}`, e);
       }
       throw new Error('no video device selected');
@@ -1671,6 +1726,7 @@ export class DemoMeetingApp implements
     try {
       await this.audioVideo.chooseVideoInputDevice(device);
     } catch (e) {
+      fatal(e);
       this.log(`failed to chooseVideoInputDevice ${device}`, e);
     }
 

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -392,6 +392,23 @@ svg {
   visibility: hidden;
 }
 
+#flow-fatal {
+  width: 100%;
+  height: 100%;
+  vertical-align: middle;
+  background-color: darkred;
+}
+
+#flow-fatal h1 {
+  color: ghostwhite;
+  -webkit-text-stroke: white 1px;
+  text-shadow: 0 0 1px $gray-900;
+}
+
+#flow-fatal p {
+  color: ghostwhite;
+}
+
 #flow-meeting {
   min-width: 320px;
 }

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4982,9 +4982,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.806.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.806.0.tgz",
-      "integrity": "sha512-kCrGfZyzZiS56qblXEzznkTi64ZbzhQGlbyEjDI9cIUjX4dA9IyqvNWUdJvUQoZmiEnObbuXMVrv7blJzT8uhQ==",
+      "version": "2.807.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.807.0.tgz",
+      "integrity": "sha512-C8eJlA/Sqwowbz4NupphwS5xFbaGkBCJetHzu+VjtmTPfg2AMpfh0Uqp5hG9qiiC1UjVlqlut99l5W9ZBGGj/w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.806.0",
+    "aws-sdk": "^2.807.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",


### PR DESCRIPTION
This change introduces the Red Screen of Death, which will be shown if
an unexpected error is thrown during execution, even if that error would
otherwise have been caught by code in the demo app.

<img width="832" alt="Screen Shot 2020-12-09 at Dec 9 11 41 20 " src="https://user-images.githubusercontent.com/40039049/101681325-d6a8a480-3a16-11eb-8736-74bec3aef7ae.png">

This is largely manual: each time you add a catch block that *should
never be hit*, add a call to `fatal(err)`. Catch blocks that catch
routine failures (e.g., the browser not supporting Voice Focus) should
not add a call to `fatal`.

However, this change also adds a top-level unhandled promise rejection
listener, and a top-level error listener. These will cause fatal errors
to be detected in e.g., async tasks.

You can test this with something like:

```
setTimeout(() => Promise.reject(new Error('oh no')), 2000)
```

This change should be sufficient to alert developers and integration
tests to new programming errors.

This commit adds the following URL query params to the demo:

* `testfatal=1`: if provided, this will show the fatal error page.
* `fatal=0`: if provided, fatal errors will be ignored, even for
  localhost.
* `fatal=1`: if provided, fatal errors will cause a Red Screen of Death,
  even when not testing locally.

The default is for the Red Screen of Death to be shown if loading from
`127.0.0.1:8080` only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


(#940 pushed to `origin`)