### PR TITLE
[Tests] Temporarily set FF version for content share test to 86

### DIFF
--- a/integration/configs/app_quit_content_share_test.config.json
+++ b/integration/configs/app_quit_content_share_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_join_later_test.config.json
+++ b/integration/configs/content_share_join_later_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_only_allow_two_test.config.json
+++ b/integration/configs/content_share_only_allow_two_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_screen_capture_test.config.json
+++ b/integration/configs/content_share_screen_capture_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/content_share_video_test.config.json
+++ b/integration/configs/content_share_video_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]

--- a/integration/configs/meeting_leave_content_share_test.config.json
+++ b/integration/configs/meeting_leave_content_share_test.config.json
@@ -23,7 +23,7 @@
     },
     {
       "browserName": "firefox",
-      "version": "latest",
+      "version": "86",
       "platform": "MAC"
     }
   ]


### PR DESCRIPTION
**Description of changes:**
Content share integration tests for FF 87 stopped working so temporarily set the FF version to 86 to unblock other PRs.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? No
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

