### PR TITLE
Enable SIMD autodetection for Chrome 90+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enable SIMD autodetection for Amazon Voice Focus in Chrome 90+.
+
 ### Removed
 
 ### Fixed

--- a/libs/voicefocus/support.js
+++ b/libs/voicefocus/support.js
@@ -94,6 +94,7 @@ const supportsWASMStreaming = (scope = globalThis, logger) => {
     }
 };
 exports.supportsWASMStreaming = supportsWASMStreaming;
+const SUPPORTED_CHROME_VERSION = 90;
 const isOldChrome = (global = globalThis, logger) => {
     try {
         if (!global.chrome) {
@@ -107,6 +108,10 @@ const isOldChrome = (global = globalThis, logger) => {
         logger === null || logger === void 0 ? void 0 : logger.debug('Unknown Chrome version.');
         return true;
     }
-    return true;
+    if (parseInt(versionCheck[1], 10) < SUPPORTED_CHROME_VERSION) {
+        logger === null || logger === void 0 ? void 0 : logger.debug(`Chrome ${versionCheck[1]} has incomplete SIMD support.`);
+        return true;
+    }
+    return false;
 };
 exports.isOldChrome = isOldChrome;


### PR DESCRIPTION
This imports the current Amazon Voice Focus library, which — now that [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1160031) is fixed — enables SIMD autodetection in Chrome 90+.

This change is tested upstream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

