### PR TITLE
Fix wrong redirect on back button when app is deployed

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -462,7 +462,7 @@
       To enable permissions, accept the dialog popup that appears on the device preview page.
       Alternatively, you can enable them in your browser's privacy settings.
     </p>
-    <a href="/" class="home-btn">Back to Home</a>
+    <button id="back-to-home-btn" class="home-btn">Back to Home</button>
   </div>
 </div>
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -412,6 +412,10 @@ export class DemoMeetingApp
       (document.getElementById('planB') as HTMLInputElement).disabled = true;
     }
 
+    document.querySelector('#back-to-home-btn').addEventListener('click', () =>{
+      window.location.href = window.location.pathname;
+    })
+
     document.getElementById('form-authenticate').addEventListener('submit', e => {
       e.preventDefault();
       this.meeting = (document.getElementById('inputMeeting') as HTMLInputElement).value;
@@ -596,7 +600,7 @@ export class DemoMeetingApp
                 notifTimeout = null;
                 videoNotif.style.display = 'none';
               }, 2500)
-             
+
               return
             }
             this.audioVideo.startLocalVideoTile();

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -780,6 +780,7 @@ a.markdown:active {
     padding: 12px 20px;
     border-radius: 4px;
     text-align: center;
+    border: none;
     transition: background-color 225ms ease;
 
     &:hover {


### PR DESCRIPTION
**Issue #:**
Can't rely on `href="/"` once you deploy the app...

**Description of changes:**

**Testing**

1. Have you successfully run `npm run build:release` locally?
2. How did you test these changes?
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

