### PR TITLE
Add additional logging in DefaultDeviceController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
-- Add more debug logging for choose input device.
+- Add more debug logging for choose input device. 
 - Add the meeting and device error sections in the meeting-event guide.
 - Add a `forceUpdate` parameter to use when listing devices. In some cases, builders
   need to delay the triggering of permission dialogs, _e.g._, when joining a

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1662">src/devicecontroller/DefaultDeviceController.ts:1662</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1664">src/devicecontroller/DefaultDeviceController.ts:1664</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1771">src/devicecontroller/DefaultDeviceController.ts:1771</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1773">src/devicecontroller/DefaultDeviceController.ts:1773</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -756,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1757">src/devicecontroller/DefaultDeviceController.ts:1757</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1759">src/devicecontroller/DefaultDeviceController.ts:1759</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -800,7 +800,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1807">src/devicecontroller/DefaultDeviceController.ts:1807</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1809">src/devicecontroller/DefaultDeviceController.ts:1809</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -383,7 +383,7 @@ export default class DefaultDeviceController
 
       await this.chooseAudioTransformInputDevice(device);
     } else {
-      this.logger.info(`Choosing intrinsic input device ${device}`);
+      this.logger.info(`Choosing intrinsic audio input device ${device}`);
       this.removeTransform();
       await this.chooseInputIntrinsicDevice('audio', device, false);
       this.trace('chooseAudioInputDevice', device, `success`);
@@ -1304,6 +1304,7 @@ export default class DefaultDeviceController
       }
     }
     delete device.endedCallback;
+    this.logger.debug(`Releasing active device ${JSON.stringify(device)}`);
     this.releaseMediaStream(device.stream);
     delete device.stream;
   }
@@ -1370,7 +1371,7 @@ export default class DefaultDeviceController
     // `applyConstraints` can be used to reuse the active device while changing the
     // requested constraints.
     if (this.matchesDeviceSelection(kind, device, this.activeDevices[kind], proposedConstraints)) {
-      this.logger.info(`reusing existing ${kind} device`);
+      this.logger.info(`reusing existing ${kind} input device`);
       return;
     }
 
@@ -1491,6 +1492,7 @@ export default class DefaultDeviceController
     const oldDevice = this.activeDevices[kind];
 
     this.activeDevices[kind] = newDevice;
+    this.logger.debug(`Set activeDevice to ${JSON.stringify(newDevice)}`);
     this.watchForDeviceChangesIfNecessary();
 
     if (kind === 'video') {
@@ -1642,7 +1644,7 @@ export default class DefaultDeviceController
         throw new Error(`no ${kind} device chosen, stopping local video tile`);
       }
     } else {
-      this.logger.info(`checking whether existing ${kind} device can be reused`);
+      this.logger.info(`checking whether existing ${kind} input device can be reused`);
       const active = this.activeDevices[kind];
       // @ts-ignore
       existingConstraints = active.constraints ? active.constraints[kind] : null;


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Add additional logging for Input device selection

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? Just logs
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes, shows logs
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

