### PR TITLE
Metric signalingOpenDurationMs from the demo app

### DIFF
--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -16,6 +16,7 @@ const packages = [
   // Use latest AWS SDK instead of default version provided by Lambda runtime
   'aws-sdk',
   'uuid',
+  'aws-embedded-metrics',
 ];
 
 function usage() {

--- a/demos/serverless/package-lock.json
+++ b/demos/serverless/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "aws-embedded-metrics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/aws-embedded-metrics/-/aws-embedded-metrics-2.0.2.tgz",
+      "integrity": "sha512-Nx1H+V6qtkMD2mR/jTiMvwHbbOkV5sMtjf3TgSFtzTMve0eUgUqGURHcuIf6o1/JdYdkoB+o+FY1kOh62qo+kw=="
+    },
     "aws-sdk": {
       "version": "2.664.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.664.0.tgz",

--- a/demos/serverless/package.json
+++ b/demos/serverless/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "aws-sdk": "^2.664.0",
     "fs-extra": "^9.0.0",
-    "uuid": "^8.2.0"
+    "uuid": "^8.2.0",
+    "aws-embedded-metrics": "^2.0.2"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -4,6 +4,7 @@
 const AWS = require('./aws-sdk');
 const fs = require('fs');
 const { v4: uuidv4 } = require('./uuid');
+const { metricScope } = require('./aws-embedded-metrics');
 
 // Store meetings in a DynamoDB table so attendees can join by meeting title
 const ddb = new AWS.DynamoDB();
@@ -139,6 +140,7 @@ exports.log_meeting_event = async (event, context) => {
         message: log.message,
         timestamp: log.timestampMs
       });
+      addSignalMetricsToCloudWatch(log.message, meetingId, attendeeId);
     }
     return logEvents;
   });
@@ -271,4 +273,27 @@ function response(statusCode, contentType, body) {
     body: body,
     isBase64Encoded: false
   };
+}
+
+function addSignalMetricsToCloudWatch(logMsg, meetingId, attendeeId) {
+  const logMsgJson = JSON.parse(logMsg);
+  const metricList = ['signalingOpenDurationMs'];
+  const putMetric =
+    metricScope(metrics => (metricName, metricValue, meetingId, attendeeId) => {
+      metrics.putDimensions({MeetingId: meetingId, AttendeeId: attendeeId});
+      metrics.putMetric(metricName, metricValue);
+    });
+  const putSignalMetric =
+    metricScope(metrics => (metricName, metricValue) => {
+      metrics.putMetric(metricName, metricValue);
+    });
+  for (let metricIndex = 0; metricIndex <= metricList.length; metricIndex += 1) {
+    const metricName = metricList[metricIndex];
+    if (logMsgJson.attributes.hasOwnProperty(metricName)) {
+      const metricValue = logMsgJson.attributes[metricName];
+      console.log('Logging metric -> ', metricName, ': ', metricValue );
+      putMetric(metricName, metricValue, meetingId, attendeeId);
+      putSignalMetric(metricName, metricValue);
+    }
+  }
 }


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
The demo app will now be able to log the signalingOpenDurationMs as metrics on the cloudwatch.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manually

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, meetings demo app

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

