### PR TITLE
Fix crash issue "Cannot read property 'toLowerCasePropertyNames' of undefined"

### DIFF
--- a/src/meetingsession/MeetingSessionConfiguration.ts
+++ b/src/meetingsession/MeetingSessionConfiguration.ts
@@ -173,7 +173,12 @@ export default class MeetingSessionConfiguration {
     } else if (typeof input !== 'object') {
       return input;
     } else if (Array.isArray(input)) {
-      return input.map(this.toLowerCasePropertyNames);
+        if (input.length) {
+            return input.map(this.toLowerCasePropertyNames);
+        } else {
+            return input;
+        }
+      
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return Object.keys(input).reduce((result: any, key: string) => {


### PR DESCRIPTION


Related issue link: https://github.com/aws/amazon-chime-sdk-js/issues/1052

**Issue #1052:**

**Description of changes:**

**Testing**

1. No
2. Unit test
3. no
4. no
5. no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

