### PR TITLE
Mark optional for new constructors and interface in clientMetricReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bump version for lodash, y18n, and ssri dependencies 
+- Mark `getObservableVideoMetrics` optional in ClientMetricReprt and `videoStreamIndex` and `selfAttendeeId` optional in DefaultClientMetricReport
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `WKWebView` on iOS.
 - Output a warning message when the volume adapter cleans up the self-attendee after reconnection.
 - Add FAQ for more information on `AudioJoinFromAnotherDevice` meeting session status code.
-- Add downstream audio webrtc metrics in `observableMetricSpec`
-- Add `getObservableVideoMetrics` and in ClientMetricReport to expose video stream metrics in webrtc
-- Update `SignalingProtocol` with optional video metric fields
+- Add downstream audio webrtc metrics in `observableMetricSpec`.
+- Add `getObservableVideoMetrics` and in `ClientMetricReport` to expose video stream metrics in webrtc.
+- Update `SignalingProtocol` with optional video metric fields.
 
 ### Changed
-- Bump version for lodash, y18n, and ssri dependencies 
-- Mark `getObservableVideoMetrics` optional in ClientMetricReprt and `videoStreamIndex` and `selfAttendeeId` optional in DefaultClientMetricReport
+- Bump version for lodash, y18n, and ssri dependencies.
+- Mark `getObservableVideoMetrics` optional in ClientMetricReprt and `videoStreamIndex` and `selfAttendeeId` optional in `DefaultClientMetricReport`.
 
 ### Removed
 

--- a/docs/classes/defaultclientmetricreport.html
+++ b/docs/classes/defaultclientmetricreport.html
@@ -140,13 +140,13 @@
 					<a name="constructor" class="tsd-anchor"></a>
 					<h3>constructor</h3>
 					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Client<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">(</span>logger<span class="tsd-signature-symbol">: </span><a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a>, videoStreamIndex<span class="tsd-signature-symbol">: </span><a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a>, audioVideoController<span class="tsd-signature-symbol">: </span><a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaultclientmetricreport.html" class="tsd-signature-type">DefaultClientMetricReport</a></li>
+						<li class="tsd-signature tsd-kind-icon">new <wbr>Default<wbr>Client<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">(</span>logger<span class="tsd-signature-symbol">: </span><a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a>, videoStreamIndex<span class="tsd-signature-symbol">?: </span><a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a>, selfAttendeeId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaultclientmetricreport.html" class="tsd-signature-type">DefaultClientMetricReport</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L19">src/clientmetricreport/DefaultClientMetricReport.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L18">src/clientmetricreport/DefaultClientMetricReport.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,10 +155,10 @@
 									<h5>logger: <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></h5>
 								</li>
 								<li>
-									<h5>videoStreamIndex: <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a></h5>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> videoStreamIndex: <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a></h5>
 								</li>
 								<li>
-									<h5>audioVideoController: <a href="../interfaces/audiovideocontroller.html" class="tsd-signature-type">AudioVideoController</a></h5>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> selfAttendeeId: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="defaultclientmetricreport.html" class="tsd-signature-type">DefaultClientMetricReport</a></h4>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Ssrcs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L19">src/clientmetricreport/DefaultClientMetricReport.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L18">src/clientmetricreport/DefaultClientMetricReport.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">current<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L17">src/clientmetricreport/DefaultClientMetricReport.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L16">src/clientmetricreport/DefaultClientMetricReport.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Metric<wbr>Report<span class="tsd-signature-symbol">:</span> <a href="globalmetricreport.html" class="tsd-signature-type">GlobalMetricReport</a><span class="tsd-signature-symbol"> = new GlobalMetricReport()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L15">src/clientmetricreport/DefaultClientMetricReport.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L14">src/clientmetricreport/DefaultClientMetricReport.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">previous<wbr>Timestamp<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L18">src/clientmetricreport/DefaultClientMetricReport.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L17">src/clientmetricreport/DefaultClientMetricReport.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">stream<wbr>Metric<wbr>Reports<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L16">src/clientmetricreport/DefaultClientMetricReport.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L15">src/clientmetricreport/DefaultClientMetricReport.ts:15</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -247,7 +247,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L86">src/clientmetricreport/DefaultClientMetricReport.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L85">src/clientmetricreport/DefaultClientMetricReport.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L592">src/clientmetricreport/DefaultClientMetricReport.ts:592</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L591">src/clientmetricreport/DefaultClientMetricReport.ts:591</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -295,7 +295,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L69">src/clientmetricreport/DefaultClientMetricReport.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L68">src/clientmetricreport/DefaultClientMetricReport.ts:68</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L36">src/clientmetricreport/DefaultClientMetricReport.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L35">src/clientmetricreport/DefaultClientMetricReport.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -347,7 +347,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L325">src/clientmetricreport/DefaultClientMetricReport.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L324">src/clientmetricreport/DefaultClientMetricReport.ts:324</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -410,7 +410,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L504">src/clientmetricreport/DefaultClientMetricReport.ts:504</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L503">src/clientmetricreport/DefaultClientMetricReport.ts:503</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -434,7 +434,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/clientmetricreport.html">ClientMetricReport</a>.<a href="../interfaces/clientmetricreport.html#getobservablemetrics">getObservableMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L551">src/clientmetricreport/DefaultClientMetricReport.ts:551</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L550">src/clientmetricreport/DefaultClientMetricReport.ts:550</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{}</span></h4>
@@ -456,7 +456,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L529">src/clientmetricreport/DefaultClientMetricReport.ts:529</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L528">src/clientmetricreport/DefaultClientMetricReport.ts:528</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -483,7 +483,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/clientmetricreport.html">ClientMetricReport</a>.<a href="../interfaces/clientmetricreport.html#getobservablevideometrics">getObservableVideoMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L559">src/clientmetricreport/DefaultClientMetricReport.ts:559</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L558">src/clientmetricreport/DefaultClientMetricReport.ts:558</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{}</span></h4>
@@ -512,7 +512,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L31">src/clientmetricreport/DefaultClientMetricReport.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L30">src/clientmetricreport/DefaultClientMetricReport.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -543,7 +543,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L54">src/clientmetricreport/DefaultClientMetricReport.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L53">src/clientmetricreport/DefaultClientMetricReport.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -569,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L605">src/clientmetricreport/DefaultClientMetricReport.ts:605</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L604">src/clientmetricreport/DefaultClientMetricReport.ts:604</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -586,7 +586,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L617">src/clientmetricreport/DefaultClientMetricReport.ts:617</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L616">src/clientmetricreport/DefaultClientMetricReport.ts:616</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -603,7 +603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L104">src/clientmetricreport/DefaultClientMetricReport.ts:104</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L103">src/clientmetricreport/DefaultClientMetricReport.ts:103</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -628,7 +628,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Downstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L177">src/clientmetricreport/DefaultClientMetricReport.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L176">src/clientmetricreport/DefaultClientMetricReport.ts:176</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -637,7 +637,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L198">src/clientmetricreport/DefaultClientMetricReport.ts:198</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L197">src/clientmetricreport/DefaultClientMetricReport.ts:197</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -646,7 +646,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L198">src/clientmetricreport/DefaultClientMetricReport.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L197">src/clientmetricreport/DefaultClientMetricReport.ts:197</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -656,7 +656,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L198">src/clientmetricreport/DefaultClientMetricReport.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L197">src/clientmetricreport/DefaultClientMetricReport.ts:197</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -667,7 +667,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Current<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L199">src/clientmetricreport/DefaultClientMetricReport.ts:199</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L198">src/clientmetricreport/DefaultClientMetricReport.ts:198</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -676,7 +676,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L200">src/clientmetricreport/DefaultClientMetricReport.ts:200</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L199">src/clientmetricreport/DefaultClientMetricReport.ts:199</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -686,7 +686,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_CURRENT_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_CURRENT_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L201">src/clientmetricreport/DefaultClientMetricReport.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L200">src/clientmetricreport/DefaultClientMetricReport.ts:200</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -697,7 +697,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>DecodingCTN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L191">src/clientmetricreport/DefaultClientMetricReport.ts:191</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -706,7 +706,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L191">src/clientmetricreport/DefaultClientMetricReport.ts:191</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -717,7 +717,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Decoding<wbr>Normal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L193">src/clientmetricreport/DefaultClientMetricReport.ts:193</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L192">src/clientmetricreport/DefaultClientMetricReport.ts:192</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -726,7 +726,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googDecodingCTN&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L196">src/clientmetricreport/DefaultClientMetricReport.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L195">src/clientmetricreport/DefaultClientMetricReport.ts:195</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -736,7 +736,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.decoderLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L194">src/clientmetricreport/DefaultClientMetricReport.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L193">src/clientmetricreport/DefaultClientMetricReport.ts:193</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -746,7 +746,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_FRACTION_DECODER_LOSS_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_FRACTION_DECODER_LOSS_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L195">src/clientmetricreport/DefaultClientMetricReport.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L194">src/clientmetricreport/DefaultClientMetricReport.ts:194</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -757,7 +757,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Buffer<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L203">src/clientmetricreport/DefaultClientMetricReport.ts:203</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L202">src/clientmetricreport/DefaultClientMetricReport.ts:202</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -766,7 +766,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L204">src/clientmetricreport/DefaultClientMetricReport.ts:204</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L203">src/clientmetricreport/DefaultClientMetricReport.ts:203</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -776,7 +776,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_BUFFER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_BUFFER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L205">src/clientmetricreport/DefaultClientMetricReport.ts:205</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L204">src/clientmetricreport/DefaultClientMetricReport.ts:204</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -787,7 +787,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L189">src/clientmetricreport/DefaultClientMetricReport.ts:189</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -796,7 +796,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L189">src/clientmetricreport/DefaultClientMetricReport.ts:189</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -806,7 +806,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L189">src/clientmetricreport/DefaultClientMetricReport.ts:189</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -817,7 +817,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L191">src/clientmetricreport/DefaultClientMetricReport.ts:191</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -826,7 +826,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L191">src/clientmetricreport/DefaultClientMetricReport.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -836,7 +836,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L191">src/clientmetricreport/DefaultClientMetricReport.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L190">src/clientmetricreport/DefaultClientMetricReport.ts:190</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -847,7 +847,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L185">src/clientmetricreport/DefaultClientMetricReport.ts:185</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -856,7 +856,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L188">src/clientmetricreport/DefaultClientMetricReport.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L187">src/clientmetricreport/DefaultClientMetricReport.ts:187</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -866,7 +866,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L186">src/clientmetricreport/DefaultClientMetricReport.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L185">src/clientmetricreport/DefaultClientMetricReport.ts:185</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -876,7 +876,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L187">src/clientmetricreport/DefaultClientMetricReport.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L186">src/clientmetricreport/DefaultClientMetricReport.ts:186</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -887,7 +887,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L183">src/clientmetricreport/DefaultClientMetricReport.ts:183</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -896,7 +896,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L183">src/clientmetricreport/DefaultClientMetricReport.ts:183</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -906,7 +906,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_SPK_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_SPK_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L184">src/clientmetricreport/DefaultClientMetricReport.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L183">src/clientmetricreport/DefaultClientMetricReport.ts:183</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -918,7 +918,7 @@
 					<div class="tsd-signature tsd-kind-icon">audio<wbr>Upstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L158">src/clientmetricreport/DefaultClientMetricReport.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L157">src/clientmetricreport/DefaultClientMetricReport.ts:157</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -927,7 +927,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -936,7 +936,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -946,7 +946,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -957,7 +957,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L164">src/clientmetricreport/DefaultClientMetricReport.ts:164</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -966,7 +966,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L164">src/clientmetricreport/DefaultClientMetricReport.ts:164</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -976,7 +976,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L164">src/clientmetricreport/DefaultClientMetricReport.ts:164</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -987,7 +987,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L169">src/clientmetricreport/DefaultClientMetricReport.ts:169</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -996,7 +996,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L169">src/clientmetricreport/DefaultClientMetricReport.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1006,7 +1006,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L169">src/clientmetricreport/DefaultClientMetricReport.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L168">src/clientmetricreport/DefaultClientMetricReport.ts:168</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1017,7 +1017,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1026,7 +1026,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1036,7 +1036,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L165">src/clientmetricreport/DefaultClientMetricReport.ts:165</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1047,7 +1047,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L170">src/clientmetricreport/DefaultClientMetricReport.ts:170</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L169">src/clientmetricreport/DefaultClientMetricReport.ts:169</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1056,7 +1056,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L173">src/clientmetricreport/DefaultClientMetricReport.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L172">src/clientmetricreport/DefaultClientMetricReport.ts:172</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1066,7 +1066,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L171">src/clientmetricreport/DefaultClientMetricReport.ts:171</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L170">src/clientmetricreport/DefaultClientMetricReport.ts:170</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1076,7 +1076,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L172">src/clientmetricreport/DefaultClientMetricReport.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L171">src/clientmetricreport/DefaultClientMetricReport.ts:171</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1087,7 +1087,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1096,7 +1096,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1106,7 +1106,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RTC_MIC_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.RTC_MIC_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L167">src/clientmetricreport/DefaultClientMetricReport.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L166">src/clientmetricreport/DefaultClientMetricReport.ts:166</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1118,7 +1118,7 @@
 					<div class="tsd-signature tsd-kind-icon">global<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L113">src/clientmetricreport/DefaultClientMetricReport.ts:113</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L112">src/clientmetricreport/DefaultClientMetricReport.ts:112</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1132,7 +1132,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Incoming<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L147">src/clientmetricreport/DefaultClientMetricReport.ts:147</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L146">src/clientmetricreport/DefaultClientMetricReport.ts:146</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1141,7 +1141,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L148">src/clientmetricreport/DefaultClientMetricReport.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L147">src/clientmetricreport/DefaultClientMetricReport.ts:147</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1151,7 +1151,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L149">src/clientmetricreport/DefaultClientMetricReport.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L148">src/clientmetricreport/DefaultClientMetricReport.ts:148</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1162,7 +1162,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Outgoing<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L151">src/clientmetricreport/DefaultClientMetricReport.ts:151</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L150">src/clientmetricreport/DefaultClientMetricReport.ts:150</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1171,7 +1171,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L152">src/clientmetricreport/DefaultClientMetricReport.ts:152</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L151">src/clientmetricreport/DefaultClientMetricReport.ts:151</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1181,7 +1181,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_SEND_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_SEND_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L153">src/clientmetricreport/DefaultClientMetricReport.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L152">src/clientmetricreport/DefaultClientMetricReport.ts:152</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1192,7 +1192,7 @@
 						<div class="tsd-signature tsd-kind-icon">current<wbr>Round<wbr>Trip<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L155">src/clientmetricreport/DefaultClientMetricReport.ts:155</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L154">src/clientmetricreport/DefaultClientMetricReport.ts:154</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1201,7 +1201,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L155">src/clientmetricreport/DefaultClientMetricReport.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L154">src/clientmetricreport/DefaultClientMetricReport.ts:154</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1211,7 +1211,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">STUN_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.STUN_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L155">src/clientmetricreport/DefaultClientMetricReport.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L154">src/clientmetricreport/DefaultClientMetricReport.ts:154</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1222,7 +1222,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Actual<wbr>Enc<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L120">src/clientmetricreport/DefaultClientMetricReport.ts:120</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L119">src/clientmetricreport/DefaultClientMetricReport.ts:119</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1231,7 +1231,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L121">src/clientmetricreport/DefaultClientMetricReport.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L120">src/clientmetricreport/DefaultClientMetricReport.ts:120</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1241,7 +1241,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ACTUAL_ENCODER_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ACTUAL_ENCODER_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L122">src/clientmetricreport/DefaultClientMetricReport.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L121">src/clientmetricreport/DefaultClientMetricReport.ts:121</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1252,7 +1252,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Available<wbr>Receive<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L132">src/clientmetricreport/DefaultClientMetricReport.ts:132</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L131">src/clientmetricreport/DefaultClientMetricReport.ts:131</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1261,7 +1261,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L133">src/clientmetricreport/DefaultClientMetricReport.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L132">src/clientmetricreport/DefaultClientMetricReport.ts:132</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1271,7 +1271,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_RECEIVE_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L134">src/clientmetricreport/DefaultClientMetricReport.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L133">src/clientmetricreport/DefaultClientMetricReport.ts:133</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1282,7 +1282,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Available<wbr>Send<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L124">src/clientmetricreport/DefaultClientMetricReport.ts:124</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L123">src/clientmetricreport/DefaultClientMetricReport.ts:123</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1291,7 +1291,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L125">src/clientmetricreport/DefaultClientMetricReport.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L124">src/clientmetricreport/DefaultClientMetricReport.ts:124</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1301,7 +1301,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVAILABLE_SEND_BANDWIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVAILABLE_SEND_BANDWIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L126">src/clientmetricreport/DefaultClientMetricReport.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L125">src/clientmetricreport/DefaultClientMetricReport.ts:125</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1312,7 +1312,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Bucket<wbr>Delay<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L139">src/clientmetricreport/DefaultClientMetricReport.ts:139</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1321,7 +1321,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L139">src/clientmetricreport/DefaultClientMetricReport.ts:139</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1331,7 +1331,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_BUCKET_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_BUCKET_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L139">src/clientmetricreport/DefaultClientMetricReport.ts:139</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1342,7 +1342,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Retransmit<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L128">src/clientmetricreport/DefaultClientMetricReport.ts:128</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L127">src/clientmetricreport/DefaultClientMetricReport.ts:127</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1351,7 +1351,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L129">src/clientmetricreport/DefaultClientMetricReport.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L128">src/clientmetricreport/DefaultClientMetricReport.ts:128</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1361,7 +1361,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RETRANSMIT_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RETRANSMIT_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L130">src/clientmetricreport/DefaultClientMetricReport.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L129">src/clientmetricreport/DefaultClientMetricReport.ts:129</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1372,7 +1372,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L141">src/clientmetricreport/DefaultClientMetricReport.ts:141</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1381,7 +1381,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L141">src/clientmetricreport/DefaultClientMetricReport.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1391,7 +1391,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">STUN_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.STUN_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L141">src/clientmetricreport/DefaultClientMetricReport.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L140">src/clientmetricreport/DefaultClientMetricReport.ts:140</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1402,7 +1402,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Target<wbr>Enc<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L136">src/clientmetricreport/DefaultClientMetricReport.ts:136</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L135">src/clientmetricreport/DefaultClientMetricReport.ts:135</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1411,7 +1411,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L137">src/clientmetricreport/DefaultClientMetricReport.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L136">src/clientmetricreport/DefaultClientMetricReport.ts:136</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1421,7 +1421,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_TARGET_ENCODER_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_TARGET_ENCODER_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L138">src/clientmetricreport/DefaultClientMetricReport.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L137">src/clientmetricreport/DefaultClientMetricReport.ts:137</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1432,7 +1432,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Discarded<wbr>OnSend<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L142">src/clientmetricreport/DefaultClientMetricReport.ts:142</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L141">src/clientmetricreport/DefaultClientMetricReport.ts:141</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1441,7 +1441,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L143">src/clientmetricreport/DefaultClientMetricReport.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L142">src/clientmetricreport/DefaultClientMetricReport.ts:142</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1451,7 +1451,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SOCKET_DISCARDED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.SOCKET_DISCARDED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L144">src/clientmetricreport/DefaultClientMetricReport.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L143">src/clientmetricreport/DefaultClientMetricReport.ts:143</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1463,7 +1463,7 @@
 					<div class="tsd-signature tsd-kind-icon">observable<wbr>Metric<wbr>Spec<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L442">src/clientmetricreport/DefaultClientMetricReport.ts:442</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L441">src/clientmetricreport/DefaultClientMetricReport.ts:441</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1477,7 +1477,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Decoder<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L459">src/clientmetricreport/DefaultClientMetricReport.ts:459</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L458">src/clientmetricreport/DefaultClientMetricReport.ts:458</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1486,7 +1486,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L462">src/clientmetricreport/DefaultClientMetricReport.ts:462</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L461">src/clientmetricreport/DefaultClientMetricReport.ts:461</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1496,7 +1496,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L461">src/clientmetricreport/DefaultClientMetricReport.ts:461</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L460">src/clientmetricreport/DefaultClientMetricReport.ts:460</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1506,7 +1506,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googDecodingNormal&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L460">src/clientmetricreport/DefaultClientMetricReport.ts:460</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L459">src/clientmetricreport/DefaultClientMetricReport.ts:459</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1517,7 +1517,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packet<wbr>Loss<wbr>Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L469">src/clientmetricreport/DefaultClientMetricReport.ts:469</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L468">src/clientmetricreport/DefaultClientMetricReport.ts:468</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1526,7 +1526,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L472">src/clientmetricreport/DefaultClientMetricReport.ts:472</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L471">src/clientmetricreport/DefaultClientMetricReport.ts:471</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1536,7 +1536,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L471">src/clientmetricreport/DefaultClientMetricReport.ts:471</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L470">src/clientmetricreport/DefaultClientMetricReport.ts:470</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1546,7 +1546,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsLost&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L470">src/clientmetricreport/DefaultClientMetricReport.ts:470</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L469">src/clientmetricreport/DefaultClientMetricReport.ts:469</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1557,7 +1557,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L449">src/clientmetricreport/DefaultClientMetricReport.ts:449</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L448">src/clientmetricreport/DefaultClientMetricReport.ts:448</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1566,7 +1566,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L452">src/clientmetricreport/DefaultClientMetricReport.ts:452</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L451">src/clientmetricreport/DefaultClientMetricReport.ts:451</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1576,7 +1576,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L451">src/clientmetricreport/DefaultClientMetricReport.ts:451</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L450">src/clientmetricreport/DefaultClientMetricReport.ts:450</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1586,7 +1586,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L450">src/clientmetricreport/DefaultClientMetricReport.ts:450</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L449">src/clientmetricreport/DefaultClientMetricReport.ts:449</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1597,7 +1597,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packets<wbr>Received<wbr>Fraction<wbr>Loss<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L454">src/clientmetricreport/DefaultClientMetricReport.ts:454</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L453">src/clientmetricreport/DefaultClientMetricReport.ts:453</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1606,7 +1606,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L457">src/clientmetricreport/DefaultClientMetricReport.ts:457</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L456">src/clientmetricreport/DefaultClientMetricReport.ts:456</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1616,7 +1616,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L456">src/clientmetricreport/DefaultClientMetricReport.ts:456</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L455">src/clientmetricreport/DefaultClientMetricReport.ts:455</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1626,7 +1626,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsLost&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L455">src/clientmetricreport/DefaultClientMetricReport.ts:455</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L454">src/clientmetricreport/DefaultClientMetricReport.ts:454</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1637,7 +1637,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L464">src/clientmetricreport/DefaultClientMetricReport.ts:464</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L463">src/clientmetricreport/DefaultClientMetricReport.ts:463</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1646,7 +1646,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L467">src/clientmetricreport/DefaultClientMetricReport.ts:467</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L466">src/clientmetricreport/DefaultClientMetricReport.ts:466</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1656,7 +1656,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L466">src/clientmetricreport/DefaultClientMetricReport.ts:466</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L465">src/clientmetricreport/DefaultClientMetricReport.ts:465</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1666,7 +1666,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L465">src/clientmetricreport/DefaultClientMetricReport.ts:465</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L464">src/clientmetricreport/DefaultClientMetricReport.ts:464</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1677,7 +1677,7 @@
 						<div class="tsd-signature tsd-kind-icon">audio<wbr>Speaker<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L482">src/clientmetricreport/DefaultClientMetricReport.ts:482</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L481">src/clientmetricreport/DefaultClientMetricReport.ts:481</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1686,7 +1686,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L485">src/clientmetricreport/DefaultClientMetricReport.ts:485</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L484">src/clientmetricreport/DefaultClientMetricReport.ts:484</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1696,7 +1696,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#audio" class="tsd-signature-type">AUDIO</a><span class="tsd-signature-symbol"> = MediaType.AUDIO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L484">src/clientmetricreport/DefaultClientMetricReport.ts:484</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L483">src/clientmetricreport/DefaultClientMetricReport.ts:483</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1706,7 +1706,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googCurrentDelayMs&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L483">src/clientmetricreport/DefaultClientMetricReport.ts:483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L482">src/clientmetricreport/DefaultClientMetricReport.ts:482</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1717,7 +1717,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Incoming<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L489">src/clientmetricreport/DefaultClientMetricReport.ts:489</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L488">src/clientmetricreport/DefaultClientMetricReport.ts:488</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1726,7 +1726,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;availableIncomingBitrate&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L489">src/clientmetricreport/DefaultClientMetricReport.ts:489</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L488">src/clientmetricreport/DefaultClientMetricReport.ts:488</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1737,7 +1737,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Outgoing<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L490">src/clientmetricreport/DefaultClientMetricReport.ts:490</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L489">src/clientmetricreport/DefaultClientMetricReport.ts:489</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1746,7 +1746,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;availableOutgoingBitrate&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L490">src/clientmetricreport/DefaultClientMetricReport.ts:490</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L489">src/clientmetricreport/DefaultClientMetricReport.ts:489</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1757,7 +1757,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Receive<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L481">src/clientmetricreport/DefaultClientMetricReport.ts:481</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L480">src/clientmetricreport/DefaultClientMetricReport.ts:480</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1766,7 +1766,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googAvailableReceiveBandwidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L481">src/clientmetricreport/DefaultClientMetricReport.ts:481</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L480">src/clientmetricreport/DefaultClientMetricReport.ts:480</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1777,7 +1777,7 @@
 						<div class="tsd-signature tsd-kind-icon">available<wbr>Send<wbr>Bandwidth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L480">src/clientmetricreport/DefaultClientMetricReport.ts:480</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L479">src/clientmetricreport/DefaultClientMetricReport.ts:479</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1786,7 +1786,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googAvailableSendBandwidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L480">src/clientmetricreport/DefaultClientMetricReport.ts:480</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L479">src/clientmetricreport/DefaultClientMetricReport.ts:479</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1797,7 +1797,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nack<wbr>Count<wbr>Received<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L497">src/clientmetricreport/DefaultClientMetricReport.ts:497</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L496">src/clientmetricreport/DefaultClientMetricReport.ts:496</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1806,7 +1806,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L500">src/clientmetricreport/DefaultClientMetricReport.ts:500</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L499">src/clientmetricreport/DefaultClientMetricReport.ts:499</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1816,7 +1816,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L499">src/clientmetricreport/DefaultClientMetricReport.ts:499</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L498">src/clientmetricreport/DefaultClientMetricReport.ts:498</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1826,7 +1826,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googNacksReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L498">src/clientmetricreport/DefaultClientMetricReport.ts:498</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L497">src/clientmetricreport/DefaultClientMetricReport.ts:497</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1837,7 +1837,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<wbr>Received<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L492">src/clientmetricreport/DefaultClientMetricReport.ts:492</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L491">src/clientmetricreport/DefaultClientMetricReport.ts:491</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1846,7 +1846,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L495">src/clientmetricreport/DefaultClientMetricReport.ts:495</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L494">src/clientmetricreport/DefaultClientMetricReport.ts:494</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1856,7 +1856,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L494">src/clientmetricreport/DefaultClientMetricReport.ts:494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L493">src/clientmetricreport/DefaultClientMetricReport.ts:493</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1866,7 +1866,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;nackCount&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L493">src/clientmetricreport/DefaultClientMetricReport.ts:493</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L492">src/clientmetricreport/DefaultClientMetricReport.ts:492</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1877,7 +1877,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Packet<wbr>Sent<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L475">src/clientmetricreport/DefaultClientMetricReport.ts:475</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L474">src/clientmetricreport/DefaultClientMetricReport.ts:474</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1886,7 +1886,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L478">src/clientmetricreport/DefaultClientMetricReport.ts:478</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L477">src/clientmetricreport/DefaultClientMetricReport.ts:477</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1896,7 +1896,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L477">src/clientmetricreport/DefaultClientMetricReport.ts:477</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L476">src/clientmetricreport/DefaultClientMetricReport.ts:476</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1906,7 +1906,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L476">src/clientmetricreport/DefaultClientMetricReport.ts:476</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L475">src/clientmetricreport/DefaultClientMetricReport.ts:475</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1917,7 +1917,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L474">src/clientmetricreport/DefaultClientMetricReport.ts:474</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L473">src/clientmetricreport/DefaultClientMetricReport.ts:473</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1926,7 +1926,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L474">src/clientmetricreport/DefaultClientMetricReport.ts:474</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L473">src/clientmetricreport/DefaultClientMetricReport.ts:473</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1936,7 +1936,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L474">src/clientmetricreport/DefaultClientMetricReport.ts:474</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L473">src/clientmetricreport/DefaultClientMetricReport.ts:473</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1946,7 +1946,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;bytesSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L474">src/clientmetricreport/DefaultClientMetricReport.ts:474</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L473">src/clientmetricreport/DefaultClientMetricReport.ts:473</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1958,7 +1958,7 @@
 					<div class="tsd-signature tsd-kind-icon">observable<wbr>Video<wbr>Metric<wbr>Spec<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L359">src/clientmetricreport/DefaultClientMetricReport.ts:359</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L358">src/clientmetricreport/DefaultClientMetricReport.ts:358</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -1972,7 +1972,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L401">src/clientmetricreport/DefaultClientMetricReport.ts:401</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L400">src/clientmetricreport/DefaultClientMetricReport.ts:400</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -1981,7 +1981,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L404">src/clientmetricreport/DefaultClientMetricReport.ts:404</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L403">src/clientmetricreport/DefaultClientMetricReport.ts:403</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -1991,7 +1991,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L403">src/clientmetricreport/DefaultClientMetricReport.ts:403</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L402">src/clientmetricreport/DefaultClientMetricReport.ts:402</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2001,7 +2001,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;bytesReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L402">src/clientmetricreport/DefaultClientMetricReport.ts:402</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L401">src/clientmetricreport/DefaultClientMetricReport.ts:401</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2012,7 +2012,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L426">src/clientmetricreport/DefaultClientMetricReport.ts:426</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L425">src/clientmetricreport/DefaultClientMetricReport.ts:425</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2021,7 +2021,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L429">src/clientmetricreport/DefaultClientMetricReport.ts:429</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L428">src/clientmetricreport/DefaultClientMetricReport.ts:428</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2031,7 +2031,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L428">src/clientmetricreport/DefaultClientMetricReport.ts:428</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L427">src/clientmetricreport/DefaultClientMetricReport.ts:427</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2041,7 +2041,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;frameHeight&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L427">src/clientmetricreport/DefaultClientMetricReport.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L426">src/clientmetricreport/DefaultClientMetricReport.ts:426</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2052,7 +2052,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L431">src/clientmetricreport/DefaultClientMetricReport.ts:431</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L430">src/clientmetricreport/DefaultClientMetricReport.ts:430</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2061,7 +2061,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L434">src/clientmetricreport/DefaultClientMetricReport.ts:434</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L433">src/clientmetricreport/DefaultClientMetricReport.ts:433</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2071,7 +2071,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L433">src/clientmetricreport/DefaultClientMetricReport.ts:433</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L432">src/clientmetricreport/DefaultClientMetricReport.ts:432</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2081,7 +2081,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;frameWidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L432">src/clientmetricreport/DefaultClientMetricReport.ts:432</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L431">src/clientmetricreport/DefaultClientMetricReport.ts:431</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2092,7 +2092,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Frames<wbr>Decoded<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L411">src/clientmetricreport/DefaultClientMetricReport.ts:411</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L410">src/clientmetricreport/DefaultClientMetricReport.ts:410</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2101,7 +2101,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L414">src/clientmetricreport/DefaultClientMetricReport.ts:414</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L413">src/clientmetricreport/DefaultClientMetricReport.ts:413</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2111,7 +2111,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L413">src/clientmetricreport/DefaultClientMetricReport.ts:413</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L412">src/clientmetricreport/DefaultClientMetricReport.ts:412</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2121,7 +2121,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;framesDecoded&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L412">src/clientmetricreport/DefaultClientMetricReport.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L411">src/clientmetricreport/DefaultClientMetricReport.ts:411</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2132,7 +2132,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Goog<wbr>Frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L416">src/clientmetricreport/DefaultClientMetricReport.ts:416</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L415">src/clientmetricreport/DefaultClientMetricReport.ts:415</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2141,7 +2141,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L419">src/clientmetricreport/DefaultClientMetricReport.ts:419</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L418">src/clientmetricreport/DefaultClientMetricReport.ts:418</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2151,7 +2151,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L418">src/clientmetricreport/DefaultClientMetricReport.ts:418</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L417">src/clientmetricreport/DefaultClientMetricReport.ts:417</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2161,7 +2161,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googFrameHeightReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L417">src/clientmetricreport/DefaultClientMetricReport.ts:417</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L416">src/clientmetricreport/DefaultClientMetricReport.ts:416</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2172,7 +2172,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Goog<wbr>Frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L421">src/clientmetricreport/DefaultClientMetricReport.ts:421</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L420">src/clientmetricreport/DefaultClientMetricReport.ts:420</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2181,7 +2181,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L424">src/clientmetricreport/DefaultClientMetricReport.ts:424</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L423">src/clientmetricreport/DefaultClientMetricReport.ts:423</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2191,7 +2191,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L423">src/clientmetricreport/DefaultClientMetricReport.ts:423</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L422">src/clientmetricreport/DefaultClientMetricReport.ts:422</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2201,7 +2201,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googFrameWidthReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L422">src/clientmetricreport/DefaultClientMetricReport.ts:422</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L421">src/clientmetricreport/DefaultClientMetricReport.ts:421</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2212,7 +2212,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Packet<wbr>Loss<wbr>Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L406">src/clientmetricreport/DefaultClientMetricReport.ts:406</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L405">src/clientmetricreport/DefaultClientMetricReport.ts:405</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2221,7 +2221,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#downstream" class="tsd-signature-type">DOWNSTREAM</a><span class="tsd-signature-symbol"> = Direction.DOWNSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L409">src/clientmetricreport/DefaultClientMetricReport.ts:409</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L408">src/clientmetricreport/DefaultClientMetricReport.ts:408</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2231,7 +2231,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L408">src/clientmetricreport/DefaultClientMetricReport.ts:408</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L407">src/clientmetricreport/DefaultClientMetricReport.ts:407</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2241,7 +2241,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsLost&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L407">src/clientmetricreport/DefaultClientMetricReport.ts:407</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L406">src/clientmetricreport/DefaultClientMetricReport.ts:406</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2252,7 +2252,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Bitrate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L366">src/clientmetricreport/DefaultClientMetricReport.ts:366</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L365">src/clientmetricreport/DefaultClientMetricReport.ts:365</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2261,7 +2261,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L369">src/clientmetricreport/DefaultClientMetricReport.ts:369</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L368">src/clientmetricreport/DefaultClientMetricReport.ts:368</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2271,7 +2271,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L368">src/clientmetricreport/DefaultClientMetricReport.ts:368</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L367">src/clientmetricreport/DefaultClientMetricReport.ts:367</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2281,7 +2281,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;bytesSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L367">src/clientmetricreport/DefaultClientMetricReport.ts:367</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L366">src/clientmetricreport/DefaultClientMetricReport.ts:366</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2292,7 +2292,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L391">src/clientmetricreport/DefaultClientMetricReport.ts:391</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L390">src/clientmetricreport/DefaultClientMetricReport.ts:390</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2301,7 +2301,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L394">src/clientmetricreport/DefaultClientMetricReport.ts:394</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L393">src/clientmetricreport/DefaultClientMetricReport.ts:393</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2311,7 +2311,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L393">src/clientmetricreport/DefaultClientMetricReport.ts:393</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L392">src/clientmetricreport/DefaultClientMetricReport.ts:392</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2321,7 +2321,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;frameHeight&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L392">src/clientmetricreport/DefaultClientMetricReport.ts:392</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L391">src/clientmetricreport/DefaultClientMetricReport.ts:391</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2332,7 +2332,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L396">src/clientmetricreport/DefaultClientMetricReport.ts:396</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L395">src/clientmetricreport/DefaultClientMetricReport.ts:395</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2341,7 +2341,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L399">src/clientmetricreport/DefaultClientMetricReport.ts:399</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L398">src/clientmetricreport/DefaultClientMetricReport.ts:398</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2351,7 +2351,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L398">src/clientmetricreport/DefaultClientMetricReport.ts:398</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L397">src/clientmetricreport/DefaultClientMetricReport.ts:397</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2361,7 +2361,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;frameWidth&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L397">src/clientmetricreport/DefaultClientMetricReport.ts:397</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L396">src/clientmetricreport/DefaultClientMetricReport.ts:396</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2372,7 +2372,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Frames<wbr>Encoded<wbr>Per<wbr>Second<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L376">src/clientmetricreport/DefaultClientMetricReport.ts:376</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L375">src/clientmetricreport/DefaultClientMetricReport.ts:375</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2381,7 +2381,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L379">src/clientmetricreport/DefaultClientMetricReport.ts:379</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L378">src/clientmetricreport/DefaultClientMetricReport.ts:378</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2391,7 +2391,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L378">src/clientmetricreport/DefaultClientMetricReport.ts:378</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L377">src/clientmetricreport/DefaultClientMetricReport.ts:377</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2401,7 +2401,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;framesEncoded&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L377">src/clientmetricreport/DefaultClientMetricReport.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L376">src/clientmetricreport/DefaultClientMetricReport.ts:376</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2412,7 +2412,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Goog<wbr>Frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L381">src/clientmetricreport/DefaultClientMetricReport.ts:381</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L380">src/clientmetricreport/DefaultClientMetricReport.ts:380</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2421,7 +2421,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L384">src/clientmetricreport/DefaultClientMetricReport.ts:384</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L383">src/clientmetricreport/DefaultClientMetricReport.ts:383</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2431,7 +2431,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L383">src/clientmetricreport/DefaultClientMetricReport.ts:383</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L382">src/clientmetricreport/DefaultClientMetricReport.ts:382</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2441,7 +2441,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googFrameHeightSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L382">src/clientmetricreport/DefaultClientMetricReport.ts:382</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L381">src/clientmetricreport/DefaultClientMetricReport.ts:381</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2452,7 +2452,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Goog<wbr>Frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L386">src/clientmetricreport/DefaultClientMetricReport.ts:386</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L385">src/clientmetricreport/DefaultClientMetricReport.ts:385</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2461,7 +2461,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L389">src/clientmetricreport/DefaultClientMetricReport.ts:389</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L388">src/clientmetricreport/DefaultClientMetricReport.ts:388</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2471,7 +2471,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L388">src/clientmetricreport/DefaultClientMetricReport.ts:388</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L387">src/clientmetricreport/DefaultClientMetricReport.ts:387</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2481,7 +2481,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;googFrameWidthSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L387">src/clientmetricreport/DefaultClientMetricReport.ts:387</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L386">src/clientmetricreport/DefaultClientMetricReport.ts:386</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2492,7 +2492,7 @@
 						<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L371">src/clientmetricreport/DefaultClientMetricReport.ts:371</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L370">src/clientmetricreport/DefaultClientMetricReport.ts:370</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2501,7 +2501,7 @@
 							<div class="tsd-signature tsd-kind-icon">dir<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportdirection.html#upstream" class="tsd-signature-type">UPSTREAM</a><span class="tsd-signature-symbol"> = Direction.UPSTREAM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L374">src/clientmetricreport/DefaultClientMetricReport.ts:374</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L373">src/clientmetricreport/DefaultClientMetricReport.ts:373</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2511,7 +2511,7 @@
 							<div class="tsd-signature tsd-kind-icon">media<span class="tsd-signature-symbol">:</span> <a href="../enums/clientmetricreportmediatype.html#video" class="tsd-signature-type">VIDEO</a><span class="tsd-signature-symbol"> = MediaType.VIDEO</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L373">src/clientmetricreport/DefaultClientMetricReport.ts:373</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L372">src/clientmetricreport/DefaultClientMetricReport.ts:372</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2521,7 +2521,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L372">src/clientmetricreport/DefaultClientMetricReport.ts:372</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L371">src/clientmetricreport/DefaultClientMetricReport.ts:371</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2533,7 +2533,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Downstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L256">src/clientmetricreport/DefaultClientMetricReport.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L255">src/clientmetricreport/DefaultClientMetricReport.ts:255</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -2542,7 +2542,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L291">src/clientmetricreport/DefaultClientMetricReport.ts:291</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2551,7 +2551,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L291">src/clientmetricreport/DefaultClientMetricReport.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2561,7 +2561,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L291">src/clientmetricreport/DefaultClientMetricReport.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2572,7 +2572,7 @@
 						<div class="tsd-signature tsd-kind-icon">discarded<wbr>Packets<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L300">src/clientmetricreport/DefaultClientMetricReport.ts:300</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L299">src/clientmetricreport/DefaultClientMetricReport.ts:299</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2581,7 +2581,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L300">src/clientmetricreport/DefaultClientMetricReport.ts:300</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L299">src/clientmetricreport/DefaultClientMetricReport.ts:299</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2591,7 +2591,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DISCARDED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DISCARDED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L300">src/clientmetricreport/DefaultClientMetricReport.ts:300</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L299">src/clientmetricreport/DefaultClientMetricReport.ts:299</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2602,7 +2602,7 @@
 						<div class="tsd-signature tsd-kind-icon">fir<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2611,7 +2611,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2621,7 +2621,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2632,7 +2632,7 @@
 						<div class="tsd-signature tsd-kind-icon">frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L320">src/clientmetricreport/DefaultClientMetricReport.ts:320</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2641,7 +2641,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L320">src/clientmetricreport/DefaultClientMetricReport.ts:320</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2651,7 +2651,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_HEIGHT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_HEIGHT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L320">src/clientmetricreport/DefaultClientMetricReport.ts:320</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2662,7 +2662,7 @@
 						<div class="tsd-signature tsd-kind-icon">frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L322">src/clientmetricreport/DefaultClientMetricReport.ts:322</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2671,7 +2671,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L322">src/clientmetricreport/DefaultClientMetricReport.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2681,7 +2681,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_WIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_WIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L322">src/clientmetricreport/DefaultClientMetricReport.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L321">src/clientmetricreport/DefaultClientMetricReport.ts:321</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2692,7 +2692,7 @@
 						<div class="tsd-signature tsd-kind-icon">framerate<wbr>Mean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L282">src/clientmetricreport/DefaultClientMetricReport.ts:282</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2701,7 +2701,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L282">src/clientmetricreport/DefaultClientMetricReport.ts:282</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2711,7 +2711,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L282">src/clientmetricreport/DefaultClientMetricReport.ts:282</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2722,7 +2722,7 @@
 						<div class="tsd-signature tsd-kind-icon">frames<wbr>Decoded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2731,7 +2731,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2741,7 +2741,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L283">src/clientmetricreport/DefaultClientMetricReport.ts:283</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2752,7 +2752,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Current<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L292">src/clientmetricreport/DefaultClientMetricReport.ts:292</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L291">src/clientmetricreport/DefaultClientMetricReport.ts:291</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2761,7 +2761,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L293">src/clientmetricreport/DefaultClientMetricReport.ts:293</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L292">src/clientmetricreport/DefaultClientMetricReport.ts:292</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2771,7 +2771,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_CURRENT_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_CURRENT_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L294">src/clientmetricreport/DefaultClientMetricReport.ts:294</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L293">src/clientmetricreport/DefaultClientMetricReport.ts:293</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2782,7 +2782,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Decode<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L266">src/clientmetricreport/DefaultClientMetricReport.ts:266</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2791,7 +2791,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L266">src/clientmetricreport/DefaultClientMetricReport.ts:266</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2801,7 +2801,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L266">src/clientmetricreport/DefaultClientMetricReport.ts:266</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2812,7 +2812,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Firs<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2821,7 +2821,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2831,7 +2831,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L287">src/clientmetricreport/DefaultClientMetricReport.ts:287</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2842,7 +2842,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Height<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L313">src/clientmetricreport/DefaultClientMetricReport.ts:313</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L312">src/clientmetricreport/DefaultClientMetricReport.ts:312</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2851,7 +2851,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L314">src/clientmetricreport/DefaultClientMetricReport.ts:314</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L313">src/clientmetricreport/DefaultClientMetricReport.ts:313</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2861,7 +2861,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_HEIGHT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_HEIGHT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L315">src/clientmetricreport/DefaultClientMetricReport.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L314">src/clientmetricreport/DefaultClientMetricReport.ts:314</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2872,7 +2872,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Output<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2881,7 +2881,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2891,7 +2891,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_OUTPUT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_OUTPUT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L267">src/clientmetricreport/DefaultClientMetricReport.ts:267</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2902,7 +2902,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L279">src/clientmetricreport/DefaultClientMetricReport.ts:279</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L278">src/clientmetricreport/DefaultClientMetricReport.ts:278</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2911,7 +2911,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L280">src/clientmetricreport/DefaultClientMetricReport.ts:280</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L279">src/clientmetricreport/DefaultClientMetricReport.ts:279</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2921,7 +2921,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L281">src/clientmetricreport/DefaultClientMetricReport.ts:281</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L280">src/clientmetricreport/DefaultClientMetricReport.ts:280</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2932,7 +2932,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Width<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L317">src/clientmetricreport/DefaultClientMetricReport.ts:317</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L316">src/clientmetricreport/DefaultClientMetricReport.ts:316</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2941,7 +2941,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L318">src/clientmetricreport/DefaultClientMetricReport.ts:318</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L317">src/clientmetricreport/DefaultClientMetricReport.ts:317</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2951,7 +2951,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DECODE_WIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DECODE_WIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L319">src/clientmetricreport/DefaultClientMetricReport.ts:319</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L318">src/clientmetricreport/DefaultClientMetricReport.ts:318</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2962,7 +2962,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Buffer<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L296">src/clientmetricreport/DefaultClientMetricReport.ts:296</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L295">src/clientmetricreport/DefaultClientMetricReport.ts:295</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -2971,7 +2971,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L297">src/clientmetricreport/DefaultClientMetricReport.ts:297</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L296">src/clientmetricreport/DefaultClientMetricReport.ts:296</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2981,7 +2981,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_JITTER_BUFFER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_JITTER_BUFFER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L298">src/clientmetricreport/DefaultClientMetricReport.ts:298</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L297">src/clientmetricreport/DefaultClientMetricReport.ts:297</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -2992,7 +2992,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Jitter<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L301">src/clientmetricreport/DefaultClientMetricReport.ts:301</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L300">src/clientmetricreport/DefaultClientMetricReport.ts:300</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3001,7 +3001,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L302">src/clientmetricreport/DefaultClientMetricReport.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L301">src/clientmetricreport/DefaultClientMetricReport.ts:301</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3011,7 +3011,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L303">src/clientmetricreport/DefaultClientMetricReport.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L302">src/clientmetricreport/DefaultClientMetricReport.ts:302</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3022,7 +3022,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nacks<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3031,7 +3031,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3041,7 +3041,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L284">src/clientmetricreport/DefaultClientMetricReport.ts:284</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3052,7 +3052,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Plis<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3061,7 +3061,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3071,7 +3071,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L288">src/clientmetricreport/DefaultClientMetricReport.ts:288</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3082,7 +3082,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Render<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L275">src/clientmetricreport/DefaultClientMetricReport.ts:275</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L274">src/clientmetricreport/DefaultClientMetricReport.ts:274</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3091,7 +3091,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L276">src/clientmetricreport/DefaultClientMetricReport.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L275">src/clientmetricreport/DefaultClientMetricReport.ts:275</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3101,7 +3101,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RENDER_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RENDER_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L277">src/clientmetricreport/DefaultClientMetricReport.ts:277</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L276">src/clientmetricreport/DefaultClientMetricReport.ts:276</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3112,7 +3112,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Target<wbr>Delay<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L263">src/clientmetricreport/DefaultClientMetricReport.ts:263</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L262">src/clientmetricreport/DefaultClientMetricReport.ts:262</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3121,7 +3121,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L264">src/clientmetricreport/DefaultClientMetricReport.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L263">src/clientmetricreport/DefaultClientMetricReport.ts:263</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3131,7 +3131,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_TARGET_DELAY_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_TARGET_DELAY_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L265">src/clientmetricreport/DefaultClientMetricReport.ts:265</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L264">src/clientmetricreport/DefaultClientMetricReport.ts:264</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3142,7 +3142,7 @@
 						<div class="tsd-signature tsd-kind-icon">jitter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L305">src/clientmetricreport/DefaultClientMetricReport.ts:305</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L304">src/clientmetricreport/DefaultClientMetricReport.ts:304</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3151,7 +3151,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.secondsToMilliseconds</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L306">src/clientmetricreport/DefaultClientMetricReport.ts:306</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L305">src/clientmetricreport/DefaultClientMetricReport.ts:305</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3161,7 +3161,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_JITTER_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_JITTER_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L307">src/clientmetricreport/DefaultClientMetricReport.ts:307</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L306">src/clientmetricreport/DefaultClientMetricReport.ts:306</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3172,7 +3172,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3181,7 +3181,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3191,7 +3191,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L286">src/clientmetricreport/DefaultClientMetricReport.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L285">src/clientmetricreport/DefaultClientMetricReport.ts:285</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3202,7 +3202,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L270">src/clientmetricreport/DefaultClientMetricReport.ts:270</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3211,7 +3211,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsReceived&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L273">src/clientmetricreport/DefaultClientMetricReport.ts:273</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L272">src/clientmetricreport/DefaultClientMetricReport.ts:272</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3221,7 +3221,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L271">src/clientmetricreport/DefaultClientMetricReport.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L270">src/clientmetricreport/DefaultClientMetricReport.ts:270</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3231,7 +3231,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L272">src/clientmetricreport/DefaultClientMetricReport.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L271">src/clientmetricreport/DefaultClientMetricReport.ts:271</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3242,7 +3242,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3251,7 +3251,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3261,7 +3261,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L269">src/clientmetricreport/DefaultClientMetricReport.ts:269</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L268">src/clientmetricreport/DefaultClientMetricReport.ts:268</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3272,7 +3272,7 @@
 						<div class="tsd-signature tsd-kind-icon">pli<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3281,7 +3281,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3291,7 +3291,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_SENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_SENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L290">src/clientmetricreport/DefaultClientMetricReport.ts:290</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L289">src/clientmetricreport/DefaultClientMetricReport.ts:289</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3302,7 +3302,7 @@
 						<div class="tsd-signature tsd-kind-icon">qp<wbr>Sum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L309">src/clientmetricreport/DefaultClientMetricReport.ts:309</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L308">src/clientmetricreport/DefaultClientMetricReport.ts:308</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3311,7 +3311,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L310">src/clientmetricreport/DefaultClientMetricReport.ts:310</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L309">src/clientmetricreport/DefaultClientMetricReport.ts:309</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3321,7 +3321,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_RECEIVED_QP_SUM</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_RECEIVED_QP_SUM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L311">src/clientmetricreport/DefaultClientMetricReport.ts:311</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L310">src/clientmetricreport/DefaultClientMetricReport.ts:310</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3333,7 +3333,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Upstream<wbr>Metric<wbr>Map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L209">src/clientmetricreport/DefaultClientMetricReport.ts:209</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L208">src/clientmetricreport/DefaultClientMetricReport.ts:208</a></li>
 						</ul>
 					</aside>
 					<section class="tsd-panel tsd-member tsd-kind-object-literal tsd-parent-kind-object-literal">
@@ -3342,7 +3342,7 @@
 						<div class="tsd-signature tsd-kind-icon">bytes<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L243">src/clientmetricreport/DefaultClientMetricReport.ts:243</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3351,7 +3351,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.bitsPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L243">src/clientmetricreport/DefaultClientMetricReport.ts:243</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3361,7 +3361,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_BITRATE</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_BITRATE</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L243">src/clientmetricreport/DefaultClientMetricReport.ts:243</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3372,7 +3372,7 @@
 						<div class="tsd-signature tsd-kind-icon">dropped<wbr>Frames<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3381,7 +3381,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3391,7 +3391,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_DROPPED_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_DROPPED_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L244">src/clientmetricreport/DefaultClientMetricReport.ts:244</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3402,7 +3402,7 @@
 						<div class="tsd-signature tsd-kind-icon">fir<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3411,7 +3411,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3421,7 +3421,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3432,7 +3432,7 @@
 						<div class="tsd-signature tsd-kind-icon">frame<wbr>Height<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3441,7 +3441,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3451,7 +3451,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_HEIGHT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_HEIGHT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3462,7 +3462,7 @@
 						<div class="tsd-signature tsd-kind-icon">frame<wbr>Width<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3471,7 +3471,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3481,7 +3481,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_WIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_WIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L253">src/clientmetricreport/DefaultClientMetricReport.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L252">src/clientmetricreport/DefaultClientMetricReport.ts:252</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3492,7 +3492,7 @@
 						<div class="tsd-signature tsd-kind-icon">framerate<wbr>Mean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3501,7 +3501,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3511,7 +3511,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3522,7 +3522,7 @@
 						<div class="tsd-signature tsd-kind-icon">frames<wbr>Encoded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3531,7 +3531,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3541,7 +3541,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3552,7 +3552,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Avg<wbr>Encode<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L230">src/clientmetricreport/DefaultClientMetricReport.ts:230</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L229">src/clientmetricreport/DefaultClientMetricReport.ts:229</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3561,7 +3561,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L231">src/clientmetricreport/DefaultClientMetricReport.ts:231</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L230">src/clientmetricreport/DefaultClientMetricReport.ts:230</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3571,7 +3571,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_AVERAGE_ENCODE_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_AVERAGE_ENCODE_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L232">src/clientmetricreport/DefaultClientMetricReport.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L231">src/clientmetricreport/DefaultClientMetricReport.ts:231</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3582,7 +3582,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Encode<wbr>Usage<wbr>Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L217">src/clientmetricreport/DefaultClientMetricReport.ts:217</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L216">src/clientmetricreport/DefaultClientMetricReport.ts:216</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3591,7 +3591,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L218">src/clientmetricreport/DefaultClientMetricReport.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L217">src/clientmetricreport/DefaultClientMetricReport.ts:217</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3601,7 +3601,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_USAGE_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_USAGE_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L219">src/clientmetricreport/DefaultClientMetricReport.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L218">src/clientmetricreport/DefaultClientMetricReport.ts:218</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3612,7 +3612,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Firs<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3621,7 +3621,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3631,7 +3631,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_FIRS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_FIRS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L228">src/clientmetricreport/DefaultClientMetricReport.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3642,7 +3642,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Height<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L247">src/clientmetricreport/DefaultClientMetricReport.ts:247</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L246">src/clientmetricreport/DefaultClientMetricReport.ts:246</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3651,7 +3651,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L248">src/clientmetricreport/DefaultClientMetricReport.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L247">src/clientmetricreport/DefaultClientMetricReport.ts:247</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3661,7 +3661,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_HEIGHT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_HEIGHT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L249">src/clientmetricreport/DefaultClientMetricReport.ts:249</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L248">src/clientmetricreport/DefaultClientMetricReport.ts:248</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3672,7 +3672,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Input<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L233">src/clientmetricreport/DefaultClientMetricReport.ts:233</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3681,7 +3681,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L233">src/clientmetricreport/DefaultClientMetricReport.ts:233</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3691,7 +3691,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_INPUT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_INPUT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L234">src/clientmetricreport/DefaultClientMetricReport.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L233">src/clientmetricreport/DefaultClientMetricReport.ts:233</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3702,7 +3702,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Rate<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3711,7 +3711,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3721,7 +3721,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L236">src/clientmetricreport/DefaultClientMetricReport.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L235">src/clientmetricreport/DefaultClientMetricReport.ts:235</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3732,7 +3732,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Frame<wbr>Width<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L250">src/clientmetricreport/DefaultClientMetricReport.ts:250</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3741,7 +3741,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L250">src/clientmetricreport/DefaultClientMetricReport.ts:250</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3751,7 +3751,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_ENCODE_WIDTH</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_ENCODE_WIDTH</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L251">src/clientmetricreport/DefaultClientMetricReport.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L250">src/clientmetricreport/DefaultClientMetricReport.ts:250</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3762,7 +3762,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Nacks<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L221">src/clientmetricreport/DefaultClientMetricReport.ts:221</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L220">src/clientmetricreport/DefaultClientMetricReport.ts:220</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3771,7 +3771,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L222">src/clientmetricreport/DefaultClientMetricReport.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L221">src/clientmetricreport/DefaultClientMetricReport.ts:221</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3781,7 +3781,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L223">src/clientmetricreport/DefaultClientMetricReport.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L222">src/clientmetricreport/DefaultClientMetricReport.ts:222</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3792,7 +3792,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Plis<wbr>Received<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3801,7 +3801,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3811,7 +3811,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3822,7 +3822,7 @@
 						<div class="tsd-signature tsd-kind-icon">goog<wbr>Rtt<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L216">src/clientmetricreport/DefaultClientMetricReport.ts:216</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L215">src/clientmetricreport/DefaultClientMetricReport.ts:215</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3831,7 +3831,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.identityValue</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L216">src/clientmetricreport/DefaultClientMetricReport.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L215">src/clientmetricreport/DefaultClientMetricReport.ts:215</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3841,7 +3841,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_RTT_MS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_RTT_MS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L216">src/clientmetricreport/DefaultClientMetricReport.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L215">src/clientmetricreport/DefaultClientMetricReport.ts:215</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3852,7 +3852,7 @@
 						<div class="tsd-signature tsd-kind-icon">nack<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L224">src/clientmetricreport/DefaultClientMetricReport.ts:224</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3861,7 +3861,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L224">src/clientmetricreport/DefaultClientMetricReport.ts:224</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3871,7 +3871,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_NACKS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_NACKS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L225">src/clientmetricreport/DefaultClientMetricReport.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L224">src/clientmetricreport/DefaultClientMetricReport.ts:224</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3882,7 +3882,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Lost<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L239">src/clientmetricreport/DefaultClientMetricReport.ts:239</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3891,7 +3891,7 @@
 							<div class="tsd-signature tsd-kind-icon">source<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;packetsSent&quot;</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L242">src/clientmetricreport/DefaultClientMetricReport.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L241">src/clientmetricreport/DefaultClientMetricReport.ts:241</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3901,7 +3901,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.packetLossPercent</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L240">src/clientmetricreport/DefaultClientMetricReport.ts:240</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L239">src/clientmetricreport/DefaultClientMetricReport.ts:239</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3911,7 +3911,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_FRACTION_PACKET_LOST_PERCENT</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_FRACTION_PACKET_LOST_PERCENT</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L241">src/clientmetricreport/DefaultClientMetricReport.ts:241</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L240">src/clientmetricreport/DefaultClientMetricReport.ts:240</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3922,7 +3922,7 @@
 						<div class="tsd-signature tsd-kind-icon">packets<wbr>Sent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3931,7 +3931,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3941,7 +3941,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_PPS</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_PPS</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L238">src/clientmetricreport/DefaultClientMetricReport.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L237">src/clientmetricreport/DefaultClientMetricReport.ts:237</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3952,7 +3952,7 @@
 						<div class="tsd-signature tsd-kind-icon">pli<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3961,7 +3961,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3971,7 +3971,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_PLIS_RECEIVED</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_PLIS_RECEIVED</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L227">src/clientmetricreport/DefaultClientMetricReport.ts:227</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L226">src/clientmetricreport/DefaultClientMetricReport.ts:226</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -3982,7 +3982,7 @@
 						<div class="tsd-signature tsd-kind-icon">qp<wbr>Sum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L246">src/clientmetricreport/DefaultClientMetricReport.ts:246</a></li>
+								<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
 							</ul>
 						</aside>
 						<section class="tsd-panel tsd-member tsd-kind-variable tsd-parent-kind-object-literal">
@@ -3991,7 +3991,7 @@
 							<div class="tsd-signature tsd-kind-icon">transform<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">(Anonymous function)</span><span class="tsd-signature-symbol"> = this.countPerSecond</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L246">src/clientmetricreport/DefaultClientMetricReport.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
 								</ul>
 							</aside>
 						</section>
@@ -4001,7 +4001,7 @@
 							<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">VIDEO_SENT_QP_SUM</span><span class="tsd-signature-symbol"> = SdkMetric.Type.VIDEO_SENT_QP_SUM</span></div>
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L246">src/clientmetricreport/DefaultClientMetricReport.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L245">src/clientmetricreport/DefaultClientMetricReport.ts:245</a></li>
 								</ul>
 							</aside>
 						</section>

--- a/docs/classes/defaultclientmetricreport.html
+++ b/docs/classes/defaultclientmetricreport.html
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L591">src/clientmetricreport/DefaultClientMetricReport.ts:591</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L597">src/clientmetricreport/DefaultClientMetricReport.ts:597</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -569,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L604">src/clientmetricreport/DefaultClientMetricReport.ts:604</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L610">src/clientmetricreport/DefaultClientMetricReport.ts:610</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -586,7 +586,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L616">src/clientmetricreport/DefaultClientMetricReport.ts:616</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/clientmetricreport/DefaultClientMetricReport.ts#L622">src/clientmetricreport/DefaultClientMetricReport.ts:622</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/interfaces/clientmetricreport.html
+++ b/docs/interfaces/clientmetricreport.html
@@ -133,7 +133,7 @@
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface">
 					<a name="getobservablevideometrics" class="tsd-anchor"></a>
-					<h3>get<wbr>Observable<wbr>Video<wbr>Metrics</h3>
+					<h3><span class="tsd-flag ts-flagOptional">Optional</span> get<wbr>Observable<wbr>Video<wbr>Metrics</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
 						<li class="tsd-signature tsd-kind-icon">get<wbr>Observable<wbr>Video<wbr>Metrics<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{}</span></li>
 					</ul>

--- a/src/clientmetricreport/ClientMetricReport.ts
+++ b/src/clientmetricreport/ClientMetricReport.ts
@@ -14,5 +14,5 @@ export default interface ClientMetricReport {
   /**
    * Gets video client media metrics
    */
-  getObservableVideoMetrics(): { [id: string]: { [id: string]: {} } };
+  getObservableVideoMetrics?(): { [id: string]: { [id: string]: {} } };
 }

--- a/src/clientmetricreport/DefaultClientMetricReport.ts
+++ b/src/clientmetricreport/DefaultClientMetricReport.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import AudioVideoController from '../audiovideocontroller/AudioVideoController';
 import Logger from '../logger/Logger';
 import { SdkMetric } from '../signalingprotocol/SignalingProtocol.js';
 import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
@@ -20,8 +19,8 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
 
   constructor(
     private logger: Logger,
-    private videoStreamIndex: VideoStreamIndex,
-    private audioVideoController: AudioVideoController
+    private videoStreamIndex?: VideoStreamIndex,
+    private selfAttendeeId?: string
   ) {}
 
   /**
@@ -575,7 +574,7 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
         const streamId = this.streamMetricReports[ssrc].streamId;
         const attendeeId = streamId
           ? this.videoStreamIndex.attendeeIdForStreamId(streamId)
-          : this.audioVideoController.configuration.credentials.attendeeId;
+          : this.selfAttendeeId;
         videoStreamMetrics[attendeeId] = videoStreamMetrics[attendeeId]
           ? videoStreamMetrics[attendeeId]
           : {};
@@ -593,7 +592,7 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
     const cloned = new DefaultClientMetricReport(
       this.logger,
       this.videoStreamIndex,
-      this.audioVideoController
+      this.selfAttendeeId
     );
     cloned.globalMetricReport = this.globalMetricReport;
     cloned.streamMetricReports = this.streamMetricReports;

--- a/src/clientmetricreport/DefaultClientMetricReport.ts
+++ b/src/clientmetricreport/DefaultClientMetricReport.ts
@@ -557,6 +557,12 @@ export default class DefaultClientMetricReport implements ClientMetricReport {
 
   getObservableVideoMetrics(): { [id: string]: { [id: string]: {} } } {
     const videoStreamMetrics: { [id: string]: { [id: string]: {} } } = {};
+    if (!this.videoStreamIndex || !this.selfAttendeeId) {
+      this.logger.error(
+        'Need to define VideoStreamIndex and selfAttendeeId if using getObservableVideoMetrics API'
+      );
+      return videoStreamMetrics;
+    }
     for (const ssrc in this.streamMetricReports) {
       if (this.streamMetricReports[ssrc].mediaType === MediaType.VIDEO) {
         const metric: { [id: string]: number } = {};

--- a/src/statscollector/DefaultStatsCollector.ts
+++ b/src/statscollector/DefaultStatsCollector.ts
@@ -189,7 +189,7 @@ export default class DefaultStatsCollector implements StatsCollector {
       this.clientMetricReport = new DefaultClientMetricReport(
         this.logger,
         this.videoStreamIndex,
-        this.audioVideoController
+        this.audioVideoController.configuration.credentials.attendeeId
       );
     }
 

--- a/test/clientmetricreport/DefaultClientMetricReport.test.ts
+++ b/test/clientmetricreport/DefaultClientMetricReport.test.ts
@@ -3,7 +3,6 @@
 
 import * as chai from 'chai';
 
-import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import Direction from '../../src/clientmetricreport/ClientMetricReportDirection';
 import MediaType from '../../src/clientmetricreport/ClientMetricReportMediaType';
 import DefaultClientMetricReport from '../../src/clientmetricreport/DefaultClientMetricReport';
@@ -15,12 +14,13 @@ import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStre
 describe('DefaultClientMetricReport', () => {
   const expect: Chai.ExpectStatic = chai.expect;
   let clientMetricReport: DefaultClientMetricReport;
+  const selfAttendeeId = 'attendee-1';
 
   beforeEach(() => {
     clientMetricReport = new DefaultClientMetricReport(
       new NoOpDebugLogger(),
       new DefaultVideoStreamIndex(new NoOpDebugLogger()),
-      new NoOpAudioVideoController()
+      selfAttendeeId
     );
   });
 
@@ -400,8 +400,8 @@ describe('DefaultClientMetricReport', () => {
       audioUpstreamReport.currentMetrics['packetsSent'] = 100;
       clientMetricReport.streamMetricReports[audioUpstreamSsrc] = audioUpstreamReport;
       const videoStreamMetrics = clientMetricReport.getObservableVideoMetrics();
-      expect(Object.keys(videoStreamMetrics[''][downstreamSsrc]).length).to.equal(0);
-      expect(Object.keys(videoStreamMetrics[''][upstreamSsrc]).length).to.equal(1);
+      expect(Object.keys(videoStreamMetrics[selfAttendeeId][downstreamSsrc]).length).to.equal(0);
+      expect(Object.keys(videoStreamMetrics[selfAttendeeId][upstreamSsrc]).length).to.equal(1);
     });
 
     it('returns the observable video metrics for streams with streamId', () => {
@@ -410,14 +410,12 @@ describe('DefaultClientMetricReport', () => {
       upstreamReport_1.mediaType = MediaType.VIDEO;
       upstreamReport_1.direction = Direction.UPSTREAM;
       upstreamReport_1.currentMetrics['framesEncoded'] = 100;
-      upstreamReport_1.streamId = 11;
       clientMetricReport.streamMetricReports[upstreamSsrc_1] = upstreamReport_1;
       const upstreamSsrc_2 = 12;
       const upstreamReport_2 = new StreamMetricReport();
       upstreamReport_2.mediaType = MediaType.VIDEO;
       upstreamReport_2.direction = Direction.UPSTREAM;
       upstreamReport_2.currentMetrics['framesEncoded'] = 100;
-      upstreamReport_2.streamId = 12;
       clientMetricReport.streamMetricReports[upstreamSsrc_2] = upstreamReport_2;
       const downstreamSsrc = 22;
       const downstreamReport = new StreamMetricReport();
@@ -429,8 +427,8 @@ describe('DefaultClientMetricReport', () => {
       clientMetricReport.previousTimestampMs = 0;
       const videoStreamMetrics = clientMetricReport.getObservableVideoMetrics();
       expect(Object.keys(videoStreamMetrics[''][downstreamSsrc]).length).to.equal(0);
-      expect(Object.keys(videoStreamMetrics[''][upstreamSsrc_1]).length).to.equal(1);
-      expect(Object.keys(videoStreamMetrics[''][upstreamSsrc_2]).length).to.equal(1);
+      expect(Object.keys(videoStreamMetrics[selfAttendeeId][upstreamSsrc_1]).length).to.equal(1);
+      expect(Object.keys(videoStreamMetrics[selfAttendeeId][upstreamSsrc_2]).length).to.equal(1);
     });
 
     it('returns 0 observable video metrics if no desired report in stream metric reports', () => {

--- a/test/clientmetricreport/DefaultClientMetricReport.test.ts
+++ b/test/clientmetricreport/DefaultClientMetricReport.test.ts
@@ -478,4 +478,18 @@ describe('DefaultClientMetricReport', () => {
       expect(clientMetricReport.streamMetricReports[ssrc1]).to.equal(undefined);
     });
   });
+
+  describe('error logging', () => {
+    it('returns undefined observable video metrics if no VideoStreamIndex and selfAttendeeId defined stream metric reports', () => {
+      clientMetricReport = new DefaultClientMetricReport(new NoOpDebugLogger());
+      const ssrc = 1;
+      const report = new StreamMetricReport();
+      report.mediaType = MediaType.VIDEO;
+      report.direction = Direction.UPSTREAM;
+      report.currentMetrics['framesEncoded'] = 10;
+      clientMetricReport.streamMetricReports[ssrc] = report;
+      const videoStreamMetrics = clientMetricReport.getObservableVideoMetrics();
+      expect(Object.keys(videoStreamMetrics).length).to.equal(0);
+    });
+  });
 });

--- a/test/statscollector/DefaultStatsCollector.test.ts
+++ b/test/statscollector/DefaultStatsCollector.test.ts
@@ -76,7 +76,7 @@ describe('DefaultStatsCollector', () => {
     clientMetricReport = new DefaultClientMetricReport(
       logger,
       new DefaultVideoStreamIndex(logger),
-      audioVideoController
+      audioVideoController.configuration.credentials.attendeeId
     );
   });
 

--- a/test/task/MonitorTask.test.ts
+++ b/test/task/MonitorTask.test.ts
@@ -383,11 +383,7 @@ describe('MonitorTask', () => {
       const clientMetricReport = new TestClientMetricReport();
       task.metricsDidReceive(clientMetricReport);
 
-      const defaultClientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const defaultClientMetricReport = new DefaultClientMetricReport(logger);
       const ssrc = 6789;
       defaultClientMetricReport.streamMetricReports[ssrc] = new StreamMetricReport();
       task.metricsDidReceive(defaultClientMetricReport);
@@ -402,11 +398,7 @@ describe('MonitorTask', () => {
       streamMetricReport.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReport.direction = ClientMetricReportDirection.DOWNSTREAM;
 
-      const clientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new DefaultClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       task.metricsDidReceive(clientMetricReport);
     });
@@ -434,11 +426,7 @@ describe('MonitorTask', () => {
       streamMetricReportAudio.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReportAudio.direction = ClientMetricReportDirection.UPSTREAM;
 
-      const clientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new DefaultClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       clientMetricReport.streamMetricReports[56789] = streamMetricReportAudio;
       task.metricsDidReceive(clientMetricReport);
@@ -477,11 +465,7 @@ describe('MonitorTask', () => {
       streamMetricReportAudio.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReportAudio.direction = ClientMetricReportDirection.UPSTREAM;
 
-      const clientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new DefaultClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       clientMetricReport.streamMetricReports[56789] = streamMetricReportAudio;
       task.metricsDidReceive(clientMetricReport);
@@ -503,11 +487,7 @@ describe('MonitorTask', () => {
       streamMetricReport.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReport.direction = ClientMetricReportDirection.DOWNSTREAM;
 
-      const clientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new DefaultClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       task.metricsDidReceive(clientMetricReport);
     });
@@ -527,11 +507,7 @@ describe('MonitorTask', () => {
       streamMetricReport.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReport.direction = ClientMetricReportDirection.DOWNSTREAM;
 
-      const clientMetricReport = new DefaultClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new DefaultClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       task.metricsDidReceive(clientMetricReport);
     });
@@ -607,11 +583,7 @@ describe('MonitorTask', () => {
       streamMetricReportAudio.mediaType = ClientMetricReportMediaType.VIDEO;
       streamMetricReportAudio.direction = ClientMetricReportDirection.UPSTREAM;
 
-      const clientMetricReport = new TestClientMetricReport(
-        logger,
-        context.videoStreamIndex,
-        context.audioVideoController
-      );
+      const clientMetricReport = new TestClientMetricReport(logger);
       clientMetricReport.streamMetricReports[1] = streamMetricReport;
       clientMetricReport.streamMetricReports[56789] = streamMetricReportAudio;
       task.metricsDidReceive(clientMetricReport);

--- a/test/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy.test.ts
@@ -3,7 +3,6 @@
 
 import * as chai from 'chai';
 
-import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import DefaultClientMetricReport from '../../src/clientmetricreport/DefaultClientMetricReport';
 import LogLevel from '../../src/logger/LogLevel';
 import NoOpLogger from '../../src/logger/NoOpLogger';
@@ -221,11 +220,7 @@ describe('AllHighestVideoBandwidthPolicy', () => {
         })
       );
 
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        index,
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 1000;
 
       policy.updateIndex(index);

--- a/test/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy.test.ts
@@ -3,7 +3,6 @@
 
 import * as chai from 'chai';
 
-import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import DefaultClientMetricReport from '../../src/clientmetricreport/DefaultClientMetricReport';
 import LogLevel from '../../src/logger/LogLevel';
 import NoOpLogger from '../../src/logger/NoOpLogger';
@@ -32,11 +31,7 @@ describe('NoVideoDownlinkBandwidthPolicy', () => {
       expect(policy.wantsResubscribe()).to.be.false;
       policy.updateIndex(emptyVideoStreamIndex);
       expect(policy.wantsResubscribe()).to.be.false;
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        emptyVideoStreamIndex,
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 500;
       policy.updateMetrics(metricReport);
       expect(policy.wantsResubscribe()).to.be.false;

--- a/test/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.test.ts
@@ -5,7 +5,6 @@ import * as chai from 'chai';
 
 import AudioVideoTileController from '../../src/audiovideocontroller/AudioVideoController';
 import NoOpAudioVideoTileController from '../../src/audiovideocontroller/NoOpAudioVideoController';
-import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import ClientMetricReportDirection from '../../src/clientmetricreport/ClientMetricReportDirection';
 import DefaultClientMetricReport from '../../src/clientmetricreport/DefaultClientMetricReport';
 import GlobalMetricReport from '../../src/clientmetricreport/GlobalMetricReport';
@@ -18,7 +17,6 @@ import {
   SdkStreamMediaType,
 } from '../../src/signalingprotocol/SignalingProtocol';
 import VideoAdaptiveProbePolicy from '../../src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy';
-import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStreamIndex';
 import SimulcastVideoStreamIndex from '../../src/videostreamindex/SimulcastVideoStreamIndex';
 import VideoTileController from '../../src/videotilecontroller/VideoTileController';
 
@@ -202,23 +200,13 @@ describe('VideoAdaptiveProbePolicy', () => {
     it('can be no-op if there are no streams available to subscribe', () => {
       videoStreamIndex.integrateIndexFrame(new SdkIndexFrame());
       policy.updateIndex(videoStreamIndex);
-      policy.updateMetrics(
-        new DefaultClientMetricReport(
-          logger,
-          new DefaultVideoStreamIndex(logger),
-          new NoOpAudioVideoController()
-        )
-      );
+      policy.updateMetrics(new DefaultClientMetricReport(logger));
     });
 
     it('can update metrics', () => {
       prepareVideoStreamIndex(videoStreamIndex);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       const streamReport1 = new StreamMetricReport();
       streamReport1.streamId = 1;
       streamReport1.direction = ClientMetricReportDirection.DOWNSTREAM;
@@ -289,11 +277,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       const received = policy.chooseSubscriptions();
       expect(received.array()).to.deep.equal([1, 3, 11, 22]);
 
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableSendBandwidth'] = 4000 * 1000;
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 4000 * 1000;
@@ -331,11 +315,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       policy.MIN_TIME_BETWEEN_PROBE = 20;
       // @ts-ignore
       policy.STARTUP_PERIOD_MS = 5;
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableSendBandwidth'] = 4000 * 1000;
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 4000 * 1000;
@@ -450,11 +430,7 @@ describe('VideoAdaptiveProbePolicy', () => {
     it('prefers content', () => {
       prepareVideoStreamIndex(videoStreamIndex);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2800 * 1000;
       policy.updateMetrics(metricReport);
@@ -501,11 +477,7 @@ describe('VideoAdaptiveProbePolicy', () => {
     it('Includes paused stream in subscribe', () => {
       updateIndexFrame(videoStreamIndex, 4, 300, 600);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2800 * 1000;
       let resub = policy.wantsResubscribe();
@@ -567,11 +539,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       expect(received.array()).to.deep.equal([2, 4, 6, 8]);
 
       incrementTime(6100);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 3600 * 1000;
       policy.updateMetrics(metricReport);
@@ -632,11 +600,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       expect(received.array()).to.deep.equal([2, 4, 6, 8]);
 
       incrementTime(6100);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 3600 * 1000;
       policy.updateMetrics(metricReport);
@@ -699,11 +663,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       expect(received.array()).to.deep.equal([2, 4, 6, 8]);
 
       incrementTime(6100);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 3600 * 1000;
       policy.updateMetrics(metricReport);
@@ -759,11 +719,7 @@ describe('VideoAdaptiveProbePolicy', () => {
       expect(received.array()).to.deep.equal([2, 4, 6, 8]);
 
       incrementTime(6100);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 3600 * 1000;
       policy.updateMetrics(metricReport);

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -6,7 +6,6 @@ import * as sinon from 'sinon';
 
 import AudioVideoTileController from '../../src/audiovideocontroller/AudioVideoController';
 import NoOpAudioVideoTileController from '../../src/audiovideocontroller/NoOpAudioVideoController';
-import NoOpAudioVideoController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import ClientMetricReportDirection from '../../src/clientmetricreport/ClientMetricReportDirection';
 import DefaultClientMetricReport from '../../src/clientmetricreport/DefaultClientMetricReport';
 import GlobalMetricReport from '../../src/clientmetricreport/GlobalMetricReport';
@@ -24,7 +23,6 @@ import VideoDownlinkObserver from '../../src/videodownlinkbandwidthpolicy/VideoD
 import VideoPreference from '../../src/videodownlinkbandwidthpolicy/VideoPreference';
 import { VideoPreferences } from '../../src/videodownlinkbandwidthpolicy/VideoPreferences';
 import VideoPriorityBasedPolicy from '../../src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy';
-import DefaultVideoStreamIndex from '../../src/videostreamindex/DefaultVideoStreamIndex';
 import SimulcastVideoStreamIndex from '../../src/videostreamindex/SimulcastVideoStreamIndex';
 import VideoTileController from '../../src/videotilecontroller/VideoTileController';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
@@ -249,11 +247,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('no priority to priority', () => {
       updateIndexFrame(videoStreamIndex, 5, 0, 600);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2400 * 1000;
       policy.updateMetrics(metricReport);
@@ -280,11 +274,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('priority to no priority', () => {
       updateIndexFrame(videoStreamIndex, 4, 0, 600);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2400 * 1000;
       policy.updateMetrics(metricReport);
@@ -310,11 +300,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('priority value comparison checker', () => {
       updateIndexFrame(videoStreamIndex, 4, 0, 600);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2400 * 1000;
       policy.updateMetrics(metricReport);
@@ -356,11 +342,7 @@ describe('VideoPriorityBasedPolicy', () => {
       policy.addObserver(observer);
       updateIndexFrame(videoStreamIndex, 2, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;
@@ -498,11 +480,7 @@ describe('VideoPriorityBasedPolicy', () => {
       tile4.stateRef().boundAttendeeId = 'attendee-4';
 
       incrementTime(6100);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2100 * 1000;
       policy.updateMetrics(metricReport);
@@ -581,11 +559,7 @@ describe('VideoPriorityBasedPolicy', () => {
       const domMockBuilder = new DOMMockBuilder();
       updateIndexFrame(videoStreamIndex, 2, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;
@@ -663,11 +637,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('Stream not added until enough bandwidth', () => {
       updateIndexFrame(videoStreamIndex, 3, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;
@@ -783,11 +753,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('Video Tile cleaned up if never subscribed', () => {
       updateIndexFrame(videoStreamIndex, 2, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;
@@ -884,11 +850,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('Video Tile cleaned up removed from preference list', () => {
       updateIndexFrame(videoStreamIndex, 2, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;
@@ -966,11 +928,7 @@ describe('VideoPriorityBasedPolicy', () => {
     it('dont change subscription with small change', () => {
       updateIndexFrame(videoStreamIndex, 4, 300, 1200);
       policy.updateIndex(videoStreamIndex);
-      const metricReport = new DefaultClientMetricReport(
-        logger,
-        new DefaultVideoStreamIndex(logger),
-        new NoOpAudioVideoController()
-      );
+      const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] =
         10000 * 1000;


### PR DESCRIPTION
**Issue #:**
Previously submitted a pr which has breaking changes for exposing video metrics: https://github.com/aws/amazon-chime-sdk-js/pull/1251

**Description of changes:**
This change is to make some attribute in DefaultClientMetricReport optional and make getObersableVideoMetricReport interface optional.

Also pass in attendeeId instead of audioVideoController to DefaultClientMetricReport.
**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? test in meeting demo app
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? meetingV2
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? yes
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

