### PR TITLE
Fix npm scripts in the browser demo.

### DIFF
--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "deps": "cd ../.. && npm run build",
     "build:fast": "node script/webpack-wrapper.js",
-    "build": "npm run deps && npm install && npm run build:fast",
-    "start:fast": "npm run build:fast && node serve.js",
-    "start:hot": "tsc && webpack-cli serve --config ./webpack.config.js",
+    "build": "npm run deps && npm install && tsc && npm run build:fast",
+    "start:fast": "node script/webpack-wrapper.js --serve",
+    "start:hot": "webpack-cli serve --config ./webpack.config.js",
     "start": "npm run deps && npm install && npm run start:fast"
   },
   "devDependencies": {

--- a/demos/browser/script/webpack-wrapper.js
+++ b/demos/browser/script/webpack-wrapper.js
@@ -18,11 +18,17 @@ const options = {
   },
 };
 
+const serve = argv.indexOf('--serve') !== -1;
+
+console.info('Should start local server:', serve);
+
 // This won't be present with npm 6.
 // Exclude file paths.
-const lastIndex = argv.length - 1;
+const remainingArgs = argv.filter(v => v !== '--serve');
+const lastIndex = remainingArgs.length - 1;
+let possibleApp;
 if (lastIndex >= 2) {
-  let possibleApp = argv[lastIndex];
+  possibleApp = remainingArgs[lastIndex];
   if (!possibleApp.startsWith('/')) {
     if (possibleApp.startsWith('app=')) {
       possibleApp = possibleApp.substring(4);
@@ -31,11 +37,22 @@ if (lastIndex >= 2) {
   }
 }
 
+console.info('Possible app:', possibleApp);
+
 const webpack = spawn(command, args, options);
 
 webpack.stdout.on('data', (data) => console.log(data.toString()));
 webpack.stderr.on('data', (data) => console.error(data.toString()));
 webpack.on('close', (status) => {
   console.info('Webpack existed with status', status);
-  process.exit(status);
+
+  if (serve) {
+    console.info('Starting server.');
+    if (possibleApp) {
+      process.env.npm_config_app = possibleApp;
+    }
+    require('../serve.js');
+  } else {
+    process.exit(status);
+  }
 });

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -8,11 +8,16 @@ const http = require('http');
 const url = require('url');
 const { v4: uuidv4 } = require('uuid');
 
-// Store created meetings in a map so attendees can join by meeting title
+// Store created meetings in a map so attendees can join by meeting title.
 const meetingTable = {};
 
-// Load the contents of the web application to be used as the index page
-const indexPage = fs.readFileSync(`dist/${process.env.npm_config_app || 'meetingV2'}.html`);
+// Load the contents of the web application to be used as the index page.
+const app = process.env.npm_config_app || 'meetingV2';
+const indexPagePath = `dist/${app}.html`;
+
+console.info('Using index path', indexPagePath);
+
+const indexPage = fs.readFileSync(indexPagePath);
 
 // Create ans AWS SDK Chime object. Region 'us-east-1' is currently required.
 // Use the MediaRegion property below in CreateMeeting to select the region
@@ -20,7 +25,10 @@ const indexPage = fs.readFileSync(`dist/${process.env.npm_config_app || 'meeting
 const chime = new AWS.Chime({ region: 'us-east-1' });
 
 // Set the AWS SDK Chime endpoint. The global endpoint is https://service.chime.aws.amazon.com.
-chime.endpoint = new AWS.Endpoint(process.env.ENDPOINT || 'https://service.chime.aws.amazon.com');
+const endpoint = process.env.ENDPOINT || 'https://service.chime.aws.amazon.com';
+console.info('Using endpoint', endpoint);
+
+chime.endpoint = new AWS.Endpoint(endpoint);
 
 function serve(host = '127.0.0.1:8080') {
   // Start an HTTP server to serve the index page and handle meeting actions

--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = env => {
         index: `${app}.html`,
       },
       onListening: (server) => {
+        // Just so that the code in server.js isn't confused about
+        // which app finally made it through the gauntlet.
+        process.env.npm_config_app = app;
         const { serve } = require('./server.js');
         serve('127.0.0.1:8081');
       },


### PR DESCRIPTION
`npm run start` and its variants now correctly load the selected app.

Additionally, this commit has the build only run `tsc` in `npm run
build`, which makes everyday development faster, but still catches
issues that the Webpack loader will not.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

N/A.

> 2. How did you test these changes?

Running each variant script.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

N/A.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

