### PR TITLE
Rework stopping of tracks, fix several tests.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "simple-import-sort"
   ],
   "extends": [
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
     "prettier/@typescript-eslint",
     "plugin:prettier/recommended"
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .nyc_output
 .npmrc
+__data*
 build
 coverage
 demos/browser/logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- Improve some unit tests.
+
 ## [2.6.0] - 2021-03-09
 
 ### Added
@@ -18,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MeetingSessionPOSTLogger` now matches the regular `Logger` API signature.
 
 ### Changed
+
 - Allow device checker APIs to take devices as input, rather than only MediaDeviceInfo objects.
 - Enable SIMD autodetection for Amazon Voice Focus in Chrome 90+.
 - Clean up task cancel hooks after they cease to be relevant.
@@ -25,10 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean up usage of audioDeviceInformation in ReceiveAudioInputTask.
 
 ### Removed
+
 - Removed audioDeviceInformation from AudioVideoControllerState.
 
 ### Fixed
-- Upgrade ua-parser-js package version to latest 
+
+- Upgrade ua-parser-js package version to latest.
 - Don't automatically upgrade dev-dependencies to avoid a breaking typedoc upgrade.
 - Safely handle calling logger `debug` methods with `undefined`.
 

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -578,7 +578,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1237">src/devicecontroller/DefaultDeviceController.ts:1237</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1243">src/devicecontroller/DefaultDeviceController.ts:1243</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -669,7 +669,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1346">src/devicecontroller/DefaultDeviceController.ts:1346</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1352">src/devicecontroller/DefaultDeviceController.ts:1352</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -692,7 +692,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1130">src/devicecontroller/DefaultDeviceController.ts:1130</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1136">src/devicecontroller/DefaultDeviceController.ts:1136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -733,7 +733,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1138">src/devicecontroller/DefaultDeviceController.ts:1138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1144">src/devicecontroller/DefaultDeviceController.ts:1144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -830,7 +830,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L953">src/devicecontroller/DefaultDeviceController.ts:953</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L957">src/devicecontroller/DefaultDeviceController.ts:957</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1017,7 +1017,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1222">src/devicecontroller/DefaultDeviceController.ts:1222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1228">src/devicecontroller/DefaultDeviceController.ts:1228</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1150,7 +1150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1358">src/devicecontroller/DefaultDeviceController.ts:1358</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1364">src/devicecontroller/DefaultDeviceController.ts:1364</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1172,7 +1172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1369">src/devicecontroller/DefaultDeviceController.ts:1369</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1375">src/devicecontroller/DefaultDeviceController.ts:1375</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1195,7 +1195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1304">src/devicecontroller/DefaultDeviceController.ts:1304</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1310">src/devicecontroller/DefaultDeviceController.ts:1310</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1305,7 +1305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1093">src/devicecontroller/DefaultDeviceController.ts:1093</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1099">src/devicecontroller/DefaultDeviceController.ts:1099</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1337,7 +1337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1278">src/devicecontroller/DefaultDeviceController.ts:1278</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1284">src/devicecontroller/DefaultDeviceController.ts:1284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1406,7 +1406,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1282">src/devicecontroller/DefaultDeviceController.ts:1282</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1288">src/devicecontroller/DefaultDeviceController.ts:1288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1602,7 +1602,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1308">src/devicecontroller/DefaultDeviceController.ts:1308</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1314">src/devicecontroller/DefaultDeviceController.ts:1314</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1666,7 +1666,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1330">src/devicecontroller/DefaultDeviceController.ts:1330</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1336">src/devicecontroller/DefaultDeviceController.ts:1336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{ </span>device<span class="tsd-signature-symbol">: </span><a href="../interfaces/audiotransformdevice.html" class="tsd-signature-type">AudioTransformDevice</a><span class="tsd-signature-symbol">; </span>nodes<span class="tsd-signature-symbol">: </span><a href="../interfaces/audionodesubgraph.html" class="tsd-signature-type">AudioNodeSubgraph</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></h4>
@@ -1747,7 +1747,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1318">src/devicecontroller/DefaultDeviceController.ts:1318</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1324">src/devicecontroller/DefaultDeviceController.ts:1324</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1838,7 +1838,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1406">src/devicecontroller/DefaultDeviceController.ts:1406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1412">src/devicecontroller/DefaultDeviceController.ts:1412</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1855,7 +1855,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1398">src/devicecontroller/DefaultDeviceController.ts:1398</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1404">src/devicecontroller/DefaultDeviceController.ts:1404</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1872,7 +1872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1402">src/devicecontroller/DefaultDeviceController.ts:1402</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1408">src/devicecontroller/DefaultDeviceController.ts:1408</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1889,7 +1889,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1411">src/devicecontroller/DefaultDeviceController.ts:1411</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1417">src/devicecontroller/DefaultDeviceController.ts:1417</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1969,7 +1969,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1387">src/devicecontroller/DefaultDeviceController.ts:1387</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1393">src/devicecontroller/DefaultDeviceController.ts:1393</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2046,7 +2046,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1373">src/devicecontroller/DefaultDeviceController.ts:1373</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1379">src/devicecontroller/DefaultDeviceController.ts:1379</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/script/check-code-style.js
+++ b/script/check-code-style.js
@@ -177,7 +177,9 @@ components().forEach(component => {
       return;
     }
     let fileText = fs.readFileSync(filePath, 'utf-8').toString();
-    let lines = fileText.split('\n');
+
+    // Ignore comment lines, so you can have a block comment followed by ts-ignore.
+    let lines = fileText.split('\n').filter(s => !(s.match(/^\s*\/\//)));
     for (let i = 0; i < lines.length; i++) {
       if (lines[i].trim()[0] !== '*') {
         let commentStartRegex = new RegExp(/\s+\w+\(.*[:]/);

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -921,6 +921,10 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
   }
 
   private handleGetUserMediaError(error: Error, errorTimeMs?: number): void {
+    if (!error) {
+      throw new GetUserMediaError(error);
+    }
+
     switch (error.name) {
       case 'NotReadableError':
       case 'TrackStartError':
@@ -1021,6 +1025,8 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
 
         await this.handleDeviceChange();
         newDevice.stream.getTracks()[0].addEventListener('ended', () => {
+          // Hard to test, but the safety check is worthwhile.
+          /* istanbul ignore else */
           if (this.activeDevices[kind] && this.activeDevices[kind].stream === newDevice.stream) {
             this.logger.warn(
               `${kind} input device which was active is no longer available, resetting to null device`
@@ -1059,7 +1065,7 @@ export default class DefaultDeviceController implements DeviceControllerBasedMed
       );
 
       // This is effectively `error instanceof OverconstrainedError` but works in Node.
-      if ('constraint' in error) {
+      if (error && 'constraint' in error) {
         this.logger.error(`Over-constrained by constraint: ${error.constraint}`);
       }
 

--- a/src/mediadevicefactory/MediaDeviceProxyHandler.ts
+++ b/src/mediadevicefactory/MediaDeviceProxyHandler.ts
@@ -103,11 +103,11 @@ export default class MediaDeviceProxyHandler implements ProxyHandler<MediaDevice
     return newDevices.sort((device1: MediaDeviceInfo, device2: MediaDeviceInfo) => {
       if (device1.deviceId < device2.deviceId) {
         return 1;
-      } else if (device1.deviceId > device2.deviceId) {
-        return -1;
-      } else {
-        return 0;
       }
+      if (device1.deviceId > device2.deviceId) {
+        return -1;
+      }
+      return 0;
     });
   }
 

--- a/test/contentsharecontroller/DefaultContentShareController.test.ts
+++ b/test/contentsharecontroller/DefaultContentShareController.test.ts
@@ -20,7 +20,7 @@ import MeetingSessionStatus from '../../src/meetingsession/MeetingSessionStatus'
 import MeetingSessionStatusCode from '../../src/meetingsession/MeetingSessionStatusCode';
 import MeetingSessionURLs from '../../src/meetingsession/MeetingSessionURLs';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
-import DOMMockBuilder from '../dommock/DOMMockBuilder';
+import DOMMockBuilder, { StoppableMediaStreamTrack } from '../dommock/DOMMockBuilder';
 import { delay } from '../utils';
 
 describe('DefaultContentShareController', () => {
@@ -341,7 +341,7 @@ describe('DefaultContentShareController', () => {
       const mediaVideoTrack = new MediaStreamTrack('video-track-id', 'video');
       mediaStream.addTrack(mediaVideoTrack);
       await contentShareController.startContentShare(mediaStream);
-      mediaVideoTrack.stop();
+      (mediaVideoTrack as StoppableMediaStreamTrack).externalStop();
       expect(contentShareControllerSpy.calledOnce).to.be.true;
       await delay(defaultDelay);
       expect(contentShareObserverSpy.calledOnce).to.be.true;

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -7,7 +7,6 @@ import UserMediaState from './UserMediaState';
 export default class DOMMockBehavior {
   asyncWaitMs: number = 10;
   getDisplayMediaResult: DisplayMediaState = DisplayMediaState.Success;
-  triggeredEndedEventForStopStreamTrack: boolean = true;
   getUserMediaResult: UserMediaState = null;
   getUserMediaSucceeds: boolean = true;
   getUserMediaError: Error = undefined;

--- a/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
+++ b/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
@@ -532,7 +532,6 @@ describe('DefaultMeetingReadinessChecker', () => {
 
     it('start content share success with source id', async () => {
       domMockBehavior.getDisplayMediaResult = DisplayMediaState.Success;
-      domMockBehavior.triggeredEndedEventForStopStreamTrack = false;
       const result: CheckContentShareConnectivityFeedback = await meetingReadinessCheckerController.checkContentShareConnectivity(
         'sourceId'
       );

--- a/test/task/CreatePeerConnectionTask.test.ts
+++ b/test/task/CreatePeerConnectionTask.test.ts
@@ -20,7 +20,7 @@ import VideoTile from '../../src/videotile/VideoTile';
 import DefaultVideoTileController from '../../src/videotilecontroller/DefaultVideoTileController';
 import DefaultVideoTileFactory from '../../src/videotilefactory/DefaultVideoTileFactory';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
-import DOMMockBuilder from '../dommock/DOMMockBuilder';
+import DOMMockBuilder, { StoppableMediaStreamTrack } from '../dommock/DOMMockBuilder';
 import SDPMock from '../sdp/SDPMock';
 import { delay } from '../utils';
 
@@ -433,7 +433,7 @@ describe('CreatePeerConnectionTask', () => {
         await task.run();
         context.peer.addEventListener('track', (event: RTCTrackEvent) => {
           const track = event.track;
-          track.stop();
+          (track as StoppableMediaStreamTrack).externalStop();
         });
         await context.peer.setRemoteDescription(videoRemoteDescription);
         await delay(domMockBehavior.asyncWaitMs + 10);
@@ -458,7 +458,7 @@ describe('CreatePeerConnectionTask', () => {
         await task.run();
         context.peer.addEventListener('track', (event: RTCTrackEvent) => {
           const track = event.track;
-          track.stop();
+          (track as StoppableMediaStreamTrack).externalStop();
         });
         await context.peer.setRemoteDescription(videoRemoteDescription);
         await delay(domMockBehavior.asyncWaitMs + 10);
@@ -608,7 +608,7 @@ describe('CreatePeerConnectionTask', () => {
         task.run().then(() => {
           context.peer.addEventListener('track', (event: RTCTrackEvent) => {
             const track = event.track;
-            track.stop();
+            (track as StoppableMediaStreamTrack).externalStop();
           });
           context.peer.setRemoteDescription(videoRemoteDescription);
         });
@@ -668,7 +668,7 @@ describe('CreatePeerConnectionTask', () => {
         context.removableObservers[0].removeObserver();
 
         const track = event.track;
-        track.stop();
+        (track as StoppableMediaStreamTrack).externalStop();
       });
       await context.peer.setRemoteDescription(videoRemoteDescription);
       await delay(domMockBehavior.asyncWaitMs + 10);
@@ -700,7 +700,7 @@ describe('CreatePeerConnectionTask', () => {
         context.removableObservers[0].removeObserver();
 
         const track = event.track;
-        track.stop();
+        (track as StoppableMediaStreamTrack).externalStop();
       });
       await context.peer.setRemoteDescription(videoRemoteDescription);
       await delay(domMockBehavior.asyncWaitMs + 10);

--- a/test/voicefocus/VoiceFocusDeviceTransformer.test.ts
+++ b/test/voicefocus/VoiceFocusDeviceTransformer.test.ts
@@ -130,13 +130,21 @@ describe('VoiceFocusDeviceTransformer', () => {
 
     describe('with working worker', () => {
       beforeEach(() => {
-        fetchMock.get(/\/worker-v1\.js/, (_url: string, _request: MockRequest) => {
-          return {
-            status: 200,
-            'content-type': 'application/javascript',
-            body: 'function(){}',
-          };
-        });
+        fetchMock
+          .get(/\/worker-v1\.js/, (_url: string, _request: MockRequest) => {
+            return {
+              status: 200,
+              'content-type': 'application/javascript',
+              body: 'function(){}',
+            };
+          })
+          .get(/\/estimator-v1.js/, (_url: string, _request: MockRequest) => {
+            return {
+              status: 200,
+              'content-type': 'application/javascript',
+              body: 'function(){}',
+            };
+          });
       });
 
       afterEach(() => {


### PR DESCRIPTION
The main change in this commit is to alter the behavior of the mock for
`MediaStreamTrack.stop`. This method in reality does _not_ trigger
`onended`/`ended` observer notifications if called by application code.
Those notifications are only signaled if the track stops due to e.g.,
being remotely closed.

Fixing this necessitates introducing a new method, `externalStop`, on a
named mock class. Call this method if you want the side effects of
observers being triggered. Call the regular `stop` method to act like
you're in a browser and call the method in the normal way.

This commit also fixes a wide variety of small test errors.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

These are mostly test changes. The rest will be exercised by integration tests.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

They're fundamental.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

