### PR TITLE
Add macOS 11 check for SauceLabs WebDriver to support Safari 14

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -5,10 +5,11 @@ const Base64 = require('js-base64').Base64;
 const { AppPage, MeetingReadinessCheckerPage, MessagingSessionPage, TestAppPage } = require('../pages');
 
 const getPlatformName = capabilities => {
-  switch (capabilities.platform) {
+  const { browserName, version, platform } = capabilities;
+  switch (platform) {
     case 'MAC':
-      if (capabilities.browserName === "safari") {
-        return "macOS 10.13";
+      if (browserName === 'safari') {
+        return version === 'latest' ? 'macOS 11.00' : 'macOS 10.13';
       }
       return 'macOS 10.14';
     case 'WINDOWS':


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Safari 12 is old and we would like to test audio test runs on latest Safari which is 14. We need SauceLabs WebDriver to use macOS 11.00 to achieve this.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Triggered runs from local to SauceLabs to check if Audio test is running fine on Safari 14.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? NA.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

