### PR TITLE
Bump maxVideos limit to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump maxVideos limit to 25
+
 ### Removed
 
 ### Fixed

--- a/src/task/JoinAndReceiveIndexTask.ts
+++ b/src/task/JoinAndReceiveIndexTask.ts
@@ -21,7 +21,7 @@ import BaseTask from './BaseTask';
 export default class JoinAndReceiveIndexTask extends BaseTask {
   protected taskName = 'JoinAndReceiveIndexTask';
   private taskCanceler: TaskCanceler | null = null;
-  private maxVideos = 16;
+  private maxVideos = 25;
 
   constructor(private context: AudioVideoControllerState) {
     super(context.logger);


### PR DESCRIPTION
**Description of changes:**
Bump maxVideos limit from 16 to 25
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? npm run build:release
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? This change will require a demo change to verify (to be able to render 25 video tiles). We will deploy a modified demo app for testing.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

