### PR TITLE
Use setProperty to log meeting attributes to Cloudwatch

### DIFF
--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -280,11 +280,8 @@ function addSignalMetricsToCloudWatch(logMsg, meetingId, attendeeId) {
   const metricList = ['signalingOpenDurationMs', 'iceGatheringDurationMs', 'attendeePresenceDurationMs', 'meetingStartDurationMs'];
   const putMetric =
     metricScope(metrics => (metricName, metricValue, meetingId, attendeeId) => {
-      metrics.putDimensions({MeetingId: meetingId, AttendeeId: attendeeId});
-      metrics.putMetric(metricName, metricValue);
-    });
-  const putSignalMetric =
-    metricScope(metrics => (metricName, metricValue) => {
+      metrics.setProperty('MeetingId', meetingId);
+      metrics.setProperty('AttendeeId', attendeeId);
       metrics.putMetric(metricName, metricValue);
     });
   for (let metricIndex = 0; metricIndex <= metricList.length; metricIndex += 1) {
@@ -293,7 +290,6 @@ function addSignalMetricsToCloudWatch(logMsg, meetingId, attendeeId) {
       const metricValue = logMsgJson.attributes[metricName];
       console.log('Logging metric -> ', metricName, ': ', metricValue );
       putMetric(metricName, metricValue, meetingId, attendeeId);
-      putSignalMetric(metricName, metricValue);
     }
   }
 }


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
Use setProperty to log meeting attributes to Cloudwatch

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes

2. How did you test these changes?
Manually

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, meeting demo app

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

