### PR TITLE
[Demo] Fix meeting demo pin remove videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Do not start local video tile if there is no stream for content share
 
 
 ## [2.9.0] - 2021-05-10
@@ -41,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `npm run start:hot` in the browser demo.
-- Do not start local video tile if there is no stream for content share
 
 ## [2.8.0] - 2021-04-23
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1408,7 +1408,8 @@ export class DemoMeetingApp
       }
       if (!this.roster[attendeeId] || !this.roster[attendeeId].name) {
         this.roster[attendeeId] = {
-          name: externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : ''),
+          ...this.roster[attendeeId],
+          ... {name: externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '')}
         };
       }
       this.audioVideo.realtimeSubscribeToVolumeIndicator(


### PR DESCRIPTION
**Description of changes:**
Fix an issue in the meeting demo when joining a meeting with video priority downlink policy enabled and pin a video element will cause content share and videos to disappear. This is due to in attendee presence handler, if reset the roster[attendeeId] object and remove the hasVideo flag.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
   1. First attendee: Joining a meeting with video priority downlink policy enabled
   2. First attendee: Enable video and content share
   3. Second attendee: Joining a meeting with video priority downlink policy enabled
   4. Second attendee: Try to pin a video and verify that both content share and video are still displayed.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

