### PR TITLE
Add 'Guides' and 'Resources' headers to leverage GitHub TOC generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,47 +20,57 @@ control meeting features such as audio mute and video tile bindings.
 
 If you are building a React application, consider using the [Amazon Chime SDK React Component Library](https://github.com/aws/amazon-chime-sdk-component-library-react) that supplies client-side state management and reusable UI components for common web interfaces used in audio and video conferencing applications. Amazon Chime also offers [Amazon Chime SDK for iOS](https://github.com/aws/amazon-chime-sdk-ios) and [Amazon Chime SDK for Android](https://github.com/aws/amazon-chime-sdk-android) for native mobile application development.
 
-Other resources:
+## Resources
 
-* [Amazon Chime SDK](https://aws.amazon.com/chime/chime-sdk/)
-* [High Level Architecture - Building a Meeting Application with Chime SDK](https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-using-the-amazon-chime-sdk/)
-* [Security](https://aws.amazon.com/blogs/business-productivity/understanding-security-in-the-amazon-chime-application-and-sdk/)
-* [Pricing](https://aws.amazon.com/chime/pricing/#Chime_SDK_)
-* [Supported Browsers](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-browsers)
-* [Technical Blogs](https://aws.amazon.com/blogs/business-productivity/tag/amazon-chime-sdk/)
-* [Developer Guide](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html)
-* [Control Plane API Reference](https://docs.aws.amazon.com/chime/latest/APIReference/Welcome.html)
-* [Webinar: Creating Classroom Experiences Using the Amazon Chime SDK](https://www.youtube.com/watch?v=S8T-0xfvXJ8)
+- [Amazon Chime SDK Overview](https://aws.amazon.com/chime/chime-sdk/)
+- [Pricing](https://aws.amazon.com/chime/pricing/#Chime_SDK_)
+- [Supported Browsers](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-browsers)
+- [Developer Guide](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html)
+- [Control Plane API Reference](https://docs.aws.amazon.com/chime/latest/APIReference/Welcome.html)
 
-You can also review the following guides:
+## Blog posts
 
-* [Getting Started](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html)
-* [API Overview](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html)
-* [Content Share](https://aws.github.io/amazon-chime-sdk-js/modules/contentshare.html)
-* [Quality, Bandwidth, and Connectivity](https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html)
-* [Simulcast](https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html)
-* [Meeting events](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html)
-* [Frequently Asked Questions](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html)
-* [Integrating Amazon Voice Focus into your application](https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html)
-* [Adding frame-by-frame processing to an outgoing video stream](https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/10_Video_Processor.md)
+- [High Level Architecture — Building a Meeting Application with the Amazon Chime SDK](https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-using-the-amazon-chime-sdk/)
+- [Understanding security in Amazon Chime](https://aws.amazon.com/blogs/business-productivity/understanding-security-in-the-amazon-chime-application-and-sdk/)
+- [Transforming audio and shared content](https://aws.amazon.com/blogs/business-productivity/transforming-audio-and-shared-content-in-the-amazon-chime-sdk-for-javascript/)
+
+Here is a [list of all blog posts about the Amazon Chime SDK](https://aws.amazon.com/blogs/business-productivity/tag/amazon-chime-sdk/).
+
+### Webinars and videos
+
+- [Webinar: Creating Classroom Experiences Using the Amazon Chime SDK](https://www.youtube.com/watch?v=S8T-0xfvXJ8)
+
+## Guides
+
+The following developer guides cover specific topics for a technical audience.
+
+- [Getting Started](https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html)
+- [API Overview](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html)
+- [Frequently Asked Questions (FAQ)](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html)
+- [Content Share](https://aws.github.io/amazon-chime-sdk-js/modules/contentshare.html)
+- [Quality, Bandwidth, and Connectivity](https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html)
+- [Simulcast](https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html)
+- [Meeting events](https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html)
+- [Integrating Amazon Voice Focus into your application](https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html)
+- [Adding frame-by-frame processing to an outgoing video stream](https://aws.github.io/amazon-chime-sdk-js/modules/videoprocessor.html)
 
 ## Migration Guides
-* [Migrating from v1.0 to v2.0](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_2_0.html)
+- [Migrating from v1.0 to v2.0](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_2_0.html)
 
 ## Examples
 
-- [Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser) - A browser
+- [Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser) — A browser
  meeting application with a local server
-- [Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) - A self-contained serverless meeting application
-- [Single JS](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs) - A script to bundle the SDK into a single `.js` file
-- [Recording Demo](https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/) - Recording the meeting's audio, video and screen share in high definition
-- [Virtual Classroom](https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/) - An online classroom built with Electron and React
-- [Live Events](https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/) - Interactive live events solution
-- [Amazon Chime SDK Smart Video Sending Demo](https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/) - Demo showcasing how to dynamically display up to 16 video tiles from a pool of up to 250 meeting attendees
-- [Amazon Chime SDK and Amazon Connect Integration](https://aws.amazon.com/blogs/business-productivity/build-a-video-contact-center-with-amazon-connect-and-amazon-chime-sdk/) - Build a video contact center with Amazon Connect and Amazon Chime SDK
-- [PSTN Dial In](https://github.com/aws-samples/chime-sipmediaapplication-samples) -  Add PSTN dialin capabilities to your Amazon Chime SDK Meeting using SIP Media Application
-- [Device Integration](https://aws.amazon.com/blogs/business-productivity/using-the-amazon-chime-sdk-for-3rd-party-devices/) - Using the Amazon Chime SDK for 3rd party devices
-- [Messaging](https://aws.amazon.com/blogs/business-productivity/build-chat-features-into-your-application-with-amazon-chime-sdk-messaging/) - Build chat features into your application with Amazon Chime SDK messaging
+- [Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) — A self-contained serverless meeting application
+- [Single JS](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs) — A script to bundle the SDK into a single `.js` file
+- [Recording Demo](https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/) — Recording the meeting's audio, video and screen share in high definition
+- [Virtual Classroom](https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/) — An online classroom built with Electron and React
+- [Live Events](https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/) — Interactive live events solution
+- [Amazon Chime SDK Smart Video Sending Demo](https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/) — Demo showcasing how to dynamically display up to 16 video tiles from a pool of up to 250 meeting attendees
+- [Amazon Chime SDK and Amazon Connect Integration](https://aws.amazon.com/blogs/business-productivity/build-a-video-contact-center-with-amazon-connect-and-amazon-chime-sdk/) — Build a video contact center with Amazon Connect and Amazon Chime SDK
+- [PSTN Dial In](https://github.com/aws-samples/chime-sipmediaapplication-samples) —  Add PSTN dialin capabilities to your Amazon Chime SDK Meeting using SIP Media Application
+- [Device Integration](https://aws.amazon.com/blogs/business-productivity/using-the-amazon-chime-sdk-for-3rd-party-devices/) — Using the Amazon Chime SDK for 3rd party devices
+- [Messaging](https://aws.amazon.com/blogs/business-productivity/build-chat-features-into-your-application-with-amazon-chime-sdk-messaging/) — Build chat features into your application with Amazon Chime SDK messaging
 
 ## Troubleshooting and Support
 Review the resources given in the ReadMe and use our [client documentation](https://aws.github.io/amazon-chime-sdk-js/) for guidance on how to develop on the Chime SDK for JavaScript. Additionally, search our [issues database](https://github.com/aws/amazon-chime-sdk-js/issues) and [FAQs](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html) to see if your issue is already addressed. If not please cut us an [issue](https://github.com/aws/amazon-chime-sdk-js/issues/new/choose) using the provided templates.
@@ -1053,8 +1063,8 @@ meetingSession.audioVideo.setContentAudioProfile(AudioProfile.fullbandMusicMono(
 
 ### Starting a messaging session
 
-**Use case 34.** Setup an observer to receive events: connecting, start, stop and receive message; and 
-start a messaging session. 
+**Use case 34.** Setup an observer to receive events: connecting, start, stop and receive message; and
+start a messaging session.
 
 > Note: You can remove an observer by calling `messagingSession.removeObserver(observer)`.
 In a component-based architecture (such as React, Vue, and Angular), you may need to add an observer
@@ -1083,6 +1093,7 @@ const observer = {
 messagingSession.addObserver(observer);
 messagingSession.start();
 ```
+
 ## Notice
 
 The use of Amazon Voice Focus via this SDK involves the downloading and execution of code at runtime by end users.

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,29 +85,45 @@
 					viewing, receive callbacks when media events occur such as volume changes, and
 				control meeting features such as audio mute and video tile bindings.</p>
 				<p>If you are building a React application, consider using the <a href="https://github.com/aws/amazon-chime-sdk-component-library-react">Amazon Chime SDK React Component Library</a> that supplies client-side state management and reusable UI components for common web interfaces used in audio and video conferencing applications. Amazon Chime also offers <a href="https://github.com/aws/amazon-chime-sdk-ios">Amazon Chime SDK for iOS</a> and <a href="https://github.com/aws/amazon-chime-sdk-android">Amazon Chime SDK for Android</a> for native mobile application development.</p>
-				<p>Other resources:</p>
+				<a href="#resources" id="resources" style="color: inherit; text-decoration: none;">
+					<h2>Resources</h2>
+				</a>
 				<ul>
-					<li><a href="https://aws.amazon.com/chime/chime-sdk/">Amazon Chime SDK</a></li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-using-the-amazon-chime-sdk/">High Level Architecture - Building a Meeting Application with Chime SDK</a></li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/understanding-security-in-the-amazon-chime-application-and-sdk/">Security</a></li>
+					<li><a href="https://aws.amazon.com/chime/chime-sdk/">Amazon Chime SDK Overview</a></li>
 					<li><a href="https://aws.amazon.com/chime/pricing/#Chime_SDK_">Pricing</a></li>
 					<li><a href="https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-browsers">Supported Browsers</a></li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/tag/amazon-chime-sdk/">Technical Blogs</a></li>
 					<li><a href="https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html">Developer Guide</a></li>
 					<li><a href="https://docs.aws.amazon.com/chime/latest/APIReference/Welcome.html">Control Plane API Reference</a></li>
+				</ul>
+				<a href="#blog-posts" id="blog-posts" style="color: inherit; text-decoration: none;">
+					<h2>Blog posts</h2>
+				</a>
+				<ul>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/building-a-meeting-application-using-the-amazon-chime-sdk/">High Level Architecture — Building a Meeting Application with the Amazon Chime SDK</a></li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/understanding-security-in-the-amazon-chime-application-and-sdk/">Understanding security in Amazon Chime</a></li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/transforming-audio-and-shared-content-in-the-amazon-chime-sdk-for-javascript/">Transforming audio and shared content</a></li>
+				</ul>
+				<p>Here is a <a href="https://aws.amazon.com/blogs/business-productivity/tag/amazon-chime-sdk/">list of all blog posts about the Amazon Chime SDK</a>.</p>
+				<a href="#webinars-and-videos" id="webinars-and-videos" style="color: inherit; text-decoration: none;">
+					<h3>Webinars and videos</h3>
+				</a>
+				<ul>
 					<li><a href="https://www.youtube.com/watch?v=S8T-0xfvXJ8">Webinar: Creating Classroom Experiences Using the Amazon Chime SDK</a></li>
 				</ul>
-				<p>You can also review the following guides:</p>
+				<a href="#guides" id="guides" style="color: inherit; text-decoration: none;">
+					<h2>Guides</h2>
+				</a>
+				<p>The following developer guides cover specific topics for a technical audience.</p>
 				<ul>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/gettingstarted.html">Getting Started</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html">API Overview</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html">Frequently Asked Questions (FAQ)</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/contentshare.html">Content Share</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html">Quality, Bandwidth, and Connectivity</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/simulcast.html">Simulcast</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/meetingevents.html">Meeting events</a></li>
-					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html">Frequently Asked Questions</a></li>
 					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/amazonvoice_focus.html">Integrating Amazon Voice Focus into your application</a></li>
-					<li><a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/guides/10_Video_Processor.md">Adding frame-by-frame processing to an outgoing video stream</a></li>
+					<li><a href="https://aws.github.io/amazon-chime-sdk-js/modules/videoprocessor.html">Adding frame-by-frame processing to an outgoing video stream</a></li>
 				</ul>
 				<a href="#migration-guides" id="migration-guides" style="color: inherit; text-decoration: none;">
 					<h2>Migration Guides</h2>
@@ -119,18 +135,18 @@
 					<h2>Examples</h2>
 				</a>
 				<ul>
-					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser">Meeting Demo</a> - A browser
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/browser">Meeting Demo</a> — A browser
 					meeting application with a local server</li>
-					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless">Serverless Meeting Demo</a> - A self-contained serverless meeting application</li>
-					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs">Single JS</a> - A script to bundle the SDK into a single <code>.js</code> file</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/">Recording Demo</a> - Recording the meeting&#39;s audio, video and screen share in high definition</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/">Virtual Classroom</a> - An online classroom built with Electron and React</li>
-					<li><a href="https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/">Live Events</a> - Interactive live events solution</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/">Amazon Chime SDK Smart Video Sending Demo</a> - Demo showcasing how to dynamically display up to 16 video tiles from a pool of up to 250 meeting attendees</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/build-a-video-contact-center-with-amazon-connect-and-amazon-chime-sdk/">Amazon Chime SDK and Amazon Connect Integration</a> - Build a video contact center with Amazon Connect and Amazon Chime SDK</li>
-					<li><a href="https://github.com/aws-samples/chime-sipmediaapplication-samples">PSTN Dial In</a> -  Add PSTN dialin capabilities to your Amazon Chime SDK Meeting using SIP Media Application</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/using-the-amazon-chime-sdk-for-3rd-party-devices/">Device Integration</a> - Using the Amazon Chime SDK for 3rd party devices</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/build-chat-features-into-your-application-with-amazon-chime-sdk-messaging/">Messaging</a> - Build chat features into your application with Amazon Chime SDK messaging</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless">Serverless Meeting Demo</a> — A self-contained serverless meeting application</li>
+					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/singlejs">Single JS</a> — A script to bundle the SDK into a single <code>.js</code> file</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/">Recording Demo</a> — Recording the meeting&#39;s audio, video and screen share in high definition</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/">Virtual Classroom</a> — An online classroom built with Electron and React</li>
+					<li><a href="https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/">Live Events</a> — Interactive live events solution</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/">Amazon Chime SDK Smart Video Sending Demo</a> — Demo showcasing how to dynamically display up to 16 video tiles from a pool of up to 250 meeting attendees</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/build-a-video-contact-center-with-amazon-connect-and-amazon-chime-sdk/">Amazon Chime SDK and Amazon Connect Integration</a> — Build a video contact center with Amazon Connect and Amazon Chime SDK</li>
+					<li><a href="https://github.com/aws-samples/chime-sipmediaapplication-samples">PSTN Dial In</a> —  Add PSTN dialin capabilities to your Amazon Chime SDK Meeting using SIP Media Application</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/using-the-amazon-chime-sdk-for-3rd-party-devices/">Device Integration</a> — Using the Amazon Chime SDK for 3rd party devices</li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/build-chat-features-into-your-application-with-amazon-chime-sdk-messaging/">Messaging</a> — Build chat features into your application with Amazon Chime SDK messaging</li>
 				</ul>
 				<a href="#troubleshooting-and-support" id="troubleshooting-and-support" style="color: inherit; text-decoration: none;">
 					<h2>Troubleshooting and Support</h2>
@@ -1024,7 +1040,7 @@ meetingSession.audioVideo.addObserver(observer);
 					<h3>Starting a messaging session</h3>
 				</a>
 				<p><strong>Use case 34.</strong> Setup an observer to receive events: connecting, start, stop and receive message; and
-				start a messaging session. </p>
+				start a messaging session.</p>
 				<blockquote>
 					<p>Note: You can remove an observer by calling <code>messagingSession.removeObserver(observer)</code>.
 						In a component-based architecture (such as React, Vue, and Angular), you may need to add an observer


### PR DESCRIPTION
GitHub now adds a table of contents automatically. This makes it
possible to link directly to Guides.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

