### PR TITLE
Populate video filters after checking for Amazon Voice Focus compatibility.

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -417,7 +417,6 @@ export class DemoMeetingApp
         if (this.supportsVoiceFocus) {
           logger.info('[DEMO] Amazon Voice Focus is supported.');
           document.getElementById('voice-focus-setting').classList.remove('hidden');
-          await this.populateAllDeviceLists();
           return;
         }
       }
@@ -428,7 +427,6 @@ export class DemoMeetingApp
     logger.warn('[DEMO] Does not support Amazon Voice Focus.');
     this.supportsVoiceFocus = false;
     document.getElementById('voice-focus-setting').classList.toggle('hidden', true);
-    await this.populateAllDeviceLists();
   }
 
   private async onVoiceFocusSettingChanged(): Promise<void> {
@@ -497,6 +495,8 @@ export class DemoMeetingApp
           (document.getElementById('info-name') as HTMLSpanElement).innerText = this.name;
 
           await this.initVoiceFocus();
+          await this.populateAllDeviceLists();
+          await this.populateVideoFilterInputList();
 
           this.switchToFlow('flow-devices');
           await this.openAudioInputFromSelectionAndPreview();
@@ -1257,7 +1257,6 @@ export class DemoMeetingApp
     }
     this.audioVideo.addDeviceChangeObserver(this);
     this.setupDeviceLabelTrigger();
-    await this.populateAllDeviceLists();
     this.setupMuteHandler();
     this.setupCanUnmuteHandler();
     this.setupSubscribeToAttendeeIdPresenceHandler();
@@ -1694,7 +1693,6 @@ export class DemoMeetingApp
   async populateAllDeviceLists(): Promise<void> {
     await this.populateAudioInputList();
     await this.populateVideoInputList();
-    await this.populateVideoFilterInputList();
     await this.populateAudioOutputList();
   }
 


### PR DESCRIPTION
Previously we would update the device lists multiple times, and update the list of video filters — including loading TensorFlow.js from the CDN — at the same time as performing estimation for Voice Focus.

On the SauceLabs resource-constrained Windows machines, this contention for resources caused the canary to fail about 45% of the time, because the VF estimator correctly reported that the browser was too slow. The canary test expects that the browser is fast enough, and thus that VF not being supported means that there's a bug. That's not the case: we're just accidentally doing too much at one time.

Eliminating the parallel loading of video filters, and reducing the redundant device refreshes, should make the canary less likely to fail for spurious performance reasons.

---

### Have you successfully run npm run build:release locally?

Yes.

### How did you test these changes?

This is a demo-only change. Tested by hand. Menus are populated correctly, including filters in Chrome.

### Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

By definition.

### Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

### Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

