### PR TITLE
Fixed missing upstream video metrics for Firefox browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+### Added 
+
+### Changed
+
+### Removed
+
+### Fixed
+- Fixed missing upstream video metrics for Firefox browsers.
+
 ## [2.10.0] - 2021-05-19
 
 ### Changed

--- a/docs/classes/defaultstatscollector.html
+++ b/docs/classes/defaultstatscollector.html
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L414">src/statscollector/DefaultStatsCollector.ts:414</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L415">src/statscollector/DefaultStatsCollector.ts:415</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L364">src/statscollector/DefaultStatsCollector.ts:364</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L365">src/statscollector/DefaultStatsCollector.ts:365</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L406">src/statscollector/DefaultStatsCollector.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L407">src/statscollector/DefaultStatsCollector.ts:407</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -235,7 +235,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L394">src/statscollector/DefaultStatsCollector.ts:394</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L395">src/statscollector/DefaultStatsCollector.ts:395</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L375">src/statscollector/DefaultStatsCollector.ts:375</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L376">src/statscollector/DefaultStatsCollector.ts:376</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/statscollector/DefaultStatsCollector.ts
+++ b/src/statscollector/DefaultStatsCollector.ts
@@ -353,7 +353,8 @@ export default class DefaultStatsCollector implements StatsCollector {
 
   private getDirectionType(rawMetricReport: RawMetricReport): Direction {
     return rawMetricReport.id.toLowerCase().indexOf('send') !== -1 ||
-      rawMetricReport.id.toLowerCase().indexOf('outbound') !== -1
+      rawMetricReport.id.toLowerCase().indexOf('outbound') !== -1 ||
+      rawMetricReport.type === 'outbound-rtp'
       ? Direction.UPSTREAM
       : Direction.DOWNSTREAM;
   }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Fixed missing upstream video metrics for Firefox browsers. Currently the upstream from FF got filtered and no metrics showing for FF upstreams.

Bug tracing: The following upstream video metrics are processed as downstream https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L354-L358 and hence got recognized as invalid ssrc https://github.com/aws/amazon-chime-sdk-js/blob/master/src/statscollector/DefaultStatsCollector.ts#L401 and got filtered with the existing code. This pr is to fix this issue and mark the upstreams like this as valid ssrc streams in FF browsers.
```
bitrateMean: 1360618.949450551
bitrateStdDev: 151086.07737034056
bytesSent: 239490948
droppedFrames: 498
firCount: 16
framerateMean: 29.526739926739907
framerateStdDev: 1.034689376608254
framesEncoded: 40522
id: "41d7ab2"
kind: "video"
mediaType: "video"
nackCount: 434
packetsSent: 220971
pliCount: 0
remoteId: "6afe1743"
ssrc: 1474835099
timestamp: 1621536062622
type: "outbound-rtp"
```
**Testing step**
In firefox browsers, when user clicks the statistics icon, and hover mouse over their own video tile, they should be able to see upstream metrics.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Test across browsers for both upstream and downstreams. 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes, meetingV2 demo
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

