### PR TITLE
Update README to call listAudioInputDevice before chooseAudioInputDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ audioInputDevices.forEach(mediaDeviceInfo => {
 ```
 
 **Use case 2.** Choose audio input and audio output devices by passing the `deviceId` of a `MediaDeviceInfo` object.
+Note that you need to call `listAudioInputDevices` and `listAudioOutputDevices` first.
 
 ```js
 const audioInputDeviceInfo = /* An array item from meetingSession.audioVideo.listAudioInputDevices */;
@@ -252,6 +253,7 @@ await meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDeviceInfo.de
 ```
 
 **Use case 3.** Choose a video input device by passing the `deviceId` of a `MediaDeviceInfo` object.
+Note that you need to call `listVideoInputDevices` first.
 
 If there is an LED light next to the attendee's camera, it will be turned on indicating that it is now capturing from the camera.
 You probably want to choose a video input device when you start sharing your video.

--- a/docs/index.html
+++ b/docs/index.html
@@ -305,14 +305,16 @@ audioInputDevices.forEach(<span class="hljs-function"><span class="hljs-params">
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">`Device ID: <span class="hljs-subst">${mediaDeviceInfo.deviceId}</span> Microphone: <span class="hljs-subst">${mediaDeviceInfo.label}</span>`</span>);
 });
 </code></pre>
-				<p><strong>Use case 2.</strong> Choose audio input and audio output devices by passing the <code>deviceId</code> of a <code>MediaDeviceInfo</code> object.</p>
+				<p><strong>Use case 2.</strong> Choose audio input and audio output devices by passing the <code>deviceId</code> of a <code>MediaDeviceInfo</code> object.
+				Note that you need to call <code>listAudioInputDevices</code> and <code>listAudioOutputDevices</code> first.</p>
 				<pre><code class="language-js"><span class="hljs-keyword">const</span> audioInputDeviceInfo = <span class="hljs-comment">/* An array item from meetingSession.audioVideo.listAudioInputDevices */</span>;
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioInputDevice(audioInputDeviceInfo.deviceId);
 
 <span class="hljs-keyword">const</span> audioOutputDeviceInfo = <span class="hljs-comment">/* An array item from meetingSession.audioVideo.listAudioOutputDevices */</span>;
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDeviceInfo.deviceId);
 </code></pre>
-				<p><strong>Use case 3.</strong> Choose a video input device by passing the <code>deviceId</code> of a <code>MediaDeviceInfo</code> object.</p>
+				<p><strong>Use case 3.</strong> Choose a video input device by passing the <code>deviceId</code> of a <code>MediaDeviceInfo</code> object.
+				Note that you need to call <code>listVideoInputDevices</code> first.</p>
 				<p>If there is an LED light next to the attendee&#39;s camera, it will be turned on indicating that it is now capturing from the camera.
 				You probably want to choose a video input device when you start sharing your video.</p>
 				<pre><code class="language-js"><span class="hljs-keyword">const</span> videoInputDeviceInfo = <span class="hljs-comment">/* An array item from meetingSession.audioVideo.listVideoInputDevices */</span>;


### PR DESCRIPTION
**Issue #1245:**

**Description of changes:** 
Update README to explicitly call out that list**Device APIs have to be called before calling the corresponding choose**Device APIs. 

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

