### PR TITLE
Ignore old group IDs which may correspond to a disconnected client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `DefaultDeviceController` now attempts to resume a suspended `AudioContext`
   when choosing a transform device (#1062).
+- `DefaultVideoStreamIndex` now ignores old group IDs from a given attendee ID (#1029).
 
 
 ## [2.4.1] - 2021-01-28

--- a/docs/classes/defaultvideostreamindex.html
+++ b/docs/classes/defaultvideostreamindex.html
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L322">src/videostreamindex/DefaultVideoStreamIndex.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L138">src/videostreamindex/DefaultVideoStreamIndex.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L145">src/videostreamindex/DefaultVideoStreamIndex.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L148">src/videostreamindex/DefaultVideoStreamIndex.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L155">src/videostreamindex/DefaultVideoStreamIndex.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L288">src/videostreamindex/DefaultVideoStreamIndex.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L295">src/videostreamindex/DefaultVideoStreamIndex.ts:295</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -399,7 +399,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L256">src/videostreamindex/DefaultVideoStreamIndex.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L263">src/videostreamindex/DefaultVideoStreamIndex.ts:263</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L427">src/videostreamindex/DefaultVideoStreamIndex.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L434">src/videostreamindex/DefaultVideoStreamIndex.ts:434</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -445,7 +445,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L364">src/videostreamindex/DefaultVideoStreamIndex.ts:364</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L371">src/videostreamindex/DefaultVideoStreamIndex.ts:371</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -468,7 +468,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L385">src/videostreamindex/DefaultVideoStreamIndex.ts:385</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L392">src/videostreamindex/DefaultVideoStreamIndex.ts:392</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -491,7 +491,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L375">src/videostreamindex/DefaultVideoStreamIndex.ts:375</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L382">src/videostreamindex/DefaultVideoStreamIndex.ts:382</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -514,7 +514,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L353">src/videostreamindex/DefaultVideoStreamIndex.ts:353</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L360">src/videostreamindex/DefaultVideoStreamIndex.ts:360</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -538,7 +538,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L272">src/videostreamindex/DefaultVideoStreamIndex.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L279">src/videostreamindex/DefaultVideoStreamIndex.ts:279</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L304">src/videostreamindex/DefaultVideoStreamIndex.ts:304</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L311">src/videostreamindex/DefaultVideoStreamIndex.ts:311</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -586,7 +586,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L222">src/videostreamindex/DefaultVideoStreamIndex.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L229">src/videostreamindex/DefaultVideoStreamIndex.ts:229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -610,7 +610,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratebitratesframe">integrateBitratesFrame</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L125">src/videostreamindex/DefaultVideoStreamIndex.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L132">src/videostreamindex/DefaultVideoStreamIndex.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -658,7 +658,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratesubscribeackframe">integrateSubscribeAckFrame</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L113">src/videostreamindex/DefaultVideoStreamIndex.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L120">src/videostreamindex/DefaultVideoStreamIndex.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -724,7 +724,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L248">src/videostreamindex/DefaultVideoStreamIndex.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L255">src/videostreamindex/DefaultVideoStreamIndex.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -742,7 +742,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L251">src/videostreamindex/DefaultVideoStreamIndex.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -784,7 +784,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -808,7 +808,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -832,7 +832,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L167">src/videostreamindex/DefaultVideoStreamIndex.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L174">src/videostreamindex/DefaultVideoStreamIndex.ts:174</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -865,7 +865,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L350">src/videostreamindex/DefaultVideoStreamIndex.ts:350</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -883,7 +883,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L108">src/videostreamindex/DefaultVideoStreamIndex.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L115">src/videostreamindex/DefaultVideoStreamIndex.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -900,7 +900,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L397">src/videostreamindex/DefaultVideoStreamIndex.ts:397</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L404">src/videostreamindex/DefaultVideoStreamIndex.ts:404</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideostreamindex.html
+++ b/docs/classes/defaultvideostreamindex.html
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L294">src/videostreamindex/DefaultVideoStreamIndex.ts:294</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L322">src/videostreamindex/DefaultVideoStreamIndex.ts:322</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L110">src/videostreamindex/DefaultVideoStreamIndex.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L138">src/videostreamindex/DefaultVideoStreamIndex.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L120">src/videostreamindex/DefaultVideoStreamIndex.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L148">src/videostreamindex/DefaultVideoStreamIndex.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L260">src/videostreamindex/DefaultVideoStreamIndex.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L288">src/videostreamindex/DefaultVideoStreamIndex.ts:288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -399,7 +399,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L228">src/videostreamindex/DefaultVideoStreamIndex.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L256">src/videostreamindex/DefaultVideoStreamIndex.ts:256</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L399">src/videostreamindex/DefaultVideoStreamIndex.ts:399</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L427">src/videostreamindex/DefaultVideoStreamIndex.ts:427</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -445,7 +445,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L364">src/videostreamindex/DefaultVideoStreamIndex.ts:364</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -468,7 +468,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L357">src/videostreamindex/DefaultVideoStreamIndex.ts:357</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L385">src/videostreamindex/DefaultVideoStreamIndex.ts:385</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -491,7 +491,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L347">src/videostreamindex/DefaultVideoStreamIndex.ts:347</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L375">src/videostreamindex/DefaultVideoStreamIndex.ts:375</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -514,7 +514,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L325">src/videostreamindex/DefaultVideoStreamIndex.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L353">src/videostreamindex/DefaultVideoStreamIndex.ts:353</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -538,7 +538,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L272">src/videostreamindex/DefaultVideoStreamIndex.ts:272</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -562,7 +562,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L276">src/videostreamindex/DefaultVideoStreamIndex.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L304">src/videostreamindex/DefaultVideoStreamIndex.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -586,7 +586,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L194">src/videostreamindex/DefaultVideoStreamIndex.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L222">src/videostreamindex/DefaultVideoStreamIndex.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -610,7 +610,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratebitratesframe">integrateBitratesFrame</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L97">src/videostreamindex/DefaultVideoStreamIndex.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L125">src/videostreamindex/DefaultVideoStreamIndex.ts:125</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -658,7 +658,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#integratesubscribeackframe">integrateSubscribeAckFrame</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L85">src/videostreamindex/DefaultVideoStreamIndex.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L113">src/videostreamindex/DefaultVideoStreamIndex.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -724,7 +724,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L220">src/videostreamindex/DefaultVideoStreamIndex.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L248">src/videostreamindex/DefaultVideoStreamIndex.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -742,7 +742,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L216">src/videostreamindex/DefaultVideoStreamIndex.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -784,7 +784,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L308">src/videostreamindex/DefaultVideoStreamIndex.ts:308</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -808,7 +808,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L301">src/videostreamindex/DefaultVideoStreamIndex.ts:301</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -832,7 +832,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L139">src/videostreamindex/DefaultVideoStreamIndex.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L167">src/videostreamindex/DefaultVideoStreamIndex.ts:167</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -865,7 +865,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L315">src/videostreamindex/DefaultVideoStreamIndex.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -883,7 +883,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L80">src/videostreamindex/DefaultVideoStreamIndex.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L108">src/videostreamindex/DefaultVideoStreamIndex.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -900,7 +900,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L369">src/videostreamindex/DefaultVideoStreamIndex.ts:369</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L397">src/videostreamindex/DefaultVideoStreamIndex.ts:397</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/simulcastvideostreamindex.html
+++ b/docs/classes/simulcastvideostreamindex.html
@@ -379,7 +379,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L294">src/videostreamindex/DefaultVideoStreamIndex.ts:294</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L322">src/videostreamindex/DefaultVideoStreamIndex.ts:322</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -407,7 +407,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L110">src/videostreamindex/DefaultVideoStreamIndex.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L138">src/videostreamindex/DefaultVideoStreamIndex.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -426,7 +426,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L120">src/videostreamindex/DefaultVideoStreamIndex.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L148">src/videostreamindex/DefaultVideoStreamIndex.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -451,7 +451,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L260">src/videostreamindex/DefaultVideoStreamIndex.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L288">src/videostreamindex/DefaultVideoStreamIndex.ts:288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -476,7 +476,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L228">src/videostreamindex/DefaultVideoStreamIndex.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L256">src/videostreamindex/DefaultVideoStreamIndex.ts:256</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -501,7 +501,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L272">src/videostreamindex/DefaultVideoStreamIndex.ts:272</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -526,7 +526,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L276">src/videostreamindex/DefaultVideoStreamIndex.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L304">src/videostreamindex/DefaultVideoStreamIndex.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -551,7 +551,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L194">src/videostreamindex/DefaultVideoStreamIndex.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L222">src/videostreamindex/DefaultVideoStreamIndex.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -712,7 +712,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L220">src/videostreamindex/DefaultVideoStreamIndex.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L248">src/videostreamindex/DefaultVideoStreamIndex.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -731,7 +731,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L216">src/videostreamindex/DefaultVideoStreamIndex.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -775,7 +775,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L308">src/videostreamindex/DefaultVideoStreamIndex.ts:308</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -800,7 +800,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L301">src/videostreamindex/DefaultVideoStreamIndex.ts:301</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -825,7 +825,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L139">src/videostreamindex/DefaultVideoStreamIndex.ts:139</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L167">src/videostreamindex/DefaultVideoStreamIndex.ts:167</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -859,7 +859,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L315">src/videostreamindex/DefaultVideoStreamIndex.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -878,7 +878,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L80">src/videostreamindex/DefaultVideoStreamIndex.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L108">src/videostreamindex/DefaultVideoStreamIndex.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/simulcastvideostreamindex.html
+++ b/docs/classes/simulcastvideostreamindex.html
@@ -379,7 +379,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidsinsamegroup">StreamIdsInSameGroup</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L322">src/videostreamindex/DefaultVideoStreamIndex.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -407,7 +407,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allstreams">allStreams</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allstreams">allStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L138">src/videostreamindex/DefaultVideoStreamIndex.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L145">src/videostreamindex/DefaultVideoStreamIndex.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -426,7 +426,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#allvideosendingsourcesexcludingself">allVideoSendingSourcesExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L148">src/videostreamindex/DefaultVideoStreamIndex.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L155">src/videostreamindex/DefaultVideoStreamIndex.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -451,7 +451,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidforstreamid">attendeeIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L288">src/videostreamindex/DefaultVideoStreamIndex.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L295">src/videostreamindex/DefaultVideoStreamIndex.ts:295</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -476,7 +476,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#attendeeidfortrack">attendeeIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L256">src/videostreamindex/DefaultVideoStreamIndex.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L263">src/videostreamindex/DefaultVideoStreamIndex.ts:263</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -501,7 +501,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#externaluseridfortrack">externalUserIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L272">src/videostreamindex/DefaultVideoStreamIndex.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L279">src/videostreamindex/DefaultVideoStreamIndex.ts:279</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -526,7 +526,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#groupidforstreamid">groupIdForStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L304">src/videostreamindex/DefaultVideoStreamIndex.ts:304</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L311">src/videostreamindex/DefaultVideoStreamIndex.ts:311</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -551,7 +551,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#highestqualitystreamfromeachgroupexcludingself">highestQualityStreamFromEachGroupExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L222">src/videostreamindex/DefaultVideoStreamIndex.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L229">src/videostreamindex/DefaultVideoStreamIndex.ts:229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -712,7 +712,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#numberofparticipants">numberOfParticipants</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L248">src/videostreamindex/DefaultVideoStreamIndex.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L255">src/videostreamindex/DefaultVideoStreamIndex.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -731,7 +731,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#numberofvideopublishingparticipantsexcludingself">numberOfVideoPublishingParticipantsExcludingSelf</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L244">src/videostreamindex/DefaultVideoStreamIndex.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L251">src/videostreamindex/DefaultVideoStreamIndex.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -775,7 +775,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidforssrc">streamIdForSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -800,7 +800,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamidfortrack">streamIdForTrack</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L329">src/videostreamindex/DefaultVideoStreamIndex.ts:329</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L336">src/videostreamindex/DefaultVideoStreamIndex.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -825,7 +825,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamselectionunderbandwidthconstraint">streamSelectionUnderBandwidthConstraint</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L167">src/videostreamindex/DefaultVideoStreamIndex.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L174">src/videostreamindex/DefaultVideoStreamIndex.ts:174</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -859,7 +859,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#streamspausedatsource">streamsPausedAtSource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L343">src/videostreamindex/DefaultVideoStreamIndex.ts:343</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L350">src/videostreamindex/DefaultVideoStreamIndex.ts:350</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultvideostreamidset.html" class="tsd-signature-type">DefaultVideoStreamIdSet</a></h4>
@@ -878,7 +878,7 @@
 								<p>Implementation of <a href="../interfaces/videostreamindex.html">VideoStreamIndex</a>.<a href="../interfaces/videostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<p>Inherited from <a href="defaultvideostreamindex.html">DefaultVideoStreamIndex</a>.<a href="defaultvideostreamindex.html#subscribeframesent">subscribeFrameSent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L108">src/videostreamindex/DefaultVideoStreamIndex.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videostreamindex/DefaultVideoStreamIndex.ts#L115">src/videostreamindex/DefaultVideoStreamIndex.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/test/transceivercontroller/DefaultTransceiverController.test.ts
+++ b/test/transceivercontroller/DefaultTransceiverController.test.ts
@@ -244,6 +244,7 @@ describe('DefaultTransceiverController', () => {
             groupId: id,
             maxBitrateKbps: 100,
             mediaType: SdkStreamMediaType.VIDEO,
+            attendeeId: `attendee-${id}`,
           })
         );
       }

--- a/test/transceivercontroller/SimulcastTransceiverController.test.ts
+++ b/test/transceivercontroller/SimulcastTransceiverController.test.ts
@@ -228,6 +228,7 @@ describe('SimulcastTransceiverController', () => {
             groupId: id,
             maxBitrateKbps: 100,
             mediaType: SdkStreamMediaType.VIDEO,
+            attendeeId: `attendee-${id}`,
           })
         );
       }
@@ -252,6 +253,7 @@ describe('SimulcastTransceiverController', () => {
             groupId: id.groupId,
             maxBitrateKbps: 100,
             mediaType: SdkStreamMediaType.VIDEO,
+            attendeeId: `attendee-${id.groupId}`,
           })
         );
       }

--- a/test/videostreamindex/DefaultVideoStreamIndex.test.ts
+++ b/test/videostreamindex/DefaultVideoStreamIndex.test.ts
@@ -96,7 +96,7 @@ describe('DefaultVideoStreamIndex', () => {
               streamId: 4,
               groupId: 399,
               maxBitrateKbps: 800,
-              attendeeId: 'xy1',
+              attendeeId: 'xy3',
               mediaType: SdkStreamMediaType.VIDEO,
             }),
             new SdkStreamDescriptor({
@@ -110,7 +110,7 @@ describe('DefaultVideoStreamIndex', () => {
               streamId: 3,
               groupId: 399,
               maxBitrateKbps: 200,
-              attendeeId: 'xy1',
+              attendeeId: 'xy3',
               mediaType: SdkStreamMediaType.VIDEO,
             }),
             new SdkStreamDescriptor({
@@ -188,12 +188,66 @@ describe('DefaultVideoStreamIndex', () => {
               streamId: 4,
               groupId: 399,
               maxBitrateKbps: 800,
-              attendeeId: 'xy1',
+              attendeeId: 'xy3',
               mediaType: SdkStreamMediaType.VIDEO,
             }),
             new SdkStreamDescriptor({
               streamId: 3,
               groupId: 399,
+              maxBitrateKbps: 200,
+              attendeeId: 'xy3',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+            new SdkStreamDescriptor({
+              streamId: 2,
+              groupId: 1,
+              maxBitrateKbps: 200,
+              attendeeId: 'xy1',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+            new SdkStreamDescriptor({
+              streamId: 1,
+              groupId: 1,
+              maxBitrateKbps: 100,
+              attendeeId: 'xy1',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+          ],
+        })
+      );
+      expect(
+        index.highestQualityStreamFromEachGroupExcludingSelf('attendee-e618d153').array()
+      ).to.deep.equal([2, 4, 6]);
+    });
+
+    it('filters out old group ids for a single attendee id', () => {
+      index.integrateIndexFrame(
+        new SdkIndexFrame({
+          sources: [
+            new SdkStreamDescriptor({
+              streamId: 6,
+              groupId: 2,
+              maxBitrateKbps: 400,
+              attendeeId: 'xy2',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+            new SdkStreamDescriptor({
+              streamId: 5,
+              groupId: 2,
+              maxBitrateKbps: 50,
+              attendeeId: 'xy2',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+            new SdkStreamDescriptor({
+              streamId: 4,
+              groupId: 3,
+              maxBitrateKbps: 800,
+              attendeeId: 'xy1',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+            new SdkStreamDescriptor({
+              streamId: 3,
+              groupId: 3,
               maxBitrateKbps: 200,
               attendeeId: 'xy1',
               mediaType: SdkStreamMediaType.VIDEO,
@@ -217,7 +271,7 @@ describe('DefaultVideoStreamIndex', () => {
       );
       expect(
         index.highestQualityStreamFromEachGroupExcludingSelf('attendee-e618d153').array()
-      ).to.deep.equal([2, 4, 6]);
+      ).to.deep.equal([4, 6]);
     });
   });
 


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-ios/issues/222 https://github.com/aws/amazon-chime-sdk-android/issues/222 https://github.com/aws/amazon-chime-sdk-js/issues/1029 & partially https://github.com/aws/amazon-chime-sdk-js/issues/561 (dupes in other repos), linking so they update issue.

**Description of changes:**
Copying comment here:
```
    // In the Amazon Chime SDKs, we assume a one to one mapping of group ID to profile ID when creating
    // video tiles (multiple video sources are supported through applying a `Modality` to a given profile/session token)
    //
    // We enforce this here to mitigate any possible duplicate group IDs left from a reconnection where the previous
    // signal channel hasn't been timed out yet.  To guarantee we receive the latest stream we use the highest group ID
    // since they are monotonically increasing.
```

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes


2. How did you test these changes?
I tested by using demo client to join a meeting.  I then used two modified native clients to join the meeting with the same attendee ID, both trying to send video.  I confirmed that the JS SDK client only subscribed to the newest group ID.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, the browser demo.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

