### PR TITLE
Handle content share errors in the demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `SingleNodeAudioTransformDevice` to make simple audio transforms easier to write.
+- Reuse `VoiceFocusAudioNode` instances across transform device operations.
 - Add End-to-end Integration test for Video Test App
 
 ### Changed

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -2148,18 +2148,31 @@ export class DemoMeetingApp
 
   private async contentShareStart(videoUrl?: string): Promise<void> {
     switch (this.contentShareType) {
-      case ContentShareType.ScreenCapture:
-        await this.audioVideo.startContentShareFromScreenCapture();
+      case ContentShareType.ScreenCapture: {
+        try {
+          await this.audioVideo.startContentShareFromScreenCapture();
+        } catch (e) {
+          this.meetingLogger?.error(`Could not start content share: ${e}`);
+          return;
+        }
         break;
-      case ContentShareType.VideoFile:
+      }
+      case ContentShareType.VideoFile: {
         const videoFile = document.getElementById('content-share-video') as HTMLVideoElement;
         if (videoUrl) {
           videoFile.src = videoUrl;
         }
 
         const mediaStream = await this.playToStream(videoFile);
-        this.audioVideo.startContentShare(mediaStream);
+        try {
+          // getDisplayMedia can throw.
+          await this.audioVideo.startContentShare(mediaStream);
+        } catch (e) {
+          this.meetingLogger?.error(`Could not start content share: ${e}`);
+          return;
+        }
         break;
+      }
     }
 
     this.toggleButton('button-content-share', 'on');

--- a/docs/classes/voicefocustransformdevice.html
+++ b/docs/classes/voicefocustransformdevice.html
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L184">src/voicefocus/VoiceFocusTransformDevice.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L192">src/voicefocus/VoiceFocusTransformDevice.ts:192</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L192">src/voicefocus/VoiceFocusTransformDevice.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L200">src/voicefocus/VoiceFocusTransformDevice.ts:200</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -644,7 +644,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/AudioTransformDevice.ts#L58">src/devicecontroller/AudioTransformDevice.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/AudioTransformDevice.ts#L62">src/devicecontroller/AudioTransformDevice.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -675,7 +675,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L197">src/voicefocus/VoiceFocusTransformDevice.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/voicefocus/VoiceFocusTransformDevice.ts#L205">src/voicefocus/VoiceFocusTransformDevice.ts:205</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/audiotransformdevice.html
+++ b/docs/interfaces/audiotransformdevice.html
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/AudioTransformDevice.ts#L49">src/devicecontroller/AudioTransformDevice.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/AudioTransformDevice.ts#L53">src/devicecontroller/AudioTransformDevice.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -134,6 +134,9 @@
 									<p>Optionally return a pair of <code>AudioNode</code>s that should be connected to the applied inner
 									device. The two nodes can be the same, indicating the smallest possible subgraph.</p>
 								</div>
+								<p>Each device can be used no more than once at a time in an audio graph. It is acceptable
+									to reuse audio nodes for successive calls to <code>createAudioNode</code>, so long as the context
+								does not differ.</p>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">

--- a/src/devicecontroller/AudioTransformDevice.ts
+++ b/src/devicecontroller/AudioTransformDevice.ts
@@ -44,6 +44,10 @@ export default interface AudioTransformDevice {
    * Optionally return a pair of `AudioNode`s that should be connected to the applied inner
    * device. The two nodes can be the same, indicating the smallest possible subgraph.
    *
+   * Each device can be used no more than once at a time in an audio graph. It is acceptable
+   * to reuse audio nodes for successive calls to `createAudioNode`, so long as the context
+   * does not differ.
+   *
    * @param context The `AudioContext` to use when instantiating the nodes.
    */
   createAudioNode?(context: AudioContext): Promise<AudioNodeSubgraph | undefined>;

--- a/src/voicefocus/VoiceFocusTransformDevice.ts
+++ b/src/voicefocus/VoiceFocusTransformDevice.ts
@@ -156,6 +156,13 @@ class VoiceFocusTransformDevice implements AudioTransformDevice {
   }
 
   async createAudioNode(context: AudioContext): Promise<AudioNodeSubgraph> {
+    if (this.node?.context === context) {
+      return {
+        start: this.node,
+        end: this.node,
+      };
+    }
+
     const agc: AGCOptions = { useVoiceFocusAGC: false };
     const options = {
       enabled: true,
@@ -164,6 +171,7 @@ class VoiceFocusTransformDevice implements AudioTransformDevice {
     };
 
     try {
+      this.node?.disconnect();
       this.node = await this.voiceFocus.createNode(context, options);
       const start = this.node;
       const end = this.node;


### PR DESCRIPTION
This commit simply logs errors that arise from attempts to start content share. These will commonly be

```
      DOMException: Permission denied
```    

when the user hits Cancel rather than choosing a screen to share.

This PR is rebased on top of 1084 so it can land without re-running CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

