### PR TITLE
Don't populate name in remoteVideoSourcesDidChange

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1255,7 +1255,7 @@ export class DemoMeetingApp
       this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger);
       configuration.videoDownlinkBandwidthPolicy = this.priorityBasedDownlinkPolicy;
     }
-    
+
     if ((document.getElementById('fullband-speech-mono-quality') as HTMLInputElement).checked) {
       this.meetingSession.audioVideo.setAudioProfile(AudioProfile.fullbandSpeechMono());
       this.meetingSession.audioVideo.setContentAudioProfile(AudioProfile.fullbandSpeechMono());
@@ -1389,7 +1389,7 @@ export class DemoMeetingApp
       ) {
         this.contentShareStop();
       }
-      if (!this.roster[attendeeId]) {
+      if (!this.roster[attendeeId] || !this.roster[attendeeId].name) {
         this.roster[attendeeId] = {
           name: externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : ''),
         };
@@ -2758,7 +2758,6 @@ export class DemoMeetingApp
     for (const source of videoSources) {
       if (!(this.roster.hasOwnProperty(source.attendee.attendeeId))) {
         this.roster[source.attendee.attendeeId] = {
-          name: (source.attendee.attendeeId),
           hasVideo: true
         };
       }


### PR DESCRIPTION
**Description of changes:**
`remoteVideoSourcesDidChange` tries to populate the name property in roster object incorrectly using attendeeId, which causes attendeeId appears in roster instead of externalId. This is unnecessary since name is updated via attendee presence event already. Thus, removing that logic.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
    1. Open meeting demo and enable `Use Priority-Based Downlink Policy`
    2. Join a meeting
    3. Enable video
    4. Repeat step i and ii in another tab or browser
    5. Verify that you can see the name of the first attendee displayed correctly.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? 
    Yes, meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

