### PR TITLE
Fix issue - audio in demo app cannot be recorded by amazon-chime-sdk-recording-demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- [Demo] Fix audio cannot be recorded issue
 
 ## [2.2.1] - 2020-12-11
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -283,6 +283,7 @@ export class DemoMeetingApp implements
         this.meeting = new URL(window.location.href).searchParams.get('m');
         this.name = this.isRecorder() ? '«Meeting Recorder»' : '«Meeting Broadcaster»';
         await this.authenticate();
+        await this.openAudioOutputFromSelection();
         await this.join();
         this.displayButtonStates();
         this.switchToFlow('flow-meeting');


### PR DESCRIPTION
**Issue #:** Audio cannot be recorded in amazon-chime-sdk-recording-demo

**Description of changes:**  Call openAudioOutputFromSelection() if recorder joins the meeting

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? tested in sdk demo and recording demo
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?  Yes, with &record=true
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
