### PR TITLE
Add support for iOS WKWebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added 
+
+- Add support for iOS WKWebView
+
+### Changed
+
+### Removed
+
+### Fixed
+
+
 ## [2.9.0] - 2021-05-10
 
 ### Added

--- a/docs/classes/defaultbrowserbehavior.html
+++ b/docs/classes/defaultbrowserbehavior.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L49">src/browserbehavior/DefaultBrowserBehavior.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L51">src/browserbehavior/DefaultBrowserBehavior.ts:51</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L194">src/browserbehavior/DefaultBrowserBehavior.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L196">src/browserbehavior/DefaultBrowserBehavior.ts:196</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -190,7 +190,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#haschromiumwebrtc">hasChromiumWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L76">src/browserbehavior/DefaultBrowserBehavior.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L78">src/browserbehavior/DefaultBrowserBehavior.ts:78</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -208,7 +208,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#hasfirefoxwebrtc">hasFirefoxWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L94">src/browserbehavior/DefaultBrowserBehavior.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L96">src/browserbehavior/DefaultBrowserBehavior.ts:96</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L85">src/browserbehavior/DefaultBrowserBehavior.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L87">src/browserbehavior/DefaultBrowserBehavior.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -243,7 +243,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#issupported">isSupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L211">src/browserbehavior/DefaultBrowserBehavior.ts:211</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L213">src/browserbehavior/DefaultBrowserBehavior.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#majorversion">majorVersion</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L68">src/browserbehavior/DefaultBrowserBehavior.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L70">src/browserbehavior/DefaultBrowserBehavior.ts:70</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -279,7 +279,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L72">src/browserbehavior/DefaultBrowserBehavior.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L74">src/browserbehavior/DefaultBrowserBehavior.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresbundlepolicy">requiresBundlePolicy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L142">src/browserbehavior/DefaultBrowserBehavior.ts:142</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L144">src/browserbehavior/DefaultBrowserBehavior.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RTCBundlePolicy</span></h4>
@@ -315,7 +315,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requirescheckforsdpconnectionattributes">requiresCheckForSdpConnectionAttributes</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L118">src/browserbehavior/DefaultBrowserBehavior.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L120">src/browserbehavior/DefaultBrowserBehavior.ts:120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -333,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requirescontextrecreationforaudioworklet">requiresContextRecreationForAudioWorklet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L165">src/browserbehavior/DefaultBrowserBehavior.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L167">src/browserbehavior/DefaultBrowserBehavior.ts:167</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -351,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresgroupidmediastreamconstraints">requiresGroupIdMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L161">src/browserbehavior/DefaultBrowserBehavior.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L163">src/browserbehavior/DefaultBrowserBehavior.ts:163</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresicecandidategatheringtimeoutworkaround">requiresIceCandidateGatheringTimeoutWorkaround</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L122">src/browserbehavior/DefaultBrowserBehavior.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L124">src/browserbehavior/DefaultBrowserBehavior.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresnoexactmediastreamconstraints">requiresNoExactMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L154">src/browserbehavior/DefaultBrowserBehavior.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L156">src/browserbehavior/DefaultBrowserBehavior.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -405,7 +405,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requirespromisebasedwebrtcgetstats">requiresPromiseBasedWebRTCGetStats</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L146">src/browserbehavior/DefaultBrowserBehavior.ts:146</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L148">src/browserbehavior/DefaultBrowserBehavior.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -423,7 +423,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresresolutionalignment">requiresResolutionAlignment</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L111">src/browserbehavior/DefaultBrowserBehavior.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L113">src/browserbehavior/DefaultBrowserBehavior.ts:113</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiressimulcastmunging">requiresSimulcastMunging</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L138">src/browserbehavior/DefaultBrowserBehavior.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L140">src/browserbehavior/DefaultBrowserBehavior.ts:140</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -468,7 +468,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiressortcodecpreferencesforsdpanswer">requiresSortCodecPreferencesForSdpAnswer</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L134">src/browserbehavior/DefaultBrowserBehavior.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L136">src/browserbehavior/DefaultBrowserBehavior.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -486,7 +486,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresunifiedplan">requiresUnifiedPlan</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L102">src/browserbehavior/DefaultBrowserBehavior.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L104">src/browserbehavior/DefaultBrowserBehavior.ts:104</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -504,7 +504,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresunifiedplanmunging">requiresUnifiedPlanMunging</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L126">src/browserbehavior/DefaultBrowserBehavior.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L128">src/browserbehavior/DefaultBrowserBehavior.ts:128</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -521,7 +521,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L150">src/browserbehavior/DefaultBrowserBehavior.ts:150</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L152">src/browserbehavior/DefaultBrowserBehavior.ts:152</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -539,7 +539,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#screenshareunsupported">screenShareUnsupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L203">src/browserbehavior/DefaultBrowserBehavior.ts:203</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L205">src/browserbehavior/DefaultBrowserBehavior.ts:205</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -557,7 +557,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportstring">supportString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L224">src/browserbehavior/DefaultBrowserBehavior.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L226">src/browserbehavior/DefaultBrowserBehavior.ts:226</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -575,7 +575,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportedvideocodecs">supportedVideoCodecs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L235">src/browserbehavior/DefaultBrowserBehavior.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L237">src/browserbehavior/DefaultBrowserBehavior.ts:237</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -593,7 +593,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportscanvascapturedstreamplayback">supportsCanvasCapturedStreamPlayback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L98">src/browserbehavior/DefaultBrowserBehavior.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L100">src/browserbehavior/DefaultBrowserBehavior.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -611,7 +611,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportssendersidebandwidthestimation">supportsSenderSideBandwidthEstimation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L198">src/browserbehavior/DefaultBrowserBehavior.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L200">src/browserbehavior/DefaultBrowserBehavior.ts:200</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -629,7 +629,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportssetsinkid">supportsSetSinkId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L254">src/browserbehavior/DefaultBrowserBehavior.ts:254</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L256">src/browserbehavior/DefaultBrowserBehavior.ts:256</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -647,7 +647,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#version">version</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L64">src/browserbehavior/DefaultBrowserBehavior.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/browserbehavior/DefaultBrowserBehavior.ts#L66">src/browserbehavior/DefaultBrowserBehavior.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -20,6 +20,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
     samsung: 12,
     crios: 86,
     fxios: 23,
+    'ios-webview': 605,
   };
 
   private browserName: { [id: string]: string } = {
@@ -33,6 +34,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
     samsung: 'Samsung Internet',
     crios: 'Chrome iOS',
     fxios: 'Firefox iOS',
+    'ios-webview': 'WKWebView iOS',
   };
 
   private chromeLike: string[] = [
@@ -43,7 +45,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
     'samsung',
   ];
 
-  private webkitBrowsers: string[] = ['crios', 'fxios', 'safari', 'ios'];
+  private webkitBrowsers: string[] = ['crios', 'fxios', 'safari', 'ios', 'ios-webview'];
 
   private enableUnifiedPlanForChromiumBasedBrowsers: boolean;
   private recreateAudioContextIfNeeded: boolean;
@@ -258,7 +260,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   // These helpers should be kept private to encourage
   // feature detection instead of browser detection.
   private isIOSSafari(): boolean {
-    return this.browser.name === 'ios';
+    return this.browser.name === 'ios' || this.browser.name === 'ios-webview';
   }
 
   private isSafari(): boolean {

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -45,6 +45,8 @@ describe('DefaultBrowserBehavior', () => {
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Slack/4.9.0 Chrome/85.0.4183.93 Electron/10.1.1 Safari/537.36 Sonic Slack_SSB/4.9.0';
   const ELECTRON_WINDOWS_USER_AGENT =
     'Mozilla/5.0 (Windows NT 10.0.18362; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Slack/4.9.0 Chrome/85.0.4183.93 Electron/10.1.1 Safari/537.36 Sonic Slack_SSB/4.9.0';
+  const WKWEBVIEW_IOS_USER_AGENT =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
 
   const setUserAgent = (userAgent: string): void => {
     // @ts-ignore
@@ -247,6 +249,20 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().isSupported()).to.be.true;
       expect(new DefaultBrowserBehavior().requiresVideoElementWorkaround()).to.be.false;
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(29);
+      expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
+      expect(new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()).to.be.false;
+      expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
+      expect(new DefaultBrowserBehavior().requiresUnifiedPlan()).to.be.true;
+      expect(new DefaultBrowserBehavior().requiresUnifiedPlanMunging()).to.be.true;
+      expect(new DefaultBrowserBehavior().supportsSenderSideBandwidthEstimation()).to.be.false;
+    });
+
+    it('can detect iOS WKWebView', () => {
+      setUserAgent(WKWEBVIEW_IOS_USER_AGENT);
+      expect(new DefaultBrowserBehavior().name()).to.eq('ios-webview');
+      expect(new DefaultBrowserBehavior().isSupported()).to.be.true;
+      expect(new DefaultBrowserBehavior().requiresVideoElementWorkaround()).to.be.false;
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(605);
       expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
       expect(new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()).to.be.false;
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
WKWebView recently added support for WebRTC in iOS 14.3. This commit will add support for 'ios-webview' browsers on iOS. The change is simple - just need to add the 'ios-webview' browser name to the list of supported browsers, so that the SDK can identify the 'ios-webview' browser name and enable Unified Plan when using this client type. 

**Testing**

1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? 
I made these changes in the SDK, then deployed a demo of the SDK including the WKWebview support changes. Then I built a simple ios app that loads a WKWebview which then navigates to the newly deployed demo and joins the meeting from within the WKWebview. I verified that audio/video selection works in WKWebView.  Basic sanity tests were performed within the meeting of the WKWebView, including mute/unmute, start/stop video, etc. 


3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
No, we need an iOS app which loads a WKWebView to test these changes. 

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

