### PR TITLE
Remove deprecated legacy webrtc constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log error instead of throwing error if the signaling client is not ready to send data message.
 
 ### Removed
+- Remove deprecated unwired webrtc constraints from device controller and peer connection construction.
 
 ### Fixed
 - Fixed missing upstream video metrics for Firefox browsers.

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1659">src/devicecontroller/DefaultDeviceController.ts:1659</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1649">src/devicecontroller/DefaultDeviceController.ts:1649</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -687,7 +687,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1768">src/devicecontroller/DefaultDeviceController.ts:1768</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1758">src/devicecontroller/DefaultDeviceController.ts:1758</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -738,7 +738,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1754">src/devicecontroller/DefaultDeviceController.ts:1754</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1744">src/devicecontroller/DefaultDeviceController.ts:1744</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -800,7 +800,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1804">src/devicecontroller/DefaultDeviceController.ts:1804</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1794">src/devicecontroller/DefaultDeviceController.ts:1794</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -1561,16 +1561,6 @@ export default class DefaultDeviceController
       trackConstraints.frameRate = trackConstraints.frameRate || {
         ideal: this.videoInputQualitySettings.videoFrameRate,
       };
-      // TODO: try to replace hard-code value related to videos into quality-level presets
-      // The following configs relaxes CPU overuse detection threshold to offer better encoding quality
-      // @ts-ignore
-      trackConstraints.googCpuOveruseDetection = true;
-      // @ts-ignore
-      trackConstraints.googCpuOveruseEncodeUsage = true;
-      // @ts-ignore
-      trackConstraints.googCpuOveruseThreshold = 85;
-      // @ts-ignore
-      trackConstraints.googCpuUnderuseThreshold = 55;
     }
     if (kind === 'audio' && this.supportSampleRateConstraint()) {
       trackConstraints.sampleRate = { ideal: DefaultDeviceController.defaultSampleRate };

--- a/src/task/CreatePeerConnectionTask.ts
+++ b/src/task/CreatePeerConnectionTask.ts
@@ -87,14 +87,7 @@ export default class CreatePeerConnectionTask extends BaseTask implements Remova
     // @ts-ignore
     this.logger.info(`SDP semantics are ${configuration.sdpSemantics}`);
     const connectionConstraints = {
-      optional: [
-        { googHighStartBitrate: 0 },
-        { googCpuOveruseDetection: false },
-        { googCpuOveruseEncodeUsage: false },
-        { googCpuUnderuseThreshold: 55 },
-        { googCpuOveruseThreshold: 150 },
-        { googCombinedAudioVideoBwe: true },
-      ],
+      optional: [{ googCpuOveruseDetection: false }, { googCombinedAudioVideoBwe: true }],
     };
     if (this.context.peer) {
       this.context.logger.info('reusing peer connection');


### PR DESCRIPTION
**Issue #:**

This Chromium CR https://chromium.googlesource.com/chromium/src/+/403297d618d91f7a228c5fa3c799925a4cb564b8 removed a couple of legacy webrtc constraints a couple of months ago.

https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc;l=173?q=CopyConstraintsIntoRtcConfiguration&ss=chromium%2Fchromium%2Fsrc

listed the suppported peer connection constraints.

So we can clean up the legacy constraints as well.

**Description of changes:**

Remove deprecated legacy webrtc constraints from device controller and peer connection construction.
Only keep the useful ones.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? demo sanity test
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? no
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

