### PR TITLE
Make logger robust against undefined arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VoiceFocusDeviceTransformer`, making it easier to instantiate a new
   transformer in a different scope with the same measured settings.
 - Add End-to-end Integration test for Video Test App
+- `MeetingSessionPOSTLogger` now matches the regular `Logger` API signature.
 
 ### Changed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't automatically upgrade dev-dependencies to avoid a breaking typedoc upgrade.
+- Safely handle calling logger `debug` methods with `undefined`.
 
 
 ## [2.5.0] - 2021-02-16

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -5051,9 +5051,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.850.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.850.0.tgz",
-      "integrity": "sha512-RqPeSKe1JlhTUL9+xUsp771ZtMY7JICoQEnFJuJ+JVqGyILhg95L4t8S5KnznUfWYc0pcpTiHKLmPteHyHS3pw==",
+      "version": "2.852.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.852.0.tgz",
+      "integrity": "sha512-Oj3ZWsHly5o+TiayKDbuWZSq5SkqoNZF/wLxmqolP3tlQ55zfGme1s/5J7vcuVIz4+PlISMlgE5kAhxhjAieyg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.850.0",
+    "aws-sdk": "^2.852.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/docs/classes/consolelogger.html
+++ b/docs/classes/consolelogger.html
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L58">src/logger/ConsoleLogger.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L65">src/logger/ConsoleLogger.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L62">src/logger/ConsoleLogger.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L69">src/logger/ConsoleLogger.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -312,7 +312,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L54">src/logger/ConsoleLogger.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/ConsoleLogger.ts#L61">src/logger/ConsoleLogger.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/meetingsessionpostlogger.html
+++ b/docs/classes/meetingsessionpostlogger.html
@@ -268,7 +268,7 @@
 					<a name="debug" class="tsd-anchor"></a>
 					<h3>debug</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">debug<span class="tsd-signature-symbol">(</span>debugFunction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">debug<span class="tsd-signature-symbol">(</span>debugFunction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -280,19 +280,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>debugFunction: <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span></h5>
-									<ul class="tsd-parameters">
-										<li class="tsd-parameter-signature">
-											<ul class="tsd-signatures tsd-kind-type-literal">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></li>
-											</ul>
-											<ul class="tsd-descriptions">
-												<li class="tsd-description">
-													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
-												</li>
-											</ul>
-										</li>
-									</ul>
+									<h5>debugFunction: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -309,7 +297,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L48">src/logger/MeetingSessionPOSTLogger.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L55">src/logger/MeetingSessionPOSTLogger.ts:55</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -332,7 +320,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L60">src/logger/MeetingSessionPOSTLogger.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L67">src/logger/MeetingSessionPOSTLogger.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -349,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L56">src/logger/MeetingSessionPOSTLogger.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L63">src/logger/MeetingSessionPOSTLogger.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -366,7 +354,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L40">src/logger/MeetingSessionPOSTLogger.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L47">src/logger/MeetingSessionPOSTLogger.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -389,7 +377,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L103">src/logger/MeetingSessionPOSTLogger.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L110">src/logger/MeetingSessionPOSTLogger.ts:110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -415,7 +403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L94">src/logger/MeetingSessionPOSTLogger.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L101">src/logger/MeetingSessionPOSTLogger.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L52">src/logger/MeetingSessionPOSTLogger.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L59">src/logger/MeetingSessionPOSTLogger.ts:59</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -461,7 +449,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L64">src/logger/MeetingSessionPOSTLogger.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L71">src/logger/MeetingSessionPOSTLogger.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -484,7 +472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L88">src/logger/MeetingSessionPOSTLogger.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L95">src/logger/MeetingSessionPOSTLogger.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -501,7 +489,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L44">src/logger/MeetingSessionPOSTLogger.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MeetingSessionPOSTLogger.ts#L51">src/logger/MeetingSessionPOSTLogger.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/multilogger.html
+++ b/docs/classes/multilogger.html
@@ -216,7 +216,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#getloglevel">getLogLevel</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L58">src/logger/MultiLogger.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L62">src/logger/MultiLogger.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../enums/loglevel.html" class="tsd-signature-type">LogLevel</a></h4>
@@ -258,7 +258,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/logger.html">Logger</a>.<a href="../interfaces/logger.html#setloglevel">setLogLevel</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L52">src/logger/MultiLogger.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/logger/MultiLogger.ts#L56">src/logger/MultiLogger.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -178,7 +178,7 @@ class SdkBaseTest extends KiteBaseTest {
 
   writeCompletionTimeTo(filePath) {
     try {
-      const epochTimeInSeconds = Math.round(new Date().getTime() / 1000);
+      const epochTimeInSeconds = Math.round(Date.now() / 1000);
       fs.appendFileSync(`${filePath}/last_run_timestamp`, `${epochTimeInSeconds}\n`, {flag: 'a+'});
       console.log(`Wrote canary completion timestamp : ${epochTimeInSeconds}`);
     } catch (e) {

--- a/src/logger/ConsoleLogger.ts
+++ b/src/logger/ConsoleLogger.ts
@@ -48,7 +48,14 @@ export default class ConsoleLogger implements Logger {
     if (LogLevel.DEBUG < this.level) {
       return;
     }
-    this.log(LogLevel.DEBUG, typeof debugFunction === 'string' ? debugFunction : debugFunction());
+
+    if (typeof debugFunction === 'string') {
+      this.log(LogLevel.DEBUG, debugFunction);
+    } else if (debugFunction) {
+      this.log(LogLevel.DEBUG, debugFunction());
+    } else {
+      this.log(LogLevel.DEBUG, '' + debugFunction);
+    }
   }
 
   setLogLevel(level: LogLevel): void {

--- a/src/logger/MeetingSessionPOSTLogger.ts
+++ b/src/logger/MeetingSessionPOSTLogger.ts
@@ -30,11 +30,18 @@ export default class MeetingSessionPOSTLogger {
       });
   }
 
-  debug(debugFunction: () => string): void {
+  debug(debugFunction: string | (() => string)): void {
     if (LogLevel.DEBUG < this.level) {
       return;
     }
-    this.log(LogLevel.DEBUG, debugFunction());
+
+    if (typeof debugFunction === 'string') {
+      this.log(LogLevel.DEBUG, debugFunction);
+    } else if (debugFunction) {
+      this.log(LogLevel.DEBUG, debugFunction());
+    } else {
+      this.log(LogLevel.DEBUG, '' + debugFunction);
+    }
   }
 
   info(msg: string): void {
@@ -104,8 +111,10 @@ export default class MeetingSessionPOSTLogger {
     if (type < this.level) {
       return;
     }
-    const date = new Date();
-    this.logCapture.push(new Log(this.sequenceNumber, msg, date.getTime(), LogLevel[type]));
+    const now = Date.now();
+
+    // Handle undefined.
+    this.logCapture.push(new Log(this.sequenceNumber, msg, now, LogLevel[type]));
     this.sequenceNumber += 1;
   }
 }

--- a/src/logger/MultiLogger.ts
+++ b/src/logger/MultiLogger.ts
@@ -34,15 +34,19 @@ export default class MultiLogger implements Logger {
 
   debug(debugFunction: string | (() => string)): void {
     let message: string;
-    const memoized =
-      typeof debugFunction === 'string'
-        ? debugFunction
-        : () => {
-            if (!message) {
-              message = debugFunction();
-            }
-            return message;
-          };
+    let memoized: string | (() => string);
+    if (typeof debugFunction === 'string') {
+      memoized = debugFunction;
+    } else if (debugFunction) {
+      memoized = () => {
+        if (!message) {
+          message = debugFunction();
+        }
+        return message;
+      };
+    } else {
+      memoized = '' + debugFunction;
+    }
 
     for (const logger of this._loggers) {
       logger.debug(memoized);

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -1381,7 +1381,7 @@ describe('DefaultDeviceController', () => {
     });
   });
 
-  describe(' Samsung Internet brower', () => {
+  describe(' Samsung Internet browser', () => {
     it('chooses audio and video devices without error', async () => {
       domMockBehavior.browserName = 'samsung';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);

--- a/test/logger/ConsoleLogger.test.ts
+++ b/test/logger/ConsoleLogger.test.ts
@@ -53,6 +53,7 @@ describe('ConsoleLogger', () => {
       warnSpy = sinon.spy(console, 'warn');
       errorSpy = sinon.spy(console, 'error');
     });
+
     after(() => {
       debugSpy.restore();
       infoSpy.restore();
@@ -63,6 +64,13 @@ describe('ConsoleLogger', () => {
       console.info = originalConsole.info;
       console.warn = originalConsole.warn;
       console.error = originalConsole.error;
+    });
+
+    afterEach(() => {
+      debugSpy.resetHistory();
+      infoSpy.resetHistory();
+      warnSpy.resetHistory();
+      errorSpy.resetHistory();
     });
 
     it('should log nothing with LogLevel.OFF', () => {
@@ -86,6 +94,12 @@ describe('ConsoleLogger', () => {
       expect(debugSpy.calledOnce).to.not.be.true;
       expect(warnSpy.calledOnce).to.be.true;
       expect(errorSpy.calledOnce).to.be.true;
+    });
+
+    it('does not throw if you pass null or undefined to a logger call', () => {
+      const logger: ConsoleLogger = new ConsoleLogger('testLogger', LogLevel.DEBUG);
+      logger.debug(undefined);
+      logger.debug(null);
     });
 
     it('should have debug and info logs after setting DEBUG log level', () => {

--- a/test/logger/MeetingSessionPOSTLogger.test.ts
+++ b/test/logger/MeetingSessionPOSTLogger.test.ts
@@ -262,6 +262,36 @@ describe('MeetingSessionPOSTLogger', () => {
       });
     });
 
+    it('does not die if you pass undefined', () => {
+      const logger: MeetingSessionPOSTLogger = new MeetingSessionPOSTLogger(
+        'testLogger',
+        configuration,
+        batchSize,
+        intervalMs,
+        BASE_URL
+      );
+      logger.setLogLevel(LogLevel.DEBUG);
+
+      logger.debug(undefined);
+      expect(logger.getLogCaptureSize()).to.equal(1);
+      logger.stop();
+    });
+
+    it('does not die if you pass a string', () => {
+      const logger: MeetingSessionPOSTLogger = new MeetingSessionPOSTLogger(
+        'testLogger',
+        configuration,
+        batchSize,
+        intervalMs,
+        BASE_URL
+      );
+      logger.setLogLevel(LogLevel.DEBUG);
+
+      logger.debug('foo');
+      expect(logger.getLogCaptureSize()).to.equal(1);
+      logger.stop();
+    });
+
     it('will call stop when unloading the page', done => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const GlobalAny = global as any;

--- a/test/logger/MultiLogger.test.ts
+++ b/test/logger/MultiLogger.test.ts
@@ -128,6 +128,16 @@ describe('MultiLogger', () => {
       expect(called).to.eq(1);
     });
 
+    it('accepts undefined for debug', () => {
+      const internalLogger1: Logger = new NoOpLogger(LogLevel.DEBUG);
+      const internalLogger2: Logger = new NoOpLogger(LogLevel.DEBUG);
+      const spy1 = sinon.spy(internalLogger1, 'debug');
+      const spy2 = sinon.spy(internalLogger2, 'debug');
+      new MultiLogger(internalLogger1, internalLogger2).debug(undefined);
+      expect(spy1.withArgs('undefined').calledOnce).to.be.true;
+      expect(spy2.withArgs('undefined').calledOnce).to.be.true;
+    });
+
     it('accepts debug strings', () => {
       const internalLogger1: Logger = new NoOpLogger(LogLevel.DEBUG);
       const internalLogger2: Logger = new NoOpLogger(LogLevel.DEBUG);

--- a/test/voicefocus/LoggerAdapter.test.ts
+++ b/test/voicefocus/LoggerAdapter.test.ts
@@ -14,6 +14,14 @@ describe('LoggerAdapter', () => {
     expect(adapter).to.exist;
   });
 
+  it('calls through with stringified undefined', () => {
+    const logger = new MockLogger();
+    const adapter = new LoggerAdapter(logger);
+
+    adapter.debug(undefined);
+    expect(logger.debug.calledOnceWith('undefined')).to.be.true;
+  });
+
   it('calls through', () => {
     const logger = new MockLogger();
     const adapter = new LoggerAdapter(logger);


### PR DESCRIPTION
I saw a log from a customer that looked something like:

```
TypeError: debugFunction is not a function
```

which seems like an easy thing to avoid bailing on.

This commit also fixes a few typos and JS bad habits.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

Unit tests only. The integration tests will run on push.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

No.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

This broadens the API signature of the POST logger to match Logger.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

