### PR TITLE
Log error if signaling client is not ready when sending data message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 ### Changed
+- Log error instead of throwing error if the signaling client is not ready to send data message
 
 ### Removed
 

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -42,7 +42,7 @@
       }
     },
     "../..": {
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -77,6 +77,7 @@
         "node-fetch": "^2.6.1",
         "nyc": "^15.1.0",
         "prettier": "^2.1.2",
+        "rimraf": "^3.0.2",
         "sinon": "^7.3.2",
         "spawn-wrap": "^2.0.0",
         "ts-loader": "^8.0.18",
@@ -17379,6 +17380,7 @@
         "prettier": "^2.1.2",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
+        "rimraf": "^3.0.2",
         "sinon": "^7.3.2",
         "spawn-wrap": "^2.0.0",
         "ts-loader": "^8.0.18",

--- a/src/task/SendAndReceiveDataMessagesTask.ts
+++ b/src/task/SendAndReceiveDataMessagesTask.ts
@@ -81,7 +81,7 @@ export default class SendAndReceiveDataMessagesTask
       messageFrame.messages = [message];
       this.context.signalingClient.sendDataMessage(messageFrame);
     } else {
-      throw new Error('Signaling client is not ready');
+      this.context.logger.error('Signaling client is not ready');
     }
   };
 

--- a/test/task/SendAndReceiveDataMessagesTask.test.ts
+++ b/test/task/SendAndReceiveDataMessagesTask.test.ts
@@ -171,11 +171,11 @@ describe('SendAndReceiveDataMessagesTask', () => {
     expect(spy.calledOnceWithExactly(sinon.match(dataMessageFrame))).to.be.true;
   });
 
-  it('throw error if signaling client is not ready', () => {
+  it('log an error if signaling client is not ready', () => {
+    const spy = sinon.spy(context.logger, 'error');
     context.signalingClient.closeConnection();
-    expect(() => {
-      task.sendDataMessageHandler('topic', 'Test message');
-    }).to.throw('Signaling client is not ready');
+    task.sendDataMessageHandler('topic', 'Test message');
+    expect(spy.calledOnce).to.be.true;
   });
 
   it('thow error if invalid topic', async () => {


### PR DESCRIPTION
**Issue #1283:**

**Description of changes:**
Previously we threw an error if the signaling client is not ready when sending a data message. The data message is sent using a realtime API so an error thrown will be fatal and cause the meeting to disconnect completely.
This PR changes to log the error instead of throwing it.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
- Join a meeting
- Using Network Link Conditioner to turn off the network
- Try to send a data message
- Turn back the network
- Verify that you can reconnect
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, using the meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

