### PR TITLE
[Demo] Fix test sound in Safari

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -124,6 +124,8 @@ type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'None';
 const VIDEO_FILTERS: VideoFilterName[] = ['Emojify', 'CircularCut', 'NoOp'];
 
 class TestSound {
+  static testAudioElement = new Audio();
+
   constructor(
     private logger: Logger,
     private sinkId: string | null,
@@ -164,7 +166,7 @@ class TestSound {
       }
     }
     try {
-      await audioMixController.bindAudioElement(new Audio());
+      await audioMixController.bindAudioElement(TestSound.testAudioElement);
     } catch (e) {
       fatal(e);
       this.logger?.error(`Failed to bind audio element: ${e}`);


### PR DESCRIPTION
**Issue #1051 :**
Fix test sound button in the preview page sometimes does not play sound in Safari (macOS and iOS).

**Description of changes:**
Create an audio element for testing audio output in preview page instead of creating a new HTMLAudioElement everytime the test sound button is clicked which seems to cause issues in Safari.
 
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manually clicked on the test sound button many times in Safari MacOS and iOS and verified that there was sound.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, this can be tested using the meeting demo test sound button in preview page. 
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

