### PR TITLE
Deploy a serverless demo after submitting release PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1720,22 +1720,22 @@
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
-    "git-describe": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.0.4.tgz",
-      "integrity": "sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==",
+    "git-rev-sync": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.1.tgz",
+      "integrity": "sha512-8xZzUwzukIuU3sasgYt3RELc3Ny7o+tbtvitnnU4a4j3djyZNpJ5JmqVX+K7Xv3gE/i7ln3hGdBfZ00T5WWoow==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11",
-        "semver": "^5.6.0"
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.15",
+        "shelljs": "0.8.4"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "optional": true
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "esm": "^3.2.25",
     "fetch-mock": "^9.10.7",
     "fs-extra": "^8.1.0",
-    "git-describe": "^4.0.4",
+    "git-rev-sync": "^3.0.1",
     "mocha": "^8.1.3",
     "node-fetch": "^2.6.1",
     "nyc": "^15.1.0",

--- a/script/release
+++ b/script/release
@@ -54,19 +54,13 @@ end
 package['version'] = version_string
 changelog_file = 'CHANGELOG.md'
 tag = "amazon-chime-sdk-js@#{version_string}"
-
-# This is what most tools (e.g., `git describe`) use.
-semvertag = "v#{version_string}"
+formatted_version = version_string.gsub(".","-")
 
 puts
 puts "Warning: you are bumping the version"
 puts
 puts "From: #{original_version}"
 puts "To:   #{version_string}"
-puts
-puts "And creating the following tags:"
-puts tag
-puts semvertag
 puts
 puts "Type 'yes' to continue"
 x = STDIN.gets
@@ -82,9 +76,6 @@ verbose("npm version #{version_string} --no-git-tag-version")
 
 verbose('git add -A')
 verbose("git commit -m 'Publish #{tag}'")
-verbose("git tag -d #{tag} || true")
-verbose("git tag #{tag}")
-verbose("git tag #{semvertag} -m \"Release #{semvertag}.\"")
 
 verbose('npm run build:release')
 verbose('npm pack --dry-run')
@@ -96,4 +87,7 @@ x = STDIN.gets
 exit(1) unless x.strip == 'yes'
 puts
 
-verbose("git push origin HEAD:release --follow-tags -f")
+verbose("git push origin HEAD:release -f")
+
+Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../demos/serverless')))
+verbose("npm run deploy -- -b chime-sdk-demo-#{formatted_version} -s chime-sdk-demo-#{formatted_version}")


### PR DESCRIPTION
**Description of changes:**
- Deploy a serverless demo after submiting a release candidate
- Handle a case in generate-version.js to use package.json when the version specified there is newer than the latest tag.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually run the release script and generate-version.js
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
