### PR TITLE
add ios-webview support in DefaultBrowserBehavior

### DIFF
--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -262,7 +262,11 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   }
 
   private isSafari(): boolean {
-    return this.browser.name === 'safari' || this.browser.name === 'ios' || this.browser.name === 'ios-webview';
+    return (
+      this.browser.name === 'safari' ||
+      this.browser.name === 'ios' ||
+      this.browser.name === 'ios-webview'
+    );
   }
 
   private isFirefox(): boolean {

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -43,7 +43,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
     'samsung',
   ];
 
-  private webkitBrowsers: string[] = ['crios', 'fxios', 'safari', 'ios'];
+  private webkitBrowsers: string[] = ['crios', 'fxios', 'safari', 'ios', 'ios-webview'];
 
   private enableUnifiedPlanForChromiumBasedBrowsers: boolean;
   private recreateAudioContextIfNeeded: boolean;
@@ -258,11 +258,11 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   // These helpers should be kept private to encourage
   // feature detection instead of browser detection.
   private isIOSSafari(): boolean {
-    return this.browser.name === 'ios';
+    return this.browser.name === 'ios' || this.browser.name === 'ios-webview';
   }
 
   private isSafari(): boolean {
-    return this.browser.name === 'safari' || this.browser.name === 'ios';
+    return this.browser.name === 'safari' || this.browser.name === 'ios' || this.browser.name === 'ios-webview';
   }
 
   private isFirefox(): boolean {


### PR DESCRIPTION
**Issue #:**
#1070 

**Description of changes:**
Added `ios-webview` to the webkit browsers and safari specific feature checks.

**Testing**

1. Have you successfully run `npm run build:release` locally?
    ✅
2. How did you test these changes?
    On Device Testing 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
    When run in the webview, sure. Any demo application with other participants, as it shows that it's working with unified-plan 
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
    Nope
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
    Nope


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

