### PR TITLE
Bump y18n and ssri dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of calling `getUserMedia` again.
 - Meeting connections now do more work in parallel, which will improve
   meeting join times.
+- Bump y18n and ssri dependency version
 
 ### Removed
 

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -4557,7 +4557,7 @@
       }
     },
     "../../node_modules/y18n": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dev": true,
       "license": "ISC"
     },
@@ -14523,7 +14523,7 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "ISC",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
@@ -20425,7 +20425,7 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "dev": true
         },
         "yallist": {
@@ -26582,7 +26582,7 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -4693,8 +4693,8 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
@@ -8598,8 +8598,8 @@
       }
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },


### PR DESCRIPTION
**Description of changes:**
- Bump y18n from 4.0.0 to 4.0.1 and ssri from 6.0.1 to 6.02

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Run meeting demo and do some quick smoke testing
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Any demo
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A 
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

