### PR TITLE
Don't restart local audio unless a peer connection has been established.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Demo] Add Tensorflow BodyPix segmentation demo for `VideoProcessor`.
 - Added a workaround for a Chrome issue where Bluetooth audio would sound
-  choppy for other participants when audio transforms were applied.
+  choppy for other participants when Web Audio was enabled.
 
 ### Changed
 

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -356,7 +356,7 @@ export default class DefaultDeviceController
 
       await this.chooseAudioTransformInputDevice(device);
 
-      if (recreateAudioContext && this.boundAudioVideoController) {
+      if (recreateAudioContext && this.boundAudioVideoController?.rtcPeerConnection) {
         this.boundAudioVideoController.restartLocalAudio(() => {
           this.logger.info('Local audio restarted.');
         });


### PR DESCRIPTION
restartLocalAudio is documented as assuming that one exists, and throws if that is not the case.

This is a follow-up fix to #1162.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

