### PR TITLE
Set attendeePresenceTimeoutMs to use value passed as parameter in the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the file sharing workaround for Chrome 88 in FAQs
 
 ### Changed
+- Set attendeePresenceTimeoutMs to use value passed as parameter in the URL
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1128,7 +1128,11 @@ export class DemoMeetingApp
       enableWebAudio: this.enableWebAudio,
     });
     configuration.enableUnifiedPlanForChromiumBasedBrowsers = this.enableUnifiedPlanForChromiumBasedBrowsers;
-    configuration.attendeePresenceTimeoutMs = 5000;
+    const urlParameters = new URL(window.location.href).searchParams;
+    const timeoutMs = Number(urlParameters.get('attendee-presence-timeout-ms'));
+    if (!isNaN(timeoutMs)) {
+      configuration.attendeePresenceTimeoutMs = Number(timeoutMs);
+    }
     configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = this.enableSimulcast;
     this.meetingSession = new DefaultMeetingSession(
       configuration,


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
Set attendeePresenceTimeoutMs to use value passed as parameter in the URL 

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manually

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo app

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

