### PR TITLE
[Integ] Add a GitHub workflow to check previous version

### DIFF
--- a/.github/script/get-prev-version
+++ b/.github/script/get-prev-version
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+versions = `npm view amazon-chime-sdk-js versions --json`.strip.split("\n")
+# The output would be something like
+#[
+#  "1.0.0",
+#  ...
+#  "2.8.0", <- previous version
+#  "2.9.0"  <- latest version
+#]
+puts versions[versions.size-3][3..-3]

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -1,0 +1,80 @@
+name: Previous Version Integration Tests Workflow
+
+on:
+  schedule:
+    - cron: '30 */2 * * *'
+
+env:
+ SELENIUM_GRID_PROVIDER: saucelabs
+ CLOUD_WATCH_METRIC: false
+ TEST_TYPE: Github-Action
+ SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
+ SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+
+jobs:
+  prev-version-integ:
+    name: Previous Version Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node.js - 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Checkout Package
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get previous version
+        id: prev
+        run: |
+          prev_version=$(.github/script/get-prev-version)
+          echo "Previous version:" $prev_version
+          echo ::set-output name=prev_version::$prev_version
+      - name: Create a Job ID
+        id: create-job-id
+        uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c
+      - name: Set JOB_ID Env Variable
+        run: echo "JOB_ID=${{ steps.create-job-id.outputs.uuid }}" >> $GITHUB_ENV
+      - name: Echo Job ID
+        run: echo "${{ steps.create-job-id.outputs.uuid }}"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Setup Sauce Connect
+        uses: saucelabs/sauce-connect-action@v1
+        with:
+          username: ${{ secrets.SAUCE_USERNAME }}
+          accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+          noSSLBumpDomains: all
+          tunnelIdentifier: ${{ steps.create-job-id.outputs.uuid }}
+      - name: Install Kite
+        run: integration/js/script/install-kite
+      - name: Setup
+        # Temporarily we need to copy the run-test script over from 2.9.0. Can be removed after 2.10.0 is released
+        run: |
+          cp integration/js/script/run-test integration/js/script/run-test.bku
+          git checkout tags/v${{ steps.prev.outputs.prev_version }}
+          cp integration/js/script/run-test.bku integration/js/script/run-test
+          chmod +x integration/js/script/run-test
+      - name: Clean Install
+        run: npm ci
+      - name: Run Audio Integration Test
+        run: npm run test:integration-audio
+      - name: Run Video Integ Test
+        run: npm run test:integration-video
+      - name: Run Content Share Integration Test
+        run: npm run test:integration-content-share
+      - name: Run Data Message Integration Test
+        run: npm run test:integration-data-message
+      - name: Run Meeting Readiness Checker Integration Test
+        run: npm run test:integration-meeting-readiness-checker
+      - name: Run Messaging Integration Test
+        run: npm run test:integration-messaging

--- a/integration/js/script/run-test
+++ b/integration/js/script/run-test
@@ -126,4 +126,7 @@ case $1 in
       ;;
 esac
 
+#Kill the current local demo process
+kill -9 $(lsof -i:8080 | grep LISTEN | awk '{print $2}')
+
 ./js/script/failure-check


### PR DESCRIPTION
**Description of changes:**
Add a scheduled GitHub action to verify that previous version is working by running integration tests.
Temporarily set it to run every 2 hour  at 30 minute mark to easily verify the action works.
Will do a subsequent PR to change it to run once a day.

**Testing**

1. Have you successfully run `npm run build:release` locally? N/A
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

