### PR TITLE
[Integration Test] Update wait time in roster check

### DIFF
--- a/integration/js/checks/RosterCheckConfig.js
+++ b/integration/js/checks/RosterCheckConfig.js
@@ -1,6 +1,6 @@
 
 class RosterCheckConfig {
-  constructor(checkCount = 10, waitTimeMs = 100){
+  constructor(checkCount = 10, waitTimeMs = 1000){
     this.checkCount = checkCount;
     this.waitTimeMs = waitTimeMs;
   }

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -347,7 +347,7 @@ class AppPage {
     return await this.driver.findElement(elements.failedMeetingFlow).isDisplayed();
   }
 
-  async rosterCheck(numberOfParticipants, checkCount = 10, waitTimeMs = 100) {
+  async rosterCheck(numberOfParticipants, checkCount = 10, waitTimeMs = 1000) {
     let i = 0;
     let start = performance.now();
     while (i < checkCount) {


### PR DESCRIPTION
**Issue #:**
- Currently, roster check waits for 1s to detect the attendee presence in the roster.
- We introduced a 5s attendee presence timeout to detect the attendee presence in the roster. Since then the canaries have become flaky with results showing roster check failure.
- Further investigation shows that the logs show the roster check completion time as seconds which is actually the check count and not the exact time in seconds, checked [here](https://github.com/aws/amazon-chime-sdk-js/blob/5bb75405e2f3346ebbb8e39dc4d4bbdd1d2f4d3a/integration/js/pages/AppPage.js#L367).

**Description of changes:**
- This change updates the roster check wait time to 1000ms for each count and not 100ms.
- The roster check count is unchanged.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Ran locally.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Browser meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

