### PR TITLE
Corrected type of `outputMediaStream` on `VideoTransformDevice` and `VideoFrameProcessorPipeline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Corrected `outputMediaStream` type for interfaces `VideoTransformDevice` and `VideoProcessorPipeline`
 
 ### Removed
 

--- a/docs/interfaces/videoframeprocessorpipeline.html
+++ b/docs/interfaces/videoframeprocessorpipeline.html
@@ -136,7 +136,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
 					<a name="outputmediastream" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagReadonly">Readonly</span> output<wbr>Media<wbr>Stream</h3>
-					<div class="tsd-signature tsd-kind-icon">output<wbr>Media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span></div>
+					<div class="tsd-signature tsd-kind-icon">output<wbr>Media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videoframeprocessor/VideoFrameProcessorPipeline.ts#L63">src/videoframeprocessor/VideoFrameProcessorPipeline.ts:63</a></li>

--- a/docs/interfaces/videotransformdevice.html
+++ b/docs/interfaces/videotransformdevice.html
@@ -114,7 +114,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
 					<a name="outputmediastream" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagReadonly">Readonly</span> output<wbr>Media<wbr>Stream</h3>
-					<div class="tsd-signature tsd-kind-icon">output<wbr>Media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span></div>
+					<div class="tsd-signature tsd-kind-icon">output<wbr>Media<wbr>Stream<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/VideoTransformDevice.ts#L34">src/devicecontroller/VideoTransformDevice.ts:34</a></li>

--- a/src/devicecontroller/VideoTransformDevice.ts
+++ b/src/devicecontroller/VideoTransformDevice.ts
@@ -31,7 +31,7 @@ export default interface VideoTransformDevice {
   /**
    * `outputMediaStream` is generated after processors are applied. It will be auto-released after `stop` is called.
    */
-  readonly outputMediaStream: MediaStream;
+  readonly outputMediaStream: MediaStream | null;
 }
 
 /**

--- a/src/videoframeprocessor/VideoFrameProcessorPipeline.ts
+++ b/src/videoframeprocessor/VideoFrameProcessorPipeline.ts
@@ -60,5 +60,5 @@ export default interface VideoFrameProcessorPipeline {
   /**
    * The output `MediaStream` as a result of processor executions.
    */
-  readonly outputMediaStream: MediaStream;
+  readonly outputMediaStream: MediaStream | null;
 }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Corrected type of `outputMediaStream` on `VideoTransformDevice` and `VideoFrameProcessorPipeline`
**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? demo 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
