### PR TITLE
Fix choosing input device API when passing in a media stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pre-started signaling connections no longer cause a delay in joining if the
   user takes more than a minute to join the meeting.
+- Fix choosing input device API when passing in a media stream.
 
 ## [2.11.0] - 2021-06-04
 

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1664">src/devicecontroller/DefaultDeviceController.ts:1664</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1686">src/devicecontroller/DefaultDeviceController.ts:1686</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1773">src/devicecontroller/DefaultDeviceController.ts:1773</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1795">src/devicecontroller/DefaultDeviceController.ts:1795</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -756,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1759">src/devicecontroller/DefaultDeviceController.ts:1759</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1781">src/devicecontroller/DefaultDeviceController.ts:1781</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -800,7 +800,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1809">src/devicecontroller/DefaultDeviceController.ts:1809</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1831">src/devicecontroller/DefaultDeviceController.ts:1831</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -1163,6 +1163,28 @@ export default class DefaultDeviceController
     return device && device.id ? device : null;
   }
 
+  private hasSameMediaStreamId(
+    kind: string,
+    selection: DeviceSelection,
+    proposedConstraints: MediaStreamConstraints
+  ): boolean {
+    // Checking for stream using the fake constraint created in calculateMediaStreamConstraints
+    let streamId;
+    if (kind === 'audio') {
+      // @ts-ignore
+      streamId = proposedConstraints?.audio.streamId;
+      /* istanbul ignore next */
+      // @ts-ignore
+      return !!streamId && streamId === selection.constraints?.audio?.streamId;
+    }
+    /* istanbul ignore next */
+    // @ts-ignore
+    streamId = proposedConstraints?.video.streamId;
+    /* istanbul ignore next */
+    // @ts-ignore
+    return !!streamId && streamId === selection.constraints?.video?.streamId;
+  }
+
   private hasSameGroupId(groupId: string, kind: string, device: Device): boolean {
     if (groupId === '') {
       return true;
@@ -1327,8 +1349,8 @@ export default class DefaultDeviceController
     if (
       selection &&
       selection.stream.active &&
-      selection.groupId !== null &&
-      this.hasSameGroupId(selection.groupId, kind, device)
+      (this.hasSameMediaStreamId(kind, selection, proposedConstraints) ||
+        (selection.groupId !== null && this.hasSameGroupId(selection.groupId, kind, device)))
     ) {
       // TODO: this should be computed within this function.
       this.logger.debug(

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -1040,6 +1040,25 @@ describe('DefaultDeviceController', () => {
       expect(spy.calledTwice).to.be.true;
     });
 
+    it('Can chooseAudioInputDevice if pass in media stream', async () => {
+      class TestAudioVideoController extends NoOpAudioVideoController {
+        async restartLocalAudio(_callback: () => void): Promise<void> {
+          await deviceController.acquireAudioInputStream();
+        }
+      }
+      const mockAudioStream = getMediaStreamDevice('sample');
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      // @ts-ignore
+      const spy = sinon.spy(deviceController, 'chooseInputIntrinsicDevice');
+      try {
+        deviceController.bindToAudioVideoController(new TestAudioVideoController());
+        await deviceController.chooseAudioInputDevice(mockAudioStream);
+      } catch (e) {
+        throw new Error('This line should not be reached.');
+      }
+      expect(spy.calledTwice).to.be.true;
+    });
+
     it('sets to null device when an external device disconnects', async () => {
       enableWebAudio(true);
       try {
@@ -1382,10 +1401,12 @@ describe('DefaultDeviceController', () => {
     });
 
     it('chooses the device as a media stream', async () => {
+      const spy = sinon.spy(navigator.mediaDevices, 'getUserMedia');
       const device: VideoInputDevice = getMediaStreamDevice('device-id');
       await deviceController.chooseVideoInputDevice(device);
       const stream = await deviceController.acquireVideoInputStream();
       expect(stream).to.equal(device);
+      expect(spy.notCalled).to.be.true;
     });
 
     it('releases an old stream', async () => {


### PR DESCRIPTION
**Issue #1357:**

**Description of changes:**
Previously, passing in a media stream to `choose<Audio/Video>InputDevice` would not work:
- for audio input, it can result in infinite loop.
- for video input, once you start local video, it can result in a different media stream.

The issue is with the current logic in `matchesDeviceSelection` only consider deviceId and not media stream. Thus, it always fails for media stream.
Update the logic to compare the streamId.
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
- Add a unit test
- In meeting demo, join in a meeting and open developer console.
- Using the commands to verify that you get the correct camera:
```
// Assume you have 2 cameras
devices = await app.audioVideo.listVideoInputDevices();
const stream = await navigator.mediaDevices.getUserMedia({ video: { deviceId: { exact: devices[1].deviceId }}});
await app.audioVideo.chooseVideoInputDevice(stream);
app.audioVideo.startLocalVideoTile();
// Verify that you get the correct camera
```
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No, you would need to use developer console as the current meeting demo does not allow to select media stream.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

