### PR TITLE
Add a build step to verify the TypeScript correctness of built artifacts.

### DIFF
--- a/config/imports.test.ts
+++ b/config/imports.test.ts
@@ -1,0 +1,4 @@
+import * as Foo from 'amazon-chime-sdk-js';
+
+console.log('Imported:', Foo);
+

--- a/config/tsconfig.import.json
+++ b/config/tsconfig.import.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../build",
+    "paths": {
+      "amazon-chime-sdk-js": ["../build"]
+    }
+  },
+  "include": [
+    "./imports.test.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prebuild:release": "node script/check-voice-focus-version.js && script/prebuild",
     "build:release": "npm run build && npm run lint && npm run check && npm run doc && npm run test:retry",
     "postbuild:release": "script/postbuild",
+    "postbuild": "tsc -p config/tsconfig.import.json",
     "predoc": "rm -rf docs && node script/build-guides.js",
     "doc": "script/generate-docs",
     "postdoc": "node script/update-typedoc-link.js",


### PR DESCRIPTION
**Description of changes:**

This change adds a `postbuild` step that ensures that the stuff we just put in `build/` can actually be imported by a TypeScript program.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Yes.

> 2. How did you test these changes?

By building with and without 8d6e38c23a2e959953d127628b412e86d9522704, verifying that this build script fails.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

No.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

