### PR TITLE
Adding call to realtimeSetLocalAudioInput after restartLocalAudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improve some unit tests.
+- Calling `realtimeSetLocalAudioInput` as part of `AudioVideoController.restartLocalAudio()` to 
+  fix local mute/unmute issue while switching audio devices.
 
 ## [2.6.1] - 2021-03-17
 

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -564,7 +564,6 @@ export default class DefaultAudioVideoController
     if (!audioStream || audioStream.getAudioTracks().length < 1) {
       throw new Error('could not acquire audio track');
     }
-
     this.connectionHealthData.reset();
     this.connectionHealthData.setConnectionStartTime();
 
@@ -584,6 +583,7 @@ export default class DefaultAudioVideoController
         audioTrack
       );
     }
+    this._realtimeController.realtimeSetLocalAudioInput(audioStream);
     this.meetingSessionContext.activeAudioInput = audioStream;
     callback();
     if (replaceTrackSuccess) {

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -1158,13 +1158,17 @@ describe('DefaultAudioVideoController', () => {
       );
 
       let success = true;
+      const realtimeSetLocalAudioInput = sinon.spy(
+        audioVideoController.realtimeController,
+        'realtimeSetLocalAudioInput'
+      );
       try {
         await audioVideoController.restartLocalAudio(() => {});
       } catch (error) {
         success = false;
       }
-
       expect(success).to.be.false;
+      expect(realtimeSetLocalAudioInput.called).to.be.false;
 
       class TestDeviceController extends NoOpMediaStreamBroker {
         async acquireAudioInputStream(): Promise<MediaStream> {
@@ -1206,12 +1210,17 @@ describe('DefaultAudioVideoController', () => {
         reconnectController
       );
       let success = true;
+      const realtimeSetLocalAudioInput = sinon.spy(
+        audioVideoController.realtimeController,
+        'realtimeSetLocalAudioInput'
+      );
       try {
         await audioVideoController.restartLocalAudio(() => {});
       } catch (error) {
         success = false;
       }
       expect(success).to.be.false;
+      expect(realtimeSetLocalAudioInput.called).to.be.false;
     });
 
     it('replaces audio track for unified plan', async () => {
@@ -1242,6 +1251,10 @@ describe('DefaultAudioVideoController', () => {
         }
       }
       audioVideoController.addObserver(new TestObserver());
+      const realtimeSetLocalAudioInput = sinon.spy(
+        audioVideoController.realtimeController,
+        'realtimeSetLocalAudioInput'
+      );
       expect(audioVideoController.configuration).to.equal(configuration);
       expect(audioVideoController.rtcPeerConnection).to.be.null;
       await start();
@@ -1254,6 +1267,7 @@ describe('DefaultAudioVideoController', () => {
         callbackExecuted = true;
       });
       expect(callbackExecuted).to.be.true;
+      expect(realtimeSetLocalAudioInput.called).to.be.true;
       await stop();
     });
 
@@ -1289,6 +1303,10 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.addObserver(new TestObserver());
       expect(audioVideoController.configuration).to.equal(configuration);
       expect(audioVideoController.rtcPeerConnection).to.be.null;
+      const realtimeSetLocalAudioInput = sinon.spy(
+        audioVideoController.realtimeController,
+        'realtimeSetLocalAudioInput'
+      );
       await start();
 
       expect(sessionStarted).to.be.true;
@@ -1298,6 +1316,7 @@ describe('DefaultAudioVideoController', () => {
         callbackExecuted = true;
       });
       expect(callbackExecuted).to.be.true;
+      expect(realtimeSetLocalAudioInput.called).to.be.true;
 
       // @ts-ignore mutate the context state to trigger rejection
       audioVideoController.meetingSessionContext.localAudioSender = null;


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** 
  
*Issue:* There is no logic to update the attachment of the realtime controller to the newly selected audio device. This caused the local mute/unmute to break if a new device was selected after joining the meeting. 

*Solution:* Calling `realtimeSetLocalAudioInput` as part of `AudioVideoController.restartLocalAudio()` to 
  fix local mute/unmute issue while switching audio devices.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
Used the serverless demo to test `realtimeSetLocalAudioInput` is being called on every device switch.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes. Meeting serverless demo.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA.

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

