### PR TITLE
Add the Messaging section in FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add the Messaging section in FAQs to describe how to receive messages without using the Chime SDK for JavaScript
 
 ### Changed
 - `startVideoPreviewForVideoInput` uses the active video input stream instead of calling `getUserMedia` again

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -376,6 +376,14 @@ meetingSession.audioVideo.stop<span class="hljs-literal">()</span>;
   }
 );
 </code></pre>
+					<a href="#messaging" id="messaging" style="color: inherit; text-decoration: none;">
+						<h2>Messaging</h2>
+					</a>
+					<a href="#how-do-i-receive-amazon-chime-sdk-channel-messages-without-using-the-amazon-chime-sdk-for-javascript" id="how-do-i-receive-amazon-chime-sdk-channel-messages-without-using-the-amazon-chime-sdk-for-javascript" style="color: inherit; text-decoration: none;">
+						<h3>How do I receive Amazon Chime SDK channel messages without using the Amazon Chime SDK for JavaScript?</h3>
+					</a>
+					<p>Follow the instructions in the <a href="https://docs.aws.amazon.com/chime/latest/dg/websockets.html#connect-api">&quot;Using websockets to receive messages&quot; developer guide</a>.
+					To sign the URL in Python, use the example code in the <a href="https://github.com/aws/amazon-chime-sdk-js/issues/1241#issuecomment-830705541">GitHub issue #1241</a>.</p>
 					<p><a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=FAQs%20feedback">Give feedback on this guide</a></p>
 				</div>
 			</section>

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -321,3 +321,10 @@ meetingSession.audioVideo.setDeviceLabelTrigger(
   }
 );
 ```
+
+## Messaging
+
+### How do I receive Amazon Chime SDK channel messages without using the Amazon Chime SDK for JavaScript?
+
+Follow the instructions in the ["Using websockets to receive messages" developer guide](https://docs.aws.amazon.com/chime/latest/dg/websockets.html#connect-api).
+To sign the URL in Python, use the example code in the [GitHub issue #1241](https://github.com/aws/amazon-chime-sdk-js/issues/1241#issuecomment-830705541).


### PR DESCRIPTION
**Issue #:**
- https://github.com/aws/amazon-chime-sdk-js/issues/1241

**Description of changes:**
- Add the Messaging section in FAQ to explain how to receive channel messsages without using the JS SDK

**Testing**

1. Have you successfully run `npm run build:release` locally? N?A
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

