### PR TITLE
Remove incorrect documentation for messaging session

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,6 @@ The value of the MediaRegion parameter in the createMeeting() should ideally be 
 ### Messaging session
 Create a messaging session in your client application to receive messages from Amazon Chime SDK for Messaging.
 
-#### Getting responses from your server application
-
-You can use an AWS SDK, the AWS Command Line Interface (AWS CLI), or the REST API
-to make API calls. In this section, you will use the AWS SDK for JavaScript in your server application, e.g. Node.js.
-See [Amazon Chime SDK API Reference](https://docs.aws.amazon.com/chime/latest/APIReference/Welcome.html) for more information.
-> ⚠️ The server application does not require the Amazon Chime SDK for JavaScript.
-
-
 ```js
 import * as AWS from 'aws-sdk/global';
 import * as Chime from 'aws-sdk/clients/chime';
@@ -195,6 +187,7 @@ const userArn = /* The userArn */;
 const sessionId = /* The sessionId */;
 const configuration = new MessagingSessionConfiguration(userArn, sessionId, endpoint.Endpoint.Url, chime, AWS);
 const messagingSession = new DefaultMessagingSession(configuration, logger);
+
 ```
 ## Building and testing
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -240,15 +240,6 @@ chime.endpoint = <span class="hljs-keyword">new</span> AWS.Endpoint(<span class=
 					<h3>Messaging session</h3>
 				</a>
 				<p>Create a messaging session in your client application to receive messages from Amazon Chime SDK for Messaging.</p>
-				<a href="#getting-responses-from-your-server-application-1" id="getting-responses-from-your-server-application-1" style="color: inherit; text-decoration: none;">
-					<h4>Getting responses from your server application</h4>
-				</a>
-				<p>You can use an AWS SDK, the AWS Command Line Interface (AWS CLI), or the REST API
-					to make API calls. In this section, you will use the AWS SDK for JavaScript in your server application, e.g. Node.js.
-				See <a href="https://docs.aws.amazon.com/chime/latest/APIReference/Welcome.html">Amazon Chime SDK API Reference</a> for more information.</p>
-				<blockquote>
-					<p>⚠️ The server application does not require the Amazon Chime SDK for JavaScript.</p>
-				</blockquote>
 				<pre><code class="language-js"><span class="hljs-keyword">import</span> * <span class="hljs-keyword">as</span> AWS <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;aws-sdk/global&#x27;</span>;
 <span class="hljs-keyword">import</span> * <span class="hljs-keyword">as</span> Chime <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;aws-sdk/clients/chime&#x27;</span>;
 


### PR DESCRIPTION
**Issue #1334 :**

**Description of changes:**
The README section about creating messaging session mentioned that it needs to be in server which is incorrect.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Doc change only.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

