### PR TITLE
[Integ] Fix Maven Installation for GitHub Actions

### DIFF
--- a/integration/js/script/install-kite
+++ b/integration/js/script/install-kite
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -o xtrace
 
-cd ~/build
-
 mkdir GitHub
 cd GitHub
 git clone https://github.com/webrtc/KITE.git
@@ -10,9 +8,14 @@ cd KITE
 git checkout e9296165cd24bea92cddb59f2bf211c99f764d58
 
 chmod -R +x scripts/linux
+printf "n\n3.6.3" | ./scripts/linux/installMaven.sh
+#This is a temporary hack since maven 3.8.1 which is the default for GitHub Action VM does not work with kite
+export PATH=~/apache-maven-3.6.3/bin:$PATH
+source ~/.bashrc
+echo `mvn --version`
 
 chmod +x configureLinux.sh
 yes n | ./configureLinux.sh
 
 cd KITE-AppRTC-Test
-../scripts/linux/path/c all > /dev/null
+../scripts/linux/path/c all


### PR DESCRIPTION
**Description of changes:**
GitHub Action VM default maven version has been updated to 3.8.1 (https://github.com/actions/virtual-environments/pull/3247) and this cause the [compilation step](https://github.com/aws/amazon-chime-sdk-js/blob/master/integration/js/script/install-kite#L18) to fail.
This PR updates the install-kite script to install Maven 3.6.3 to unblock our integration tests in GitHub Actions.  

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? GitHub actions run successfully.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

