### PR TITLE
Add XCUITest test

### DIFF
--- a/.github/workflows/xcuitest.yml
+++ b/.github/workflows/xcuitest.yml
@@ -1,0 +1,26 @@
+name: WkWebView Sample Demo E2E Test
+
+on:
+  workflow_run:
+    workflows: ["Deploy Demo App Workflow"]
+    branches: [master]
+    types: 
+      - completed
+
+jobs:
+  xcuitest:
+    runs-on: macos-11
+    env:
+      DEPLOYED_MEETING_DEMO: ${{secrets.DEPLOYED_MEETING_DEMO}}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout amazon-chime-sdk repo
+        uses: actions/checkout@v2
+        with:
+          repository: 'aws-samples/amazon-chime-sdk'
+      - name: Insert meeting demo URL
+        run: |
+          sed -i '' -e 's@YOUR_SERVER_URL@${{secrets.DEPLOYED_MEETING_DEMO}}@' apps/iOS-WKWebView-sample/WkWebView\ Demo/AppConfiguration.swift
+      - name: Run XCUITest Locally
+        run: |
+          xcodebuild test -project apps/iOS-WKWebView-sample/WkWebView\ Demo.xcodeproj -scheme WkWebView\ Demo  -sdk iphonesimulator -destination "platform=iOS Simulator,OS=14.5,name=iPhone 11 Pro"


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Checks out the WKWebview demo, uses the newly deployed meeting URL and joins a meeting from a WKWebview. This needs to run after the deploy step, since we need to utilize the newly deployed meeting url.

**Testing**

1. Have you successfully run `npm run build:release` locally? This is a github action change
2. How did you test these changes? github actions were tested with the pull_request trigger first, then removed once verified that it worked.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? WKWebview demo is being used.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

