### PR TITLE
Fix guides web link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ To get started, see the following resources:
 
 And review the following guides:
 
-* [Getting Started](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html)
-* [API Overview](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html)
-* [Content Share](https://aws.github.io/amazon-chime-sdk-js/modules/contentshare.html)
-* [Quality, Bandwidth, and Connectivity](https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html)
-* [Simulcast](https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html)
-* [Meeting events](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html)
-* [Frequently Asked Questions](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html)
-* [Migrating from v1.0 to v2.0](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_2_0.html)
-* [Integrating Amazon Voice Focus into your application](https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html)
-* [Adding frame-by-frame processing to an outgoing video stream](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/10_Video_Processor.md)
+* [Getting Started](https://aws.github.io/amazon-chime-sdk-js/modules/guides.gettingstarted.html)
+* [Content Share](https://aws.github.io/amazon-chime-sdk-js/modules/guides.contentshare.html)
+* [API Overview](https://aws.github.io/amazon-chime-sdk-js/modules/guides.apioverview.html)
+* [Quality Bandwidth_Connectivity](https://aws.github.io/amazon-chime-sdk-js/modules/guides.qualitybandwidth_connectivity.html)
+* [Simulcast](https://aws.github.io/amazon-chime-sdk-js/modules/guides.simulcast.html)
+* [Meeting Events](https://aws.github.io/amazon-chime-sdk-js/modules/guides.meetingevents.html)
+* [FAQs](https://aws.github.io/amazon-chime-sdk-js/modules/guides.faqs.html)
+* [Migration to_2_0](https://aws.github.io/amazon-chime-sdk-js/modules/guides.migrationto_2_0.html)
+* [Amazon Voice_Focus](https://aws.github.io/amazon-chime-sdk-js/modules/guides.amazonvoice_focus.html)
+* [Video Processor](https://aws.github.io/amazon-chime-sdk-js/modules/guides.videoprocessor.html)
 
 ## Examples
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,16 +90,16 @@
 				</ul>
 				<p>And review the following guides:</p>
 				<ul>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html">Getting Started</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html">API Overview</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/contentshare.html">Content Share</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html">Quality, Bandwidth, and Connectivity</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html">Simulcast</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html">Meeting events</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html">Frequently Asked Questions</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_2_0.html">Migrating from v1.0 to v2.0</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html">Integrating Amazon Voice Focus into your application</a></li>
-					<li><a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/10_Video_Processor.md">Adding frame-by-frame processing to an outgoing video stream</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.gettingstarted.html">Getting Started</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.contentshare.html">Content Share</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.apioverview.html">API Overview</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.qualitybandwidth_connectivity.html">Quality Bandwidth_Connectivity</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.simulcast.html">Simulcast</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.meetingevents.html">Meeting Events</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.faqs.html">FAQs</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.migrationto_2_0.html">Migration to_2_0</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.amazonvoice_focus.html">Amazon Voice_Focus</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/guides.videoprocessor.html">Video Processor</a></li>
 				</ul>
 				<a href="#examples" id="examples" style="color: inherit; text-decoration: none;">
 					<h2>Examples</h2>

--- a/script/build-guides.js
+++ b/script/build-guides.js
@@ -21,6 +21,7 @@ const walk = function(dir) {
 
 let result = '';
 let namespaces = [];
+const customModuleNameForGuides = 'Guides';
 let guides = '';
 
 walk('guides')
@@ -45,7 +46,7 @@ walk('guides')
     const feedback = `\n[Give feedback on this guide](https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&labels=documentation&template=documentation-request.md&title=${urlName}%20feedback)`;
     const data = ' * ' + (fs.readFileSync(file, 'utf8') + feedback).split('\n').join('\n * ');
     console.log(file);
-    guides += `* [${visibleName}](https://aws.github.io/amazon-chime-sdk-js/modules/${webFilename})\n`;
+    guides += `* [${visibleName}](https://aws.github.io/amazon-chime-sdk-js/modules/${customModuleNameForGuides.toLowerCase()}.${webFilename})\n`;
     result += `/**\n${data}\n */\nnamespace ${namespaceName} {}\n\n`;
     namespaces.push(namespaceName);
   });
@@ -55,13 +56,13 @@ fs.writeFileSync('./guides/docs.ts', `${result+namespaceExports};`, 'utf8');
 const customModuleNameAnnotation =
 `/**
  * @packageDocumentation
- * @module Guides
+ * @module ${customModuleNameForGuides}
  */`;
 fs.writeFileSync('./guides/index.ts', `${customModuleNameAnnotation}\n${namespaceExports} from './docs';`, 'utf8');
 
 let readme = fs.readFileSync('./README.md', 'utf8');
 readme = readme.replace(
-  /the following guides[:][\s\S]*[#][#][#] Prerequisites/m,
-  `the following guides:\n\n${guides}\n### Prerequisites`
+  /the following guides[:][\s\S]*[#][#] Examples/m,
+  `the following guides:\n\n${guides}\n## Examples`
 );
 fs.writeFileSync('./README.md', readme, 'utf8');


### PR DESCRIPTION
**Issue #:**
- Guide links from README are broken.
- `build-guides.js` script is trying to replace "Pre-requisite" in the README which is not present, updated it to correctly generate the guide links.

**Description of changes:**
- Append "guides" which is the custom module name for guides to the generated runtime generated links updated in the README by the build-guides script.
- Changed "https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html" to "https://aws.github.io/amazon-chime-sdk-js/modules/guides.qualitybandwidth_connectivity.html"
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Checked locally but need to check once deployed if the link is working.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

