### PR TITLE
Encrypt SQS for serverless demo

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "../..": {
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -15,7 +15,7 @@ Conditions:
   ShouldUseEventBridge: !Equals [true, !Ref UseEventBridge]
 Globals:
   Function:
-    Runtime: nodejs10.x
+    Runtime: nodejs14.x
     Timeout: 30
     MemorySize: 128
     Environment:
@@ -104,15 +104,41 @@ Resources:
       TimeToLiveSpecification:
         AttributeName: "TTL"
         Enabled: true
+  ChimeKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Custom KMS Key with Chime access
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: Allow access for Chime Service
+          Effect: Allow
+          Principal:
+            Service: chime.amazonaws.com
+          Action:
+            - kms:GenerateDataKey
+            - kms:Decrypt
+          Resource: '*'
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+          Action: kms:*
+          Resource: '*'
+  ChimeKMSAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/ChimeKMS-${AWS::StackName}
+      TargetKeyId:
+        Ref: ChimeKMSKey
   MeetingNotificationsQueue:
     Type: AWS::SQS::Queue
     Properties:
-      KmsMasterKeyId: 'alias/aws/sqs'
+      KmsMasterKeyId: !Sub alias/ChimeKMS-${AWS::StackName}
   ChimeSdkIndexLambda:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: handlers.index
-      Runtime: nodejs10.x
       CodeUri: src/
       Events:
         Api1:
@@ -162,6 +188,13 @@ Resources:
           Properties:
             Queue: !GetAtt MeetingNotificationsQueue.Arn
             BatchSize: 10
+      Policies:
+        - Statement:
+          - Sid: ChimeSQSQueueLambdaPolicy
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: '*'
   ChimeEventBridgeLambda:
     Type: AWS::Serverless::Function
     Condition: ShouldUseEventBridge


### PR DESCRIPTION
**Description of changes:**
Enable SSE for SQS queue in serverless demo following these resouces:
- https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-notifications.html
- https://docs.amazonaws.cn/en_us/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-lambda-function-trigger.html

Update Node Lambda version to 14 since Node 10 is no longer supported.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
- Deployed the meeting app with this template change and observed default SSE added to the queue created by the CF template with the custom CMS Key with the correct permissions for chime services.
- Tested joining, re-joining, ending and leaving, video on/off.
- Verify in the lambda cloudwatch log that we received meeting events.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, meeting demo. 
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

