### PR TITLE
Add logging for UDP or TCP/TLS protocol being used for audio/video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Demo] Fatal errors in the demo will now cause a fatal screen if `fatal=1` is present in the
   URL, or if the demo is running locally.
+- [Demo] Add logging for UDP or TCP/TLS protocol being used for audio/video
 
 ### Changed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -645,6 +645,8 @@ export class DemoMeetingApp implements
     buttonVideoStats.addEventListener('click', () => {
       if (this.isButtonOn('button-video-stats')) {
         document.querySelectorAll('.stats-info').forEach(e => e.remove());
+      } else {
+        this.getRelayProtocol();
       }
       this.toggleButton('button-video-stats');
     });
@@ -903,7 +905,25 @@ export class DemoMeetingApp implements
         this.statsCollector.showDownstreamStats(tileIndex);
       }
     }
+  }
 
+  async getRelayProtocol() {
+    const rawStats = await this.audioVideo.getRTCPeerConnectionStats();
+    if (rawStats) {
+      rawStats.forEach(report => {
+        if (report.type === 'local-candidate') {
+          this.log(`Local WebRTC Ice Candidate stats: ${JSON.stringify(report)}`);
+          const relayProtocol = report.relayProtocol;
+          if (typeof relayProtocol === 'string') {
+            if (relayProtocol === 'udp') {
+              this.log(`Connection using ${relayProtocol.toUpperCase()} protocol`);
+            } else {
+              this.log(`Connection fell back to ${relayProtocol.toUpperCase()} protocol`);
+            }
+          }
+        }
+      });
+    }
   }
 
   async getStats(tileIndex: number) {


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/904

**Description of changes:** Currently in the SDK code, we do not have a way to identify whether the meeting is using `UDP` or has it fallen back to `TCP/TLS`. This PR adds a quick way to check which protocol is being used currently.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Tested it by running the demo app. Also added the same logic in the `TCP` & `UDP` connectivity check in the readiness-checker and verified it works there as well.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes. Serverless demo app.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA. Just demo changes.

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
