### PR TITLE
Fix meeting readiness checker create log stream bug

### DIFF
--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -432,7 +432,7 @@ export class DemoMeetingApp {
     if (
       location.hostname === 'localhost' ||
       location.hostname === '127.0.0.1' ||
-      configuration === null
+      !configuration
     ) {
       this.logger.inner = consoleLogger;
     } else {


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
As part of this commit https://github.com/aws/amazon-chime-sdk-js/commit/2ca3976c99992285954b33755dc617aa3aa0e2cf the check for `configuration == null` was changed to `configuration === null` which was returning `false` if configuration was `undefined`.

**Testing**

1. Have you successfully run `npm run build:release` locally?
> Yes.
2. How did you test these changes?
Locally.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes. It can be tested with the meeting readiness checker app.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
