### PR TITLE
Show the "Stop sharing" item while sharing the screen in the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add GatheringICECandidate Finish Duration to Meeting Event and to demo app
 - Add attendeePresenceReceived, audioInputSelected, videoInputSelected, audioInputUnselected, videoInputUnselected
 - Compute and add meetingStartDurationMs as part of the attributes of attendeePresenceReceived
+- Add the file sharing workaround for Chrome 88 in FAQs
 
 ### Changed
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -308,6 +308,7 @@
               <a id="dropdown-item-content-share-screen-capture" class="dropdown-item" href="#">Screen Capture...</a>
               <a id="dropdown-item-content-share-screen-test-video" class="dropdown-item" href="#">Test Video</a>
               <a id="dropdown-item-content-share-file-item" class="dropdown-item" href="#"><input id="content-share-item" type="file"></a>
+              <a id="dropdown-item-content-share-stop" style="display:none" class="dropdown-item" href="#">Stop Sharing</a>
             </div>
           </div>
         </div>

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -198,6 +198,11 @@
 						<h3>How can I stream music or video into a meeting?</h3>
 					</a>
 					<p>You can use the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare">AudioVideoFacade.startContentShare(MediaStream)</a> API to stream audio and/or video content to the meetings. See the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts#L1266">meeting demo application</a> for an example of how to achieve this.</p>
+					<a href="#when-i-stream-video-in-chrome-other-attendees-see-a-black-screen-is-this-a-known-issue" id="when-i-stream-video-in-chrome-other-attendees-see-a-black-screen-is-this-a-known-issue" style="color: inherit; text-decoration: none;">
+						<h3>When I stream video in Chrome, other attendees see a black screen. Is this a known issue?</h3>
+					</a>
+					<p>The <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare">AudioVideoFacade.startContentShare(MediaStream)</a> API uses the HTMLMediaElement.captureStream API to stream video content content to the meeting. Chrome 88 and above have a <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1156408">known issue</a> that the captureStream API does not send any data.</p>
+					<p>As a workaround, you can turn hardware acceleration off in Chrome (88.0.4324.146 and above) and then stream video. Go to Settings (<code>chrome://settings</code>), scroll down to the System, and turn &quot;Use hardware acceleration when available&quot; off.</p>
 					<a href="#how-do-i-broadcast-an-amazon-chime-sdk-meeting" id="how-do-i-broadcast-an-amazon-chime-sdk-meeting" style="color: inherit; text-decoration: none;">
 						<h3>How do I broadcast an Amazon Chime SDK meeting?</h3>
 					</a>

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -138,6 +138,12 @@ Applications built with the Amazon Chime SDK for JavaScript can adjust video par
 
 You can use the [AudioVideoFacade.startContentShare(MediaStream)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare) API to stream audio and/or video content to the meetings. See the [meeting demo application](https://github.com/aws/amazon-chime-sdk-js/blob/ee8831f2fe7747e52fdef49db0dc1dfc2a4778f6/demos/browser/app/meetingV2/meetingV2.ts#L1266) for an example of how to achieve this.
 
+### When I stream video in Chrome, other attendees see a black screen. Is this a known issue?
+
+The [AudioVideoFacade.startContentShare(MediaStream)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#startcontentshare) API uses the HTMLMediaElement.captureStream API to stream video content content to the meeting. Chrome 88 and above have a [known issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1156408) that the captureStream API does not send any data.
+
+As a workaround, you can turn hardware acceleration off in Chrome (88.0.4324.146 and above) and then stream video. Go to Settings (`chrome://settings`), scroll down to the System, and turn "Use hardware acceleration when available" off.
+
 ### How do I broadcast an Amazon Chime SDK meeting?
 
 You can deploy a web application broadcasting solution similar to the [Amazon Chime Meeting Broadcasting Demo](https://github.com/aws-samples/amazon-chime-meeting-broadcast-demo) to broadcast an Amazon Chime SDK meeting to RTMP-enabled streaming services by instead using a `MEETING_URL` consisting of the URL to the meeting to be broadcasted.


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- This PR fixes three UX issues in the demo. Before this PR:
  1. If you clicked the "Test Video" twice in a row and then shared screen, you and other attendees saw a different content. 
  2. If you switched the content type from one to another, the camera button indicated the wrong state.
  3. When you dismissed the browser's screen-share window, the camera button became enabled. This PR enables the button only when you actually share screen. Note that in the fatal mode (`fatal=1`), the fatal error page appears as the browser's capture API throws an error. 

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
  a. Join the meeting demo in Chrome, Firefox, or Safari.
  b. Click the "Screen Capture," "Test Video," and upload a video file.
  c. Click the camera button to disable the content share.
  d. Click the camera button to enable the content share selected at step B. Ensure that other attendees see the content.
  e. Click the "Stop sharing" under the camera dropdown. Ensure that other attendees do not see the content.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.