### PR TITLE
Add a demo video processor for segmentation based on TF bodypix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [DEMO] Add a image segmentation video filter based on Tensorflow BodyPix
 
 
 ### Changed

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -52,6 +52,11 @@ import {
 
 import CircularCut from './videofilter/CircularCut';
 import EmojifyVideoFrameProcessor from './videofilter/EmojifyVideoFrameProcessor';
+import SegmentationProcessor from './videofilter/SegmentationProcessor';
+import {
+  loadBodyPixDependency,
+  platformCanSupportBodyPixWithoutDegradation,
+} from './videofilter/SegmentationUtil';
 import WebRTCStatsCollector from './webrtcstatscollector/WebRTCStatsCollector';
 
 const SHOULD_DIE_ON_FATALS = (() => {
@@ -119,7 +124,7 @@ const VOICE_FOCUS_SPEC = {
   paths: VOICE_FOCUS_PATHS,
 };
 
-type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'None';
+type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'None' | 'Segmentation';
 
 const VIDEO_FILTERS: VideoFilterName[] = ['Emojify', 'CircularCut', 'NoOp'];
 
@@ -212,6 +217,9 @@ export class DemoMeetingApp
   static readonly MAX_MEETING_HISTORY_MS: number = 5 * 60 * 1000;
   static readonly DATA_MESSAGE_TOPIC: string = 'chat';
   static readonly DATA_MESSAGE_LIFETIME_MS: number = 300000;
+
+  // ideally we don't need to change this. Keep this configurable in case users have super slow network.
+  loadingBodyPixDependencyTimeoutMs: number = 10000;
 
   showActiveSpeakerScores = false;
   activeSpeakerLayout = true;
@@ -1588,6 +1596,16 @@ export class DemoMeetingApp
       this.enableUnifiedPlanForChromiumBasedBrowsers
     ) {
       filters = filters.concat(VIDEO_FILTERS);
+
+      if (platformCanSupportBodyPixWithoutDegradation()) {
+        try {
+          await loadBodyPixDependency(this.loadingBodyPixDependencyTimeoutMs);
+          filters.push('Segmentation');
+        } catch (error) {
+          fatal(error);
+          this.log('failed to load segmentation dependencies', error);
+        }
+      }
     }
 
     this.populateInMeetingDeviceList(
@@ -2028,6 +2046,10 @@ export class DemoMeetingApp
 
     if (videoFilter === 'NoOp') {
       return new NoOpVideoFrameProcessor();
+    }
+
+    if (videoFilter === 'Segmentation') {
+      return new SegmentationProcessor();
     }
 
     return null;

--- a/demos/browser/app/meetingV2/videofilter/CircularCut.ts
+++ b/demos/browser/app/meetingV2/videofilter/CircularCut.ts
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  CanvasVideoFrameBuffer,
-  VideoFrameBuffer,
-  VideoFrameProcessor,
-} from 'amazon-chime-sdk-js';
+import { CanvasVideoFrameBuffer, VideoFrameBuffer, VideoFrameProcessor } from 'amazon-chime-sdk-js';
 
 /**
  * [[CircularCut]] is an implementation of {@link VideoFrameProcessor} for demonstration purpose.

--- a/demos/browser/app/meetingV2/videofilter/ResizeProcessor.ts
+++ b/demos/browser/app/meetingV2/videofilter/ResizeProcessor.ts
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  CanvasVideoFrameBuffer,
-  VideoFrameBuffer,
-  VideoFrameProcessor,
-} from 'amazon-chime-sdk-js';
+import { CanvasVideoFrameBuffer, VideoFrameBuffer, VideoFrameProcessor } from 'amazon-chime-sdk-js';
 
 /**
  * [[ResizeProcessor]] updates the input {@link VideoFrameBuffer} and resize given the display aspect ratio.

--- a/demos/browser/app/meetingV2/videofilter/SegmentationProcessor.ts
+++ b/demos/browser/app/meetingV2/videofilter/SegmentationProcessor.ts
@@ -1,0 +1,70 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// eslint-disable-next-line
+declare var bodyPix: any;
+
+import { CanvasVideoFrameBuffer, VideoFrameBuffer, VideoFrameProcessor } from 'amazon-chime-sdk-js';
+
+export default class SegmentationProcessor implements VideoFrameProcessor {
+  private targetCanvas: HTMLCanvasElement = document.createElement('canvas') as HTMLCanvasElement;
+  private canvasVideoFrameBuffer = new CanvasVideoFrameBuffer(this.targetCanvas);
+  private sourceWidth: number = 0;
+  private sourceHeight: number = 0;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private mask: any | undefined = undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private model: any | undefined = undefined;
+
+  constructor() {}
+
+  async process(buffers: VideoFrameBuffer[]): Promise<VideoFrameBuffer[]> {
+    if (!this.model) {
+      this.model = await bodyPix.load();
+    }
+
+    const inputCanvas = buffers[0].asCanvasElement();
+    if (!inputCanvas) {
+      throw new Error('buffer is already destroyed');
+    }
+
+    const frameWidth = inputCanvas.width;
+    const frameHeight = inputCanvas.height;
+    if (frameWidth === 0 || frameHeight === 0) {
+      return buffers;
+    }
+
+    if (this.sourceWidth !== frameWidth || this.sourceHeight !== frameHeight) {
+      this.sourceWidth = frameWidth;
+      this.sourceHeight = frameHeight;
+
+      // update target canvas size to match the frame size
+      this.targetCanvas.width = this.sourceWidth;
+      this.targetCanvas.height = this.sourceHeight;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let predictions = await this.model.segmentPerson(inputCanvas);
+    if (predictions) {
+      const foregroundColor = { r: 255, g: 255, b: 255, a: 255 };
+      const backgroundColor = { r: 0, g: 0, b: 0, a: 255 };
+      this.mask = bodyPix.toMask(predictions, foregroundColor, backgroundColor, true);
+    }
+
+    if (this.mask) {
+      bodyPix.drawMask(this.targetCanvas, inputCanvas as HTMLCanvasElement, this.mask);
+      buffers[0] = this.canvasVideoFrameBuffer;
+    }
+    predictions = undefined;
+    return buffers;
+  }
+
+  async destroy(): Promise<void> {
+    if (this.model) {
+      this.model.dispose();
+    }
+    this.model = undefined;
+  }
+}

--- a/demos/browser/app/meetingV2/videofilter/SegmentationUtil.ts
+++ b/demos/browser/app/meetingV2/videofilter/SegmentationUtil.ts
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { detect } from 'detect-browser';
+
+const SEGMENTATION_DEPENDENCIES = [
+  {
+    src: 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.7.0/dist/tf.min.js',
+    integrity: 'sha384-uI1PW0SEa/QzAUuRQ6Bz5teBONsa9D0ZbVxMcM8mu4IjJ5msHyM7RRtZtL8LnSf3',
+    crossOrigin: 'anonymous',
+  },
+
+  {
+    src: 'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-core@2.7.0/dist/tf-core.min.js',
+    integrity: 'sha384-DlI/SVdTGUBY5hi4h0p+nmC6V8i0FW5Nya/gYElz0L68HrSiXsBh+rqWcoZx3SXY',
+    crossOrigin: 'anonymous',
+  },
+
+  {
+    src:
+      'https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-webgl@2.7.0/dist/tf-backend-webgl.min.js',
+    integrity: 'sha384-21TV9Kpzn8SF68G1U6nYN3qPZnb97F06JuW4v0FDDBzW+CUwv8GcKMR+BjnE7Vmm',
+    crossOrigin: 'anonymous',
+  },
+
+  {
+    src: 'https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2.0.5/dist/body-pix.min.js',
+    integrity: 'sha384-dPJ/sICXCqdh39bsuGLVFcOiRyeL/XcFrwiFrJq9oh7k1TCtsUKhX6UV2X4UuKU4',
+    crossOrigin: 'anonymous',
+  },
+];
+
+
+export async function loadBodyPixDependency(timeoutMs: number): Promise<void> {
+  // the tf library loading order must be followed
+  for (let i = 0; i < SEGMENTATION_DEPENDENCIES.length; i++) {
+    const dep = SEGMENTATION_DEPENDENCIES[i];
+    await new Promise<void>((resolve, reject) => {
+      let script = document.createElement('script');
+      const timer = setTimeout(() => {
+        reject(new Error(`Loading script ${dep.src} takes longer than ${timeoutMs}`));
+      }, timeoutMs);
+      script.onload = function(_ev) {
+        clearTimeout(timer);
+        resolve();
+      };
+      script.src = dep.src;
+      script.integrity = dep.integrity;
+      script.crossOrigin = dep.crossOrigin;
+      document.body.appendChild(script);
+    });
+  }
+}
+
+export function platformCanSupportBodyPixWithoutDegradation(): boolean {
+  // https://blog.tensorflow.org/2019/11/updated-bodypix-2.html for more detail on performance
+  // https://github.com/tensorflow/tfjs/issues/3319 which results in firefox memory leak
+  const browser = detect();
+  return browser.name === 'chrome' && /(android)/i.test(navigator.userAgent) === false;
+}


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Add an image segmentation video filter based on Tensorflow BodyPix to demo.
The libraries are loaded at runtime. 

The tensorflow dependencies are under Apache 2.0 licenses:

Apache-2.0 https://www.npmjs.com/package/@tensorflow/tfjs/v/2.7.0
Apache-2.0 https://www.npmjs.com/package/@tensorflow/tfjs-core/v/2.7.0
Apache-2.0 https://www.npmjs.com/package/@tensorflow/tfjs-backend-webgl/v/2.7.0
Apache-2.0 https://www.npmjs.com/package/@tensorflow-models/body-pix/v/2.0.5  (this is the body pix machine learning model) 

**Testing**

1. Have you successfully run `npm run build:release` locally?  yes
2. How did you test these changes? demo only change, launch demo on desktop chrome and in meeting, enable segmentation filter
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes, browser demo
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no change to API
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no change to protocol.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.