### PR TITLE
Add a mechanism to clear the deviceInfoCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-### Added 
-- Add more debug logging for choose input device. 
+- Add more debug logging for choose input device.
 - Add the meeting and device error sections in the meeting-event guide.
+- Add a `forceUpdate` parameter to use when listing devices. In some cases, builders
+  need to delay the triggering of permission dialogs, _e.g._, when joining a
+  meeting in view-only mode, and then later be able to trigger a permission
+  prompt in order to show device labels. This parameter allows cached device
+  labels to be forcibly discarded and recomputed after the device label trigger
+  is run.
 
 ### Changed
+
 - Log error instead of throwing error if the signaling client is not ready to send data message.
+- Now when `setDeviceLabelTrigger` is called, if the `deviceInfoCache` contains a device with no label, `deviceInfoCache` will be cleared.
 
 ### Removed
+
 - Remove deprecated unwired webrtc constraints from device controller and peer connection construction.
 
 ### Fixed
+
 - Fixed missing upstream video metrics for Firefox browsers.
 - Fix build script to run on Windows by specifying ruby when running ruby scripts and rimraf to remove folder.
 
 ## [2.10.0] - 2021-05-19
 
-### Changed
-- Update guide for priority based downlink policy
+### Added
 
-### Added 
-
-- Add new message `MeetingSessionStatusCode` `AudioAttendeeRemoved` to handle
-  the new audio server status code 411.
+- Add new message `MeetingSessionStatusCode` `AudioAttendeeRemoved` to handle the new audio server status code 411.
 - Add support for `WKWebView` on iOS.
 - Output a warning message when the volume adapter cleans up the self-attendee after reconnection.
 - Add FAQ for more information on `AudioJoinFromAnotherDevice` meeting session status code.
@@ -40,13 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `SignalingProtocol` with optional video metric fields.
 
 ### Changed
+
+- Update guide for priority based downlink policy.
 - Bump version for lodash, y18n, and ssri dependencies.
 - Mark `getObservableVideoMetrics` optional in ClientMetricReprt and `videoStreamIndex` and `selfAttendeeId` optional in `DefaultClientMetricReport`.
 
 ### Removed
 
 ### Fixed
-- Do not start local video tile if there is no stream for content share
+
+- Do not start local video tile if there is no stream for content share.
 
 - Media streams are no longer discarded during reconnects. This fixes an issue
   where initial signaling connection failures could cause a client to be unable

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Please do **not** create a public GitHub issue.
 
 **Use case 1.** List audio input, audio output, and video input devices. The browser will ask for microphone and camera permissions.
 
+With the `forceUpdate` parameter set to true, cached device information is discarded and updated after the device label trigger is called. In some cases, builders need to delay the triggering of permission dialogs, e.g., when joining a meeting in view-only mode, and then later be able to trigger a permission prompt in order to show device labels; specifying `forceUpdate`  allows this to occur.
+
 ```js
 const audioInputDevices = await meetingSession.audioVideo.listAudioInputDevices();
 const audioOutputDevices = await meetingSession.audioVideo.listAudioOutputDevices();

--- a/docs/classes/defaultaudiovideofacade.html
+++ b/docs/classes/defaultaudiovideofacade.html
@@ -660,7 +660,7 @@
 					<a name="listaudioinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -670,6 +670,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L314">src/audiovideofacade/DefaultAudioVideoFacade.ts:314</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -678,7 +684,7 @@
 					<a name="listaudiooutputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Output<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -688,6 +694,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L326">src/audiovideofacade/DefaultAudioVideoFacade.ts:326</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -696,7 +708,7 @@
 					<a name="listvideoinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Video<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -706,6 +718,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L320">src/audiovideofacade/DefaultAudioVideoFacade.ts:320</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -179,7 +179,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L689">src/devicecontroller/DefaultDeviceController.ts:689</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L699">src/devicecontroller/DefaultDeviceController.ts:699</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -197,7 +197,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L697">src/devicecontroller/DefaultDeviceController.ts:697</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L707">src/devicecontroller/DefaultDeviceController.ts:707</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L693">src/devicecontroller/DefaultDeviceController.ts:693</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L703">src/devicecontroller/DefaultDeviceController.ts:703</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -263,7 +263,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L868">src/devicecontroller/DefaultDeviceController.ts:868</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L878">src/devicecontroller/DefaultDeviceController.ts:878</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -359,7 +359,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L669">src/devicecontroller/DefaultDeviceController.ts:669</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L679">src/devicecontroller/DefaultDeviceController.ts:679</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -445,7 +445,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L685">src/devicecontroller/DefaultDeviceController.ts:685</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L695">src/devicecontroller/DefaultDeviceController.ts:695</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1649">src/devicecontroller/DefaultDeviceController.ts:1649</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1662">src/devicecontroller/DefaultDeviceController.ts:1662</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -473,7 +473,7 @@
 					<a name="listaudioinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -483,6 +483,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L259">src/devicecontroller/DefaultDeviceController.ts:259</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -491,7 +497,7 @@
 					<a name="listaudiooutputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Output<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -501,6 +507,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L271">src/devicecontroller/DefaultDeviceController.ts:271</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -509,7 +521,7 @@
 					<a name="listvideoinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Video<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -519,6 +531,12 @@
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L265">src/devicecontroller/DefaultDeviceController.ts:265</a></li>
 								</ul>
 							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagDefault value">Default value</span> forceUpdate: <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -534,7 +552,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L656">src/devicecontroller/DefaultDeviceController.ts:656</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L666">src/devicecontroller/DefaultDeviceController.ts:666</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -557,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L822">src/devicecontroller/DefaultDeviceController.ts:822</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L832">src/devicecontroller/DefaultDeviceController.ts:832</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -687,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1758">src/devicecontroller/DefaultDeviceController.ts:1758</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1771">src/devicecontroller/DefaultDeviceController.ts:1771</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -704,7 +722,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L951">src/devicecontroller/DefaultDeviceController.ts:951</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L961">src/devicecontroller/DefaultDeviceController.ts:961</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -721,7 +739,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L955">src/devicecontroller/DefaultDeviceController.ts:955</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L965">src/devicecontroller/DefaultDeviceController.ts:965</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -738,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1744">src/devicecontroller/DefaultDeviceController.ts:1744</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1757">src/devicecontroller/DefaultDeviceController.ts:1757</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -755,7 +773,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L909">src/devicecontroller/DefaultDeviceController.ts:909</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L919">src/devicecontroller/DefaultDeviceController.ts:919</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -778,7 +796,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L959">src/devicecontroller/DefaultDeviceController.ts:959</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L969">src/devicecontroller/DefaultDeviceController.ts:969</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -801,7 +819,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1005">src/devicecontroller/DefaultDeviceController.ts:1005</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1015">src/devicecontroller/DefaultDeviceController.ts:1015</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/destroyablenoopdevicecontroller.html
+++ b/docs/classes/destroyablenoopdevicecontroller.html
@@ -466,7 +466,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<p>Inherited from <a href="noopdevicecontroller.html">NoOpDeviceController</a>.<a href="noopdevicecontroller.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L20">src/devicecontroller/NoOpDeviceController.ts:20</a></li>
@@ -485,7 +484,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<p>Inherited from <a href="noopdevicecontroller.html">NoOpDeviceController</a>.<a href="noopdevicecontroller.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L28">src/devicecontroller/NoOpDeviceController.ts:28</a></li>
@@ -504,7 +502,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<p>Inherited from <a href="noopdevicecontroller.html">NoOpDeviceController</a>.<a href="noopdevicecontroller.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L24">src/devicecontroller/NoOpDeviceController.ts:24</a></li>

--- a/docs/classes/noopdevicecontroller.html
+++ b/docs/classes/noopdevicecontroller.html
@@ -424,7 +424,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L20">src/devicecontroller/NoOpDeviceController.ts:20</a></li>
 								</ul>
@@ -442,7 +441,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L28">src/devicecontroller/NoOpDeviceController.ts:28</a></li>
 								</ul>
@@ -460,7 +458,6 @@
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
-								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
 									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/NoOpDeviceController.ts#L24">src/devicecontroller/NoOpDeviceController.ts:24</a></li>
 								</ul>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -800,7 +800,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1794">src/devicecontroller/DefaultDeviceController.ts:1794</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1807">src/devicecontroller/DefaultDeviceController.ts:1807</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -319,6 +319,7 @@ npm <span class="hljs-builtin-name">run</span> doc
 					<p>Note: Before starting a session, you need to choose your microphone, speaker, and camera.</p>
 				</blockquote>
 				<p><strong>Use case 1.</strong> List audio input, audio output, and video input devices. The browser will ask for microphone and camera permissions.</p>
+				<p>With the <code>forceUpdate</code> parameter set to true, cached device information is discarded and updated after the device label trigger is called. In some cases, builders need to delay the triggering of permission dialogs, e.g., when joining a meeting in view-only mode, and then later be able to trigger a permission prompt in order to show device labels; specifying <code>forceUpdate</code>  allows this to occur.</p>
 				<pre><code class="language-js"><span class="hljs-keyword">const</span> audioInputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listAudioInputDevices();
 <span class="hljs-keyword">const</span> audioOutputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listAudioOutputDevices();
 <span class="hljs-keyword">const</span> videoInputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listVideoInputDevices();

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -701,7 +701,7 @@
 					<a name="listaudioinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -713,9 +713,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio input devices.</p>
+									<p>Lists currently available audio input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -724,7 +730,7 @@
 					<a name="listaudiooutputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Output<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -736,9 +742,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio output devices.</p>
+									<p>Lists currently available audio output devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -747,7 +759,7 @@
 					<a name="listvideoinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Video<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -759,9 +771,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available video input devices.</p>
+									<p>Lists currently available video input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>

--- a/docs/interfaces/devicecontroller.html
+++ b/docs/interfaces/devicecontroller.html
@@ -370,7 +370,7 @@
 					<a name="listaudioinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -381,9 +381,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio input devices.</p>
+									<p>Lists currently available audio input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -392,7 +398,7 @@
 					<a name="listaudiooutputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Output<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -403,9 +409,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio output devices.</p>
+									<p>Lists currently available audio output devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -414,7 +426,7 @@
 					<a name="listvideoinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Video<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -425,9 +437,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available video input devices.</p>
+									<p>Lists currently available video input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>

--- a/docs/interfaces/devicecontrollerbasedmediastreambroker.html
+++ b/docs/interfaces/devicecontrollerbasedmediastreambroker.html
@@ -455,7 +455,7 @@
 					<a name="listaudioinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -467,9 +467,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio input devices.</p>
+									<p>Lists currently available audio input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -478,7 +484,7 @@
 					<a name="listaudiooutputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Audio<wbr>Output<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Audio<wbr>Output<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -490,9 +496,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available audio output devices.</p>
+									<p>Lists currently available audio output devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>
@@ -501,7 +513,7 @@
 					<a name="listvideoinputdevices" class="tsd-anchor"></a>
 					<h3>list<wbr>Video<wbr>Input<wbr>Devices</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface tsd-is-inherited">
-						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">list<wbr>Video<wbr>Input<wbr>Devices<span class="tsd-signature-symbol">(</span>forceUpdate<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -513,9 +525,15 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Lists currently available video input devices.</p>
+									<p>Lists currently available video input devices. If <code>forceUpdate</code> is set to true, the <code>deviceInfoCache</code> will be updated from browser.</p>
 								</div>
 							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> forceUpdate: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaDeviceInfo</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
 					</ul>

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -311,21 +311,21 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     this.trace('unsubscribeFromActiveSpeakerDetector');
   }
 
-  async listAudioInputDevices(): Promise<MediaDeviceInfo[]> {
-    const result = await this.deviceController.listAudioInputDevices();
-    this.trace('listAudioInputDevices', null, result);
+  async listAudioInputDevices(forceUpdate: boolean = false): Promise<MediaDeviceInfo[]> {
+    const result = await this.deviceController.listAudioInputDevices(forceUpdate);
+    this.trace('listAudioInputDevices', forceUpdate, result);
     return result;
   }
 
-  async listVideoInputDevices(): Promise<MediaDeviceInfo[]> {
-    const result = await this.deviceController.listVideoInputDevices();
-    this.trace('listVideoInputDevices', null, result);
+  async listVideoInputDevices(forceUpdate: boolean = false): Promise<MediaDeviceInfo[]> {
+    const result = await this.deviceController.listVideoInputDevices(forceUpdate);
+    this.trace('listVideoInputDevices', forceUpdate, result);
     return result;
   }
 
-  async listAudioOutputDevices(): Promise<MediaDeviceInfo[]> {
-    const result = await this.deviceController.listAudioOutputDevices();
-    this.trace('listAudioOutputDevices', null, result);
+  async listAudioOutputDevices(forceUpdate: boolean = false): Promise<MediaDeviceInfo[]> {
+    const result = await this.deviceController.listAudioOutputDevices(forceUpdate);
+    this.trace('listAudioOutputDevices', forceUpdate, result);
     return result;
   }
 

--- a/src/devicecontroller/DeviceController.ts
+++ b/src/devicecontroller/DeviceController.ts
@@ -52,19 +52,19 @@ import VideoQualitySettings from './VideoQualitySettings';
  */
 export default interface DeviceController {
   /**
-   * Lists currently available audio input devices.
+   * Lists currently available audio input devices. If `forceUpdate` is set to true, the `deviceInfoCache` will be updated from browser.
    */
-  listAudioInputDevices(): Promise<MediaDeviceInfo[]>;
+  listAudioInputDevices(forceUpdate?: boolean): Promise<MediaDeviceInfo[]>;
 
   /**
-   * Lists currently available video input devices.
+   * Lists currently available video input devices. If `forceUpdate` is set to true, the `deviceInfoCache` will be updated from browser.
    */
-  listVideoInputDevices(): Promise<MediaDeviceInfo[]>;
+  listVideoInputDevices(forceUpdate?: boolean): Promise<MediaDeviceInfo[]>;
 
   /**
-   * Lists currently available audio output devices.
+   * Lists currently available audio output devices. If `forceUpdate` is set to true, the `deviceInfoCache` will be updated from browser.
    */
-  listAudioOutputDevices(): Promise<MediaDeviceInfo[]>;
+  listAudioOutputDevices(forceUpdate?: boolean): Promise<MediaDeviceInfo[]>;
 
   /**
    * Selects an audio input device to use. The constraint may be a device id,

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -88,6 +88,14 @@ describe('DefaultDeviceController', () => {
     };
   }
 
+  function anyDevicesAreUnlabeled(devices: MediaDeviceInfo[]): boolean {
+    return devices.some(device => !device.label);
+  }
+
+  function anyDeviceHasId(devices: MediaDeviceInfo[], deviceId: string): boolean {
+    return devices.some(device => device.deviceId === deviceId);
+  }
+
   beforeEach(() => {
     domMockBehavior = new DOMMockBehavior();
     domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -209,6 +217,49 @@ describe('DefaultDeviceController', () => {
       for (const device of devices) {
         expect(device.kind).to.equal('audioinput');
       }
+    });
+
+    it('updates cache after cache established only with forceUpdate set to true', async () => {
+      deviceController.setDeviceLabelTrigger(async () => {
+        called = true;
+        return new MediaStream();
+      });
+
+      domMockBehavior.enumerateDeviceList = [
+        getMediaDeviceInfo('deviceId1', 'audioinput', '', 'group-id-1'),
+      ];
+
+      // This will establish the cache with empty label.
+      let devices: MediaDeviceInfo[] = await deviceController.listAudioInputDevices();
+
+      // @ts-ignore
+      expect(deviceController.deviceInfoCache).to.not.be.null;
+      expect(anyDevicesAreUnlabeled(devices)).to.be.true;
+
+      // @ts-ignore
+      expect(deviceController.isWatchingForDeviceChanges()).to.be.false;
+
+      // This will set `isWatchingForDeviceChanges` to be true to avoid undesired `deviceLabelTrigger` call.
+      const device: AudioInputDevice = { deviceId: 'deviceId1' };
+      await deviceController.chooseAudioInputDevice(device);
+
+      let called = false;
+
+      // @ts-ignore
+      expect(deviceController.isWatchingForDeviceChanges()).to.be.true;
+
+      // Update the mocked list to check the `enumerateDevices` call later.
+      domMockBehavior.enumerateDeviceList = [
+        getMediaDeviceInfo('deviceId2', 'audioinput', '', 'group-id-2'),
+      ];
+
+      devices = await deviceController.listAudioInputDevices(false);
+      expect(anyDeviceHasId(devices, 'deviceId2')).to.be.false;
+      expect(called).to.be.equal(false);
+
+      devices = await deviceController.listAudioInputDevices(true);
+      expect(anyDeviceHasId(devices, 'deviceId2')).to.be.true;
+      expect(called).to.be.equal(true);
     });
 
     it('lists video input devices', async () => {
@@ -997,7 +1048,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached.');
       }
 
-      // The previous audio source node will be disconneted.
+      // The previous audio source node will be disconnected.
       try {
         await deviceController.chooseAudioInputDevice(null);
       } catch (e) {
@@ -1086,7 +1137,7 @@ describe('DefaultDeviceController', () => {
     it('reuse existing device if passing in the same device id', async () => {
       domMockBehavior.enumerateDeviceList = [
         getMediaDeviceInfo('deviceId1', 'audioinput', 'label', 'group-id-1'),
-        getMediaDeviceInfo('deviceId12', 'audioinput', 'label', 'group-id-2'),
+        getMediaDeviceInfo('deviceId2', 'audioinput', 'label', 'group-id-2'),
       ];
       domMockBehavior.mediaStreamTrackSettings = {
         deviceId: 'deviceId1',
@@ -2328,6 +2379,36 @@ describe('DefaultDeviceController', () => {
       await deviceController.listAudioInputDevices();
       await delay(100);
       expect(called).to.be.true;
+    });
+
+    it('clears the cache if it has empty label when setting new device trigger', async () => {
+      deviceController.setDeviceLabelTrigger(async () => new MediaStream());
+
+      // This will establish the cache
+      const devices: MediaDeviceInfo[] = await deviceController.listAudioInputDevices();
+
+      // @ts-ignore
+      expect(deviceController.deviceInfoCache).to.not.be.null;
+      expect(anyDevicesAreUnlabeled(devices)).to.be.true;
+
+      deviceController.setDeviceLabelTrigger(async () => new MediaStream());
+
+      // @ts-ignore
+      expect(deviceController.deviceInfoCache).to.be.null;
+    });
+
+    it('keeps current cache if it has no empty label when setting new device trigger', async () => {
+      // This will establish the cache.
+      const devices: MediaDeviceInfo[] = await deviceController.listAudioInputDevices();
+
+      // @ts-ignore
+      expect(deviceController.deviceInfoCache).to.not.be.null;
+      expect(anyDevicesAreUnlabeled(devices)).to.be.false;
+
+      deviceController.setDeviceLabelTrigger(async () => new MediaStream());
+
+      // @ts-ignore
+      expect(deviceController.deviceInfoCache).to.not.be.null;
     });
   });
 


### PR DESCRIPTION
**Issue #1305 :**

**Description of changes:**
Add an optional parameter `force` in `listAudioInputDevices`, `listAudioOutputDevices`, `listVideoInputDevices` and `listDevicesOfKind`. User can force update the `deviceInfoCache` from browser with parameter `force` set to `true`.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Write a unit test to cover the change.
* call `listAudioInputDevices` to establish `deviceInfoCache`
* check `updateDeviceInfoCacheFromBrowser` is called once
* call `listAudioInputDevices` with `force` parameter set to `true`
* check `updateDeviceInfoCacheFromBrowser` is called twice

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
Yes
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

