### PR TITLE
Do not start local video tile if there is no stream for content share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `npm run start:hot` in the browser demo.
+- Do not start local video tile if there is no stream for content share
 
 ## [2.8.0] - 2021-04-23
 

--- a/src/contentsharecontroller/DefaultContentShareController.ts
+++ b/src/contentsharecontroller/DefaultContentShareController.ts
@@ -164,7 +164,7 @@ export default class DefaultContentShareController
           return;
         }
         const stream = this.mediaStreamBroker.mediaStream;
-        if (stream.getVideoTracks().length > 0) {
+        if (stream?.getVideoTracks().length) {
           this.contentShareTile = this.attendeeAudioVideo.videoTileController.addVideoTile();
           const track = stream.getVideoTracks()[0];
           let width, height;

--- a/test/contentsharecontroller/DefaultContentShareController.test.ts
+++ b/test/contentsharecontroller/DefaultContentShareController.test.ts
@@ -307,6 +307,21 @@ describe('DefaultContentShareController', () => {
       expect(selfVideoTileSpy.notCalled).to.be.true;
     });
 
+    it(' did not add local video tile for same attendee presence events if no media stream', async () => {
+      const selfVideoTileSpy = sinon.spy(
+        attendeeAudioVideoController.videoTileController,
+        'addVideoTile'
+      );
+      attendeeAudioVideoController.realtimeController.realtimeSetAttendeeIdPresence(
+        'foo-attendee#content',
+        true,
+        'foo-external-id',
+        null,
+        null
+      );
+      expect(selfVideoTileSpy.notCalled).to.be.true;
+    });
+
     it('startContentShareFromScreenCapture', async () => {
       const mediaStreamBrokerSpy = sinon.spy(
         contentShareMediaStreamBroker,


### PR DESCRIPTION
**Issue #1153:**

**Description of changes:**
Do not start local video tile if there is no stream for content share. This can happen when:
- Joining a meeting and start content share
- Joining the same meeting with the same attendeeId. 
- This should trigger meeting status code `AudioJoinedFromAnotherDevice` in the first  meeting and disconnect the meeting. However, before the first meeting is disconnected, the content attendee presence event will fire for content share controller in the second meeting and attempt to start local video tile.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
Yes, I modify the meeting demo to cache attendeeId based on name entered to allow joining same meeting with same attendeeId and verified that there was no error thrown after following the reproduce steps above.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? 
No, since the meeting demo does not allow to join with same attendeeId.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

