### PR TITLE
Import current version of Amazon Voice Focus code: Safari Technology Preview support and multiple quanta execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add support for Amazon Voice Focus support in Safari Technology Preview for macOS.
+  Builders using an explicit revision or asset group must make sure to use a
+  revision no earlier than this; an error will be thrown in Safari if older
+  revisions are used.
 
 ### Changed
 
-- Corrected `null` type on `DefaultVideoFrameProcessorPipeline` and `DefaultVideoTransformDevice`
+- Corrected `null` type on `DefaultVideoFrameProcessorPipeline` and `DefaultVideoTransformDevice`.
+- Amazon Voice Focus now makes better use of available CPU resources,
+  extending support to lower-end devices and improving quality on higher-end
+  devices.
 
 ### Removed
 
@@ -51,8 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trying to choose an output device in a browser that does not support
   `setSinkId`, and the demo will not log an error in these cases.
 - [Demo] The meeting readiness checker no longer re-initializes the device output list
-  after the user picked a device.
-- [Test] Fix voice focus integration/canary test.
+  after the user picks a device.
+- [Test] Fix Amazon Voice Focus integration/canary test.
 - [Demo] Additional best practices around choosing audio output devices.
 
 ## [2.2.0] - 2020-12-04

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -287,8 +287,10 @@ export class DemoMeetingApp
 
     // Listen for unhandled errors, too.
     window.addEventListener('error', event => {
-      fatal(event.error);
+      // In Safari there's only a message.
+      fatal(event.error || event.message);
     });
+
     window.onunhandledrejection = (event: PromiseRejectionEvent) => {
       fatal(event.reason);
     };
@@ -324,7 +326,7 @@ export class DemoMeetingApp
    * when an unexpected error occurs.
    * If we're running locally, or we passed a `fatal=1` query parameter, fail hard.
    */
-  fatal(e: Error): void {
+  fatal(e: Error | string): void {
     // Muffle mode: let the `try-catch` do its job.
     if (!SHOULD_DIE_ON_FATALS) {
       console.info('Ignoring fatal', e);
@@ -332,7 +334,12 @@ export class DemoMeetingApp
     }
 
     console.error('Fatal error: this was going to be caught, but should not have been thrown.', e);
-    document.getElementById('stack').innerText = e.message + '\n' + e.stack?.toString();
+
+    if (e && e instanceof Error) {
+      document.getElementById('stack').innerText = e.message + '\n' + e.stack?.toString();
+    } else {
+      document.getElementById('stack').innerText = '' + e;
+    }
 
     this.switchToFlow('flow-fatal');
   }

--- a/docs/modules/amazonvoice_focus.html
+++ b/docs/modules/amazonvoice_focus.html
@@ -100,7 +100,8 @@
 					<a href="#browser-compatibility" id="browser-compatibility" style="color: inherit; text-decoration: none;">
 						<h3>Browser compatibility</h3>
 					</a>
-					<p>Amazon Voice Focus in the Amazon Chime SDK for JavaScript works in Firefox, Chrome, and Chromium-based browsers (including Electron) on desktop and Android operating systems. A full compatibility table is below. Amazon Voice Focus does not currently support Safari on desktop or iOS devices, because Safari does not implement the required web standards.</p>
+					<p>Amazon Voice Focus in the Amazon Chime SDK for JavaScript works in Firefox, Chrome, and Chromium-based browsers (including Electron) on desktop and Android operating systems. A full compatibility table is below.</p>
+					<p>Amazon Voice Focus does not support the release version of Safari on desktop or iOS devices, because Safari does not implement the required web standards. Amazon Voice Focus supports Safari Technology Preview (v14.1, 117) as of version 2.4 of the Amazon Chime SDK.</p>
 					<table>
 						<thead>
 							<tr>
@@ -124,9 +125,9 @@
 							</tr>
 							<tr>
 								<td>Safari</td>
-								<td>Not supported</td>
+								<td>14.1*</td>
 								<td>-</td>
-								<td></td>
+								<td>Technology Preview</td>
 							</tr>
 							<tr>
 								<td>Android browser</td>
@@ -167,6 +168,7 @@
 						<li><code>script-src</code> and <code>script-src-elem</code>: add <code>https://*.sdkassets.chime.aws</code> to load audio processing code to run in the browser’s audio renderer thread.</li>
 						<li><code>connect-src</code>: add <code>https://*.sdkassets.chime.aws</code> to load model files via <code>fetch</code>.</li>
 						<li><code>worker-src</code>: add <code>blob:</code> to load worker JavaScript across origins.</li>
+						<li><code>child-src</code>: add <code>blob:</code> to load worker JavaScript across origins (only in Safari).</li>
 					</ul>
 					<p>If you omit any of these entries, or if you use both HTTP headers and <code>http-equiv</code> <code>meta</code> tags to specify policy and inadvertently exclude any of these by intersection, then Amazon Voice Focus will not be able to initialize, and will either appear to be unsupported or will fail to create a suppressed audio device. You will see errors in your browser console like:</p>
 					<pre><code>Refused <span class="hljs-built_in">to</span> connect <span class="hljs-built_in">to</span>

--- a/guides/09_Amazon_Voice_Focus.md
+++ b/guides/09_Amazon_Voice_Focus.md
@@ -34,13 +34,15 @@ If you think your application might be used in these scenarios, take care to tes
 
 ### Browser compatibility
 
-Amazon Voice Focus in the Amazon Chime SDK for JavaScript works in Firefox, Chrome, and Chromium-based browsers (including Electron) on desktop and Android operating systems. A full compatibility table is below. Amazon Voice Focus does not currently support Safari on desktop or iOS devices, because Safari does not implement the required web standards.
+Amazon Voice Focus in the Amazon Chime SDK for JavaScript works in Firefox, Chrome, and Chromium-based browsers (including Electron) on desktop and Android operating systems. A full compatibility table is below.
+
+Amazon Voice Focus does not support the release version of Safari on desktop or iOS devices, because Safari does not implement the required web standards. Amazon Voice Focus supports Safari Technology Preview (v14.1, 117) as of version 2.4 of the Amazon Chime SDK.
 
 |Browser                                                                |Minimum supported version  |Preferred version  |Notes               |
 |---                                                                    |---                        |---                |---                 |
 |Firefox                                                                |76                         |83+                |                    |
 |Chromium-based browsers and environments, including Edge and Electron  |78                         |87+                |                    |
-|Safari                                                                 |Not supported              |-                  |                    |
+|Safari                                                                 |14.1*                      |-                  |Technology Preview  |
 |Android browser                                                        |78*                        |87*                |Typically too slow. |
 |iOS Safari                                                             |Not supported              |-                  |                    |
 
@@ -75,6 +77,7 @@ Modern web applications use [Content Security Policy](https://developer.mozilla.
 * `script-src` and `script-src-elem`: add `https://*.sdkassets.chime.aws` to load audio processing code to run in the browser’s audio renderer thread.
 * `connect-src`: add `https://*.sdkassets.chime.aws` to load model files via `fetch`.
 * `worker-src`: add `blob:` to load worker JavaScript across origins.
+* `child-src`: add `blob:` to load worker JavaScript across origins (only in Safari).
 
 If you omit any of these entries, or if you use both HTTP headers and `http-equiv` `meta` tags to specify policy and inadvertently exclude any of these by intersection, then Amazon Voice Focus will not be able to initialize, and will either appear to be unsupported or will fail to create a suppressed audio device. You will see errors in your browser console like:
 

--- a/libs/voicefocus/decider.d.ts
+++ b/libs/voicefocus/decider.d.ts
@@ -1,9 +1,10 @@
-import { ExecutionApproach, Logger, ModelConfig, ModelVariant, PerformanceThresholds, VoiceFocusExecutionSpec, VoiceFocusFetchConfig, VoiceFocusProcessor } from './types.js';
+import { ExecutionApproach, ExecutionQuanta, Logger, ModelConfig, ModelVariant, PerformanceThresholds, VoiceFocusExecutionSpec, VoiceFocusFetchConfig, VoiceFocusProcessor } from './types.js';
 interface SupportedExecutionDefinition {
     supported: true;
     useSIMD: boolean;
     processor: VoiceFocusProcessor;
     executionApproach: ExecutionApproach;
+    executionQuanta?: ExecutionQuanta;
     variant: ModelVariant;
 }
 export interface Unsupported {

--- a/libs/voicefocus/decider.js
+++ b/libs/voicefocus/decider.js
@@ -12,9 +12,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.decideModel = exports.measureAndDecideExecutionApproach = void 0;
 const loader_js_1 = require("./loader.js");
 const support_js_1 = require("./support.js");
+const DEFAULT_EXECUTION_QUANTA = 3;
 const SIMD_SCORE_FIXED_POINT = 2.50;
 const WASM_SCORE_FIXED_POINT = 2.63;
-const INLINE_SCORE_MULTIPLIER = 0.6;
+const SINGLE_INLINE_SCORE_MULTIPLIER = 0.6;
+const QUALITY_MULTIPLE_QUANTA_SCORE_MULTIPLIER = 0.65;
+const INTERACTIVITY_MULTIPLE_QUANTA_SCORE_MULTIPLIER = 0.5;
 const WORKER_SCORE_MULTIPLIER = 0.7;
 const PERFORMANCE_THRESHOLDS = {
     wasm: {
@@ -117,13 +120,22 @@ class Estimator {
         });
     }
 }
-const decideExecutionApproach = ({ supportsSIMD, supportsSAB, duration, executionPreference = 'auto', simdPreference, variantPreference = 'auto', }, allThresholds = PERFORMANCE_THRESHOLDS, logger) => {
+const inlineScoreMultiplier = (executionQuanta, usagePreference) => {
+    if (executionQuanta === 1) {
+        return SINGLE_INLINE_SCORE_MULTIPLIER;
+    }
+    if (usagePreference === 'quality') {
+        return QUALITY_MULTIPLE_QUANTA_SCORE_MULTIPLIER * executionQuanta;
+    }
+    return INTERACTIVITY_MULTIPLE_QUANTA_SCORE_MULTIPLIER * executionQuanta;
+};
+const decideExecutionApproach = ({ supportsSIMD, supportsSAB, duration, executionPreference = 'auto', simdPreference, variantPreference = 'auto', usagePreference, executionQuantaPreference = DEFAULT_EXECUTION_QUANTA, }, allThresholds = PERFORMANCE_THRESHOLDS, logger) => {
     const forceSIMD = (simdPreference === 'force');
     const useSIMD = forceSIMD || (simdPreference !== 'disable' && supportsSIMD);
     const checkScores = duration !== -1;
     const baseScore = checkScores ? (useSIMD ? SIMD_SCORE_FIXED_POINT : WASM_SCORE_FIXED_POINT) / duration : 0;
     const thresholds = useSIMD ? allThresholds.simd : allThresholds.wasm;
-    const inlineScore = checkScores ? INLINE_SCORE_MULTIPLIER * baseScore : 0;
+    const inlineScore = checkScores ? inlineScoreMultiplier(executionQuantaPreference, usagePreference) * baseScore : 0;
     const workerScore = checkScores ? WORKER_SCORE_MULTIPLIER * baseScore : 0;
     const unsupported = (reason) => {
         return {
@@ -144,7 +156,14 @@ const decideExecutionApproach = ({ supportsSIMD, supportsSAB, duration, executio
     }
     logger === null || logger === void 0 ? void 0 : logger.debug(`Bench duration ${duration} yields inline score ${inlineScore} and worker score ${workerScore}.`);
     const succeed = (processor, executionApproach, variant) => {
-        return { supported: true, useSIMD, processor, executionApproach, variant };
+        return {
+            supported: true,
+            useSIMD,
+            processor,
+            executionApproach,
+            variant,
+            executionQuanta: (executionApproach === 'inline' ? executionQuantaPreference : undefined),
+        };
     };
     const resolveVariant = (score, variant, lookup) => {
         if (variant !== 'auto') {
@@ -276,7 +295,7 @@ const estimateAndFeatureCheck = (forceSIMD, fetchConfig, estimatorBudget, logger
 });
 const measureAndDecideExecutionApproach = (spec, fetchConfig, logger, thresholds = PERFORMANCE_THRESHOLDS) => __awaiter(void 0, void 0, void 0, function* () {
     let executionPreference = spec.executionPreference;
-    const { usagePreference, variantPreference, simdPreference, estimatorBudget, } = spec;
+    const { usagePreference, variantPreference, simdPreference, estimatorBudget, executionQuantaPreference, } = spec;
     if (usagePreference === 'interactivity' && executionPreference !== 'inline') {
         logger === null || logger === void 0 ? void 0 : logger.debug(`Overriding execution preference ${executionPreference} to reflect interactivity preference.`);
         executionPreference = 'inline';
@@ -297,7 +316,11 @@ const measureAndDecideExecutionApproach = (spec, fetchConfig, logger, thresholds
         logger === null || logger === void 0 ? void 0 : logger.error('Could not load estimator.', e);
         throw new Error('Could not load Voice Focus estimator.');
     }
-    return decideExecutionApproach(Object.assign(Object.assign({}, supports), { simdPreference, executionPreference, variantPreference }), thresholds, logger);
+    return decideExecutionApproach(Object.assign(Object.assign({}, supports), { simdPreference,
+        executionPreference,
+        variantPreference,
+        usagePreference,
+        executionQuantaPreference }), thresholds, logger);
 });
 exports.measureAndDecideExecutionApproach = measureAndDecideExecutionApproach;
 const decideModel = ({ category, name, variant, simd }) => {

--- a/libs/voicefocus/support.d.ts
+++ b/libs/voicefocus/support.d.ts
@@ -5,6 +5,8 @@ interface LimitedWindow {
         userAgent: string;
     };
 }
+export declare const isSafari: (global?: LimitedWindow) => boolean;
+export declare const supportsWASMPostMessage: (global?: LimitedWindow) => boolean;
 export declare const supportsVoiceFocusWorker: (scope: {
     Worker?: {
         new (stringUrl: string | URL, options?: WorkerOptions | undefined): Worker;

--- a/libs/voicefocus/support.js
+++ b/libs/voicefocus/support.js
@@ -9,8 +9,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isOldChrome = exports.supportsWASMStreaming = exports.supportsSharedArrayBuffer = exports.supportsWASM = exports.supportsAudioWorklet = exports.supportsWorker = exports.supportsVoiceFocusWorker = void 0;
+exports.isOldChrome = exports.supportsWASMStreaming = exports.supportsSharedArrayBuffer = exports.supportsWASM = exports.supportsAudioWorklet = exports.supportsWorker = exports.supportsVoiceFocusWorker = exports.supportsWASMPostMessage = exports.isSafari = void 0;
 const loader_js_1 = require("./loader.js");
+const isSafari = (global = globalThis) => {
+    const ua = global.navigator.userAgent;
+    const hasSafari = ua.match(/Safari\//);
+    const hasChrome = ua.match(/Chrom(?:e|ium)\//);
+    return !!(hasSafari && !hasChrome);
+};
+exports.isSafari = isSafari;
+const supportsWASMPostMessage = (global = globalThis) => {
+    return !exports.isSafari(global);
+};
+exports.supportsWASMPostMessage = supportsWASMPostMessage;
 const supportsVoiceFocusWorker = (scope = globalThis, fetchConfig, logger) => __awaiter(void 0, void 0, void 0, function* () {
     if (!exports.supportsWorker(scope, logger)) {
         return false;
@@ -54,7 +65,7 @@ const supportsAudioWorklet = (scope = globalThis, logger) => {
 exports.supportsAudioWorklet = supportsAudioWorklet;
 const supportsWASM = (scope = globalThis, logger) => {
     try {
-        return !!scope.WebAssembly;
+        return !!scope.WebAssembly && (!!scope.WebAssembly.compile || !!scope.WebAssembly.compileStreaming);
     }
     catch (e) {
         logger === null || logger === void 0 ? void 0 : logger.info('Does not support WASM', e);

--- a/libs/voicefocus/types.d.ts
+++ b/libs/voicefocus/types.d.ts
@@ -12,6 +12,7 @@ export declare type ExecutionApproach = 'inline' | 'worker-sab' | 'worker-postMe
 export declare type ExecutionPreference = ExecutionApproach | 'worker' | 'auto';
 export declare type UsagePreference = 'quality' | 'interactivity';
 export declare type VariantPreference = ModelVariant | 'auto';
+export declare type ExecutionQuanta = 1 | 2 | 3;
 export interface ModelConfig {
     category: ModelCategory;
     name: ModelName;
@@ -24,6 +25,7 @@ export interface VoiceFocusExecutionSpec {
     executionPreference: ExecutionPreference;
     usagePreference: UsagePreference;
     estimatorBudget: number;
+    executionQuantaPreference?: ExecutionQuanta;
 }
 export interface ComplexityThresholds {
     c100: number;
@@ -86,6 +88,7 @@ export interface ProcessorOptions {
     sendBufferCount: number;
     prefill: number;
     agc: AGCOptions;
+    executionQuanta?: ExecutionQuanta;
 }
 export interface ProcessorMessageData {
     message: 'data' | 'cpu' | 'prepare-for-frames';
@@ -95,7 +98,7 @@ export interface ProcessorMessage {
     data: ProcessorMessageData;
 }
 export interface WorkerMessageData {
-    message: 'module' | 'stopped' | 'ready' | 'data' | 'cpu' | 'processing';
+    message: 'module' | 'module-buffer' | 'stopped' | 'ready' | 'data' | 'cpu' | 'processing';
     key?: string;
     preload?: boolean;
     module?: WebAssembly.Module;

--- a/libs/voicefocus/voicefocus.d.ts
+++ b/libs/voicefocus/voicefocus.d.ts
@@ -1,4 +1,4 @@
-import { AGCOptions, ExecutionPreference, Logger, ModelCategory, ModelConfig, ModelName, ModelVariant, PerformanceThresholds, SIMDPreference, UsagePreference, VoiceFocusAudioWorkletNode, VoiceFocusConfigureOptions, VoiceFocusDelegate, VoiceFocusFetchBehavior, VoiceFocusFetchConfig, VoiceFocusPaths } from './types.js';
+import { AGCOptions, ExecutionPreference, ExecutionQuanta, Logger, ModelCategory, ModelConfig, ModelName, ModelVariant, PerformanceThresholds, SIMDPreference, UsagePreference, VoiceFocusAudioWorkletNode, VoiceFocusConfigureOptions, VoiceFocusDelegate, VoiceFocusFetchBehavior, VoiceFocusFetchConfig, VoiceFocusPaths } from './types.js';
 import { Unsupported } from './decider.js';
 export interface AssetSpec {
     assetGroup?: string;
@@ -15,6 +15,7 @@ export interface VoiceFocusSpec extends AssetSpec {
     variant?: ModelVariant | 'auto';
     simd?: SIMDPreference;
     executionPreference?: ExecutionPreference;
+    executionQuantaPreference?: ExecutionQuanta;
     usagePreference?: UsagePreference;
     estimatorBudget?: number;
     paths?: VoiceFocusPaths;
@@ -24,6 +25,7 @@ interface SupportedVoiceFocusConfig {
     supported: true;
     model: ModelConfig;
     processor: string;
+    executionQuanta?: ExecutionQuanta;
     fetchConfig: VoiceFocusFetchConfig;
 }
 export declare type VoiceFocusConfig = SupportedVoiceFocusConfig | Unsupported;
@@ -43,11 +45,13 @@ export declare class VoiceFocus {
     private processorURL;
     private nodeConstructor;
     private nodeOptions;
+    private executionQuanta;
     private internal;
     private constructor();
     static isSupported(spec?: AssetSpec & {
         paths?: VoiceFocusPaths;
     }, options?: VoiceFocusConfigureOptions): Promise<boolean>;
+    private static mungeExecutionPreference;
     static configure(spec?: VoiceFocusSpec, options?: VoiceFocusConfigureOptions): Promise<VoiceFocusConfig>;
     static init(configuration: VoiceFocusConfig, { delegate, preload, logger, }: {
         delegate: VoiceFocusDelegate;

--- a/libs/voicefocus/worklet-inline-node.d.ts
+++ b/libs/voicefocus/worklet-inline-node.d.ts
@@ -3,6 +3,7 @@ declare class VoiceFocusInlineNode extends VoiceFocusAudioWorkletNode {
     private worker;
     private logger;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
+    onModuleBufferLoaded(buffer: ArrayBuffer, key: string): void;
     onModuleLoaded(module: WebAssembly.Module, key: string): void;
     enable(): Promise<void>;
     disable(): Promise<void>;

--- a/libs/voicefocus/worklet-worker-postMessage-node.js
+++ b/libs/voicefocus/worklet-worker-postMessage-node.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const support_js_1 = require("./support.js");
 const types_js_1 = require("./types.js");
 class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletNode {
     constructor(context, options) {
@@ -27,8 +28,9 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             fetchBehavior,
             model: modelURL,
         });
+        const message = support_js_1.supportsWASMPostMessage(globalThis) ? 'get-module' : 'get-module-buffer';
         this.worker.postMessage({
-            message: 'get-module',
+            message,
             key: 'buffer',
             fetchBehavior,
             path: audioBufferURL,
@@ -70,6 +72,7 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             case 'stopped':
                 this.worker.terminate();
                 break;
+            case 'module-buffer':
             case 'module':
                 this.port.postMessage(data);
                 break;

--- a/libs/voicefocus/worklet-worker-sab-node.js
+++ b/libs/voicefocus/worklet-worker-sab-node.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const support_js_1 = require("./support.js");
 const types_js_1 = require("./types.js");
 const INDICES = {
     ready: 0,
@@ -34,8 +35,9 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             enabled: options.processorOptions.enabled,
             model: modelURL,
         });
+        const message = support_js_1.supportsWASMPostMessage(globalThis) ? 'get-module' : 'get-module-buffer';
         this.worker.postMessage({
-            message: 'get-module',
+            message,
             key: 'resampler',
             fetchBehavior,
             path: resamplerURL,
@@ -93,6 +95,7 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             case 'stopped':
                 this.worker.terminate();
                 break;
+            case 'module-buffer':
             case 'module':
                 this.port.postMessage(data);
                 break;


### PR DESCRIPTION
This adds the ability to run inline work across multiple Web Audio
quanta, extending Amazon Voice Focus to lower-end devices, and
additionally supports browsers that do not support streaming
WebAssembly compilation.

This code change also supports Safari Technology Preview. Note that
Safari clients need to use the default Amazon Voice Focus revision, or
be sure to use a new revision that supports Safari.

This commit adjusts the `VoiceFocusDeviceTransformer` test to
accommodate new User-Agent checks for Safari, which does not support
sending WebAssembly modules to worklets via `postMessage`. It also
resolves some Safari-specific issues around error handling in the demo
app.


> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

There are several aspects to this change.

Behavior with current CDN contents is expected to be unchanged for Firefox, Chrome, and Safari, and **to fail** (throwing a fatal in test mode, or silently failing for builders) with Safari Technology Preview.

With unreleased CDN contents, all browsers except for release Safari should work, and inline execution should occur in three chunks rather than one.

These combinations were manually tested.

Additionally, chunked execution is covered by unit tests in the Amazon Voice Focus repo, where the bulk of this change was reviewed. The unit tests for Amazon Voice Focus in the SDK were amended to match, and integration tests will run in Firefox and Chrome as part of this PR to verify that existing CDN contents continue to work with this code.

Final testing of this change in the SDK plus the updated CDN contents will have to wait until those changes hit a prerelease CDN.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

meetingV2.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
