### PR TITLE
[Integ] Setup userArn for messaging test for prev version

### DIFF
--- a/.github/script/get-prev-version
+++ b/.github/script/get-prev-version
@@ -1,11 +1,16 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env node
 
-versions = `npm view amazon-chime-sdk-js versions --json`.strip.split("\n")
-# The output would be something like
-#[
-#  "1.0.0",
-#  ...
-#  "2.8.0", <- previous version
-#  "2.9.0"  <- latest version
-#]
-puts versions[versions.size-3][3..-3]
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const exec = require('child_process').execSync;
+
+const versions = exec('npm view amazon-chime-sdk-js versions --json').toString().trim().split("\n");
+// The output would be something like
+// [
+//   "1.0.0",
+//       ...
+//   "2.8.0", <- previous version
+//   "2.9.0"  <- latest version
+// ]
+
+const prev_version = versions[versions.length-3];
+console.log(prev_version.substring(3,prev_version.length-2))

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -2,14 +2,16 @@ name: Previous Version Integration Tests Workflow
 
 on:
   schedule:
-    - cron: '30 */2 * * *'
+    # More information on cron https://crontab.guru/
+    - cron: '0 1 * * *'
 
 env:
- SELENIUM_GRID_PROVIDER: saucelabs
- CLOUD_WATCH_METRIC: false
- TEST_TYPE: Github-Action
- SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
- SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+  SELENIUM_GRID_PROVIDER: saucelabs
+  CLOUD_WATCH_METRIC: false
+  TEST_TYPE: Github-Action
+  SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
+  SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+  MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
 
 jobs:
   prev-version-integ:
@@ -21,10 +23,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6
       - name: Checkout Package
         uses: actions/checkout@v2
         with:
@@ -76,5 +74,7 @@ jobs:
         run: npm run test:integration-data-message
       - name: Run Meeting Readiness Checker Integration Test
         run: npm run test:integration-meeting-readiness-checker
+      - name: Setup userArn
+        run: integration/js/script/test-setup
       - name: Run Messaging Integration Test
         run: npm run test:integration-messaging


### PR DESCRIPTION
**Description of changes:**
- Add a step to setup userArn before running messaging session test in previous version integration test.]
- Readjust the cron to run once every day at 1am.

**Testing**

1. Have you successfully run `npm run build:release` locally? N/A
2. How did you test these changes? Switch over to PR trigger and verify that messaging session completed successfully. 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

