### PR TITLE
Add a trivial implementation of local recording to the browser demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -341,6 +341,9 @@
         <button id="button-video-stats" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Toggle video WebRTC stats display" data-toggle="button" aria-pressed="false" autocomplete="off">
           ${require('../../node_modules/open-iconic/svg/signal.svg').default}
         </button>
+        <button id="button-record-self" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Record my audio and video" data-toggle="button" aria-pressed="false" autocomplete="off">
+          <svg><circle id="rec-svg" cx="10" cy="10" r="8" fill="red"></circle></svg>
+        </button>
       </div>
       <div class="col-4 col-lg-3 order-3 order-lg-3 text-right text-lg-right">
         <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4" title="Leave meeting">

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -352,7 +352,7 @@
       </div>
     </div>
     <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100" style="flex: unset;">
-      <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-6 col-md-5 col-lg-4 h-100">
+      <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-5 col-md-4 col-lg-3 h-100">
         <div class="bs-component" style="flex: 1 1 auto; overflow-y: auto; height: 50%;">
           <ul id="roster" class="list-group"></ul>
         </div>
@@ -365,7 +365,7 @@
           </div>
         </div>
       </div>
-      <div id="tile-container" class="col-12 col-sm-6 col-md-7 col-lg-8 my-4 my-sm-0 h-100" style="overflow-y: scroll">
+      <div id="tile-container" class="col-12 col-sm-7 col-md-8 col-lg-9 my-4 my-sm-0 h-100" style="overflow-y: scroll">
         <div id="tile-area" class="v-grid">
           <div id="tile-0" class="video-tile">
             <video id="video-0" class="video-tile-video"></video>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -17,6 +17,7 @@ import {
   DataMessage,
   DefaultActiveSpeakerPolicy,
   DefaultAudioMixController,
+  DefaultAudioVideoController,
   DefaultBrowserBehavior,
   DefaultDeviceController,
   DefaultMeetingSession,
@@ -26,8 +27,8 @@ import {
   DeviceChangeObserver,
   EventAttributes,
   EventName,
-  Logger,
   LogLevel,
+  Logger,
   MeetingSession,
   MeetingSessionConfiguration,
   MeetingSessionPOSTLogger,
@@ -43,14 +44,14 @@ import {
   Versioning,
   VideoFrameProcessor,
   VideoInputDevice,
+  VideoPreference,
+  VideoPreferences,
+  VideoPriorityBasedPolicy,
   VideoSource,
   VideoTileState,
   VoiceFocusDeviceTransformer,
   VoiceFocusPaths,
   VoiceFocusTransformDevice,
-  VideoPreference,
-  VideoPreferences,
-  VideoPriorityBasedPolicy,
   isAudioTransformDevice,
 } from 'amazon-chime-sdk-js';
 
@@ -277,6 +278,7 @@ export class DemoMeetingApp
     'button-pause-content-share': false,
     'button-video-stats': false,
     'button-video-filter': false,
+    'button-record-self': false,
   };
 
   contentShareType: ContentShareType = ContentShareType.ScreenCapture;
@@ -709,6 +711,61 @@ export class DemoMeetingApp
       } else {
         this.audioVideo.realtimeMuteLocalAudio();
       }
+    });
+
+    const buttonRecordSelf = document.getElementById('button-record-self');
+    let recorder: MediaRecorder;
+    buttonRecordSelf.addEventListener('click', _e => {
+      const chunks: Blob[] = [];
+      AsyncScheduler.nextTick(async () => {
+        if (!this.toggleButton('button-record-self')) {
+          console.info('Stopping recorder ', recorder);
+          recorder.stop();
+          recorder = undefined;
+          return;
+        }
+
+        // Combine the audio and video streams.
+        const mixed = new MediaStream();
+
+        const localTile = this.audioVideo.getLocalVideoTile();
+        if (localTile) {
+          mixed.addTrack(localTile.state().boundVideoStream.getVideoTracks()[0]);
+        }
+
+        // We need to get access to the media stream broker, which requires knowing
+        // the exact implementation. Sorry!
+        /* @ts-ignore */
+        const av: DefaultAudioVideoController = this.audioVideo.audioVideoController;
+        const input = await av.mediaStreamBroker.acquireAudioInputStream();
+        mixed.addTrack(input.getAudioTracks()[0]);
+
+        recorder = new MediaRecorder(mixed, { mimeType: 'video/webm; codecs=vp9' });
+        console.info('Setting recorder to', recorder);
+        recorder.ondataavailable = (event) => {
+          if (event.data.size) {
+            chunks.push(event.data);
+          }
+        };
+
+        recorder.onstop = () => {
+          const blob = new Blob(chunks, {
+            type: 'video/webm',
+          });
+          chunks.length = 0;
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          document.body.appendChild(a);
+          /* @ts-ignore */
+          a.style = 'display: none';
+          a.href = url;
+          a.download = 'recording.webm';
+          a.click();
+          window.URL.revokeObjectURL(url);
+        };
+
+        recorder.start();
+      });
     });
 
     const buttonVideo = document.getElementById('button-camera');


### PR DESCRIPTION
This commit adds a simple 'Record' button to the in-meeting toolbar.

When pressed this instantiates a `MediaRecorder` and attaches the current post-processed microphone and camera inputs, saving it to a local file when the button is pressed again.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

No: demo-only.

> 2. How did you test these changes?

Demo.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

Yes!

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

