### PR TITLE
Remove readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Amazon Chime SDK for JavaScript
 
 <a href="https://www.npmjs.com/package/amazon-chime-sdk-js"><img src="https://img.shields.io/npm/v/amazon-chime-sdk-js?style=flat-square"></a>
-<a href="https://github.com/aws/amazon-chime-sdk-js/actions?query=workflow%3A%22CI+Workflow%22"><img src="https://github.com/aws/amazon-chime-sdk-js/workflows/CI%20Workflow/badge.svg"></a>
 <a href="https://github.com/aws/amazon-chime-sdk-js/actions?query=workflow%3A%22Deploy+Demo+App+Workflow%22"><img src="https://github.com/aws/amazon-chime-sdk-js/workflows/Deploy%20Demo%20App%20Workflow/badge.svg"></a>
 ### Build video calling, audio calling, and screen sharing applications powered by Amazon Chime.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,6 @@
 					<h1>Amazon Chime SDK for JavaScript</h1>
 				</a>
 				<p><a href="https://www.npmjs.com/package/amazon-chime-sdk-js"><img src="https://img.shields.io/npm/v/amazon-chime-sdk-js?style=flat-square"></a>
-					<a href="https://github.com/aws/amazon-chime-sdk-js/actions?query=workflow%3A%22CI+Workflow%22"><img src="https://github.com/aws/amazon-chime-sdk-js/workflows/CI%20Workflow/badge.svg"></a>
 				<a href="https://github.com/aws/amazon-chime-sdk-js/actions?query=workflow%3A%22Deploy+Demo+App+Workflow%22"><img src="https://github.com/aws/amazon-chime-sdk-js/workflows/Deploy%20Demo%20App%20Workflow/badge.svg"></a></p>
 				<a href="#build-video-calling-audio-calling-and-screen-sharing-applications-powered-by-amazon-chime" id="build-video-calling-audio-calling-and-screen-sharing-applications-powered-by-amazon-chime" style="color: inherit; text-decoration: none;">
 					<h3>Build video calling, audio calling, and screen sharing applications powered by Amazon Chime.</h3>


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Removes the CI workflow badge on our README since it doesnt work as expected. Plus it doesnt make sense when there are multiple worklows running at the same time.

**Testing**
n/a

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? verify that badge no longer exists in readme
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n/a
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

