### PR TITLE
Add optional callback parameter to realtimeUnsubscribeFromVolumeIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  `VideoFrameProcessor`, `VideoFrameProcessorPipeline` and `VideoFrameBuffer` interfaces
  are added to support `DefaultVideoTransformDevice` and allow processing steps to be applied to device.
  The method `chooseVideoInputDevice` in `DefaultDeviceController` can handle `VideoTransformDevice` now.
+- add callback parameter to `realtimeUnsubscribeFromVolumeIndicator`
 
 ### Changed
 

--- a/docs/modules/apioverview.html
+++ b/docs/modules/apioverview.html
@@ -209,7 +209,7 @@
 					<p>To show speaker volume, mute state, and signal strength for each attendee, subscribe to volume indicators for each attendee ID. You should subscribe and unsubscribe to attendee volume indicators as part of the attendee ID presence callback.</p>
 					<p>Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on a scale of 0 to 1 (full packet loss to no packet loss). You can use the signal strength of remote attendees to show an indication of whether an attendee is experiencing packet loss and thus may be unable to communicate at the moment.</p>
 					<p>To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator(attendeeId, callback)</a>.</p>
-					<p>To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator(attendeeId)</a>.</p>
+					<p>To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator(attendeeId, callback?)</a>.</p>
 					<a href="#5c-signal-strength-change-optional" id="5c-signal-strength-change-optional" style="color: inherit; text-decoration: none;">
 						<h3>5c. Signal strength change (optional)</h3>
 					</a>

--- a/guides/03_API_Overview.md
+++ b/guides/03_API_Overview.md
@@ -176,7 +176,7 @@ Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on 
 
 To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeSubscribeToVolumeIndicator(attendeeId, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator).
 
-To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator).
+To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId, callback?)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator).
 
 ### 5c. Signal strength change (optional)
 

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -251,8 +251,17 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     this.trace('realtimeSubscribeToVolumeIndicator', attendeeId);
   }
 
-  realtimeUnsubscribeFromVolumeIndicator(attendeeId: string): void {
-    this.realtimeController.realtimeUnsubscribeFromVolumeIndicator(attendeeId);
+  realtimeUnsubscribeFromVolumeIndicator(
+    attendeeId: string,
+    callback?: (
+      attendeeId: string,
+      volume: number | null,
+      muted: boolean | null,
+      signalStrength: number | null,
+      externalUserId?: string
+    ) => void
+  ): void {
+    this.realtimeController.realtimeUnsubscribeFromVolumeIndicator(attendeeId, callback);
     this.trace('realtimeUnsubscribeFromVolumeIndicator', attendeeId);
   }
 

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -267,12 +267,26 @@ export default class DefaultRealtimeController implements RealtimeController {
       this.onError(e);
     }
   }
-
-  realtimeUnsubscribeFromVolumeIndicator(attendeeId: string): void {
-    try {
-      delete this.state.volumeIndicatorCallbacks[attendeeId];
-    } catch (e) {
-      this.onError(e);
+  realtimeUnsubscribeFromVolumeIndicator(
+    attendeeId: string,
+    callback?: (
+      attendeeId: string,
+      volume: number | null,
+      muted: boolean | null,
+      signalStrength: number | null,
+      externalUserId?: string
+    ) => void
+  ): void {
+    if (!callback) {
+      try {
+        delete this.state.volumeIndicatorCallbacks[attendeeId];
+      } catch (e) {
+        this.onError(e);
+      }
+    } else {
+      if(this.state.volumeIndicatorCallbacks[attendeeId]) {
+        this.state.volumeIndicatorCallbacks[attendeeId] = this.state.volumeIndicatorCallbacks[attendeeId].filter(f => f !== callback);
+      }
     }
   }
 

--- a/src/realtimecontroller/RealtimeController.ts
+++ b/src/realtimecontroller/RealtimeController.ts
@@ -161,7 +161,16 @@ export default interface RealtimeController {
   /**
    * Unsubscribes to volume indicator changes for a specific attendee id.
    */
-  realtimeUnsubscribeFromVolumeIndicator(attendeeId: string): void;
+  realtimeUnsubscribeFromVolumeIndicator(
+    attendeeId: string, 
+    callback?: (
+      attendeeId: string,
+      volume: number | null,
+      muted: boolean | null,
+      signalStrength: number | null,
+      externalUserId?: string
+    ) => void
+  ): void;
 
   /**
    * Computes the difference to the last state and sends a volume indicator

--- a/src/realtimecontroller/RealtimeControllerFacade.ts
+++ b/src/realtimecontroller/RealtimeControllerFacade.ts
@@ -42,7 +42,16 @@ export default interface RealtimeControllerFacade {
       externalUserId?: string
     ) => void
   ): void;
-  realtimeUnsubscribeFromVolumeIndicator(attendeeId: string): void;
+  realtimeUnsubscribeFromVolumeIndicator(
+    attendeeId: string,
+    callback?: (
+      attendeeId: string,
+      volume: number | null,
+      muted: boolean | null,
+      signalStrength: number | null,
+      externalUserId?: string
+    ) => void
+  ): void;
   realtimeSubscribeToLocalSignalStrengthChange(callback: (signalStrength: number) => void): void;
   realtimeUnsubscribeToLocalSignalStrengthChange(callback: (signalStrength: number) => void): void;
   realtimeSendDataMessage(


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/974
**Description of changes:**
Add callback parameter to realtimeUnsubscribeFromVolumeIndicator 
**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
