### PR TITLE
Revert "Log TURN credentials response URIs and username (#1110)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transformer in a different scope with the same measured settings.
 - Add End-to-end Integration test for Video Test App
 - `MeetingSessionPOSTLogger` now matches the regular `Logger` API signature.
-- Add `INFO` log for `TURN` URIs and username from `TURN` credentials.
 
 ### Changed
 - Allow device checker APIs to take devices as input, rather than only MediaDeviceInfo objects.

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -5051,9 +5051,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.855.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.855.0.tgz",
-      "integrity": "sha512-u1lO75V82E4REeu0Pt3RE1Kg2CdtUoMgMnyR02cUxdWnoTBpdSlwvz2X2U0VEGW2oYzeJJYp0N0H1sgSRnv8vg==",
+      "version": "2.860.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.860.0.tgz",
+      "integrity": "sha512-BUBWw28PNDhRDnPEnXiPEvgTWD8Iyq5pl9lk/WhXC/vkACJ3aUVe+sicezI1/JQRjLrO3R6w7X20YknVWfAibA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.855.0",
+    "aws-sdk": "^2.860.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/src/task/ReceiveTURNCredentialsTask.ts
+++ b/src/task/ReceiveTURNCredentialsTask.ts
@@ -39,9 +39,6 @@ export default class ReceiveTURNCredentialsTask extends BaseTask {
   async run(): Promise<void> {
     if (this.context.turnCredentials) {
       this.context.logger.info('TURN credentials available, skipping credentials fetch');
-      this.context.logger.info(
-        `TURN URIs: ${this.context.turnCredentials.uris} and Username: ${this.context.turnCredentials.username}`
-      );
       return;
     }
 
@@ -116,8 +113,5 @@ export default class ReceiveTURNCredentialsTask extends BaseTask {
         return !!uri;
       });
     this.context.turnCredentials.username = responseBodyJson.username;
-    this.context.logger.info(
-      `TURN URIs: ${this.context.turnCredentials.uris} and Username: ${this.context.turnCredentials.username}`
-    );
   }
 }


### PR DESCRIPTION
This reverts commit 55c075dee2dd66752626f7a2b88cb86b53dc50eb.

**Issue #:**

**Description of changes:**
- Revert logging TURN credentials response URIs and username as it is no longer needed and have been added to server side logs.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Yes, the added logs do not appear after this change.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? The demo/browser app.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

