### PR TITLE
Add documention for signal strength and getObservableVideoMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Documentation] Add documentation for `getObservableVideoMetrics` and signal strength.
 
 ### Changed
 

--- a/docs/modules/apioverview.html
+++ b/docs/modules/apioverview.html
@@ -212,6 +212,15 @@
 					</a>
 					<p>To show speaker volume, mute state, and signal strength for each attendee, subscribe to volume indicators for each attendee ID. You should subscribe and unsubscribe to attendee volume indicators as part of the attendee ID presence callback.</p>
 					<p>Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on a scale of 0 to 1 (full packet loss to no packet loss). You can use the signal strength of remote attendees to show an indication of whether an attendee is experiencing packet loss and thus may be unable to communicate at the moment.</p>
+					<p>Signal strength</p>
+					<ul>
+						<li>0 - 100% loss of audio data</li>
+						<li>&lt; 0.5 - Between 50% to 100% loss of audio data</li>
+						<li><blockquote>
+								<p>= 0.5 - Less than 50% loss of audio data</p>
+							</blockquote>
+						</li>
+					</ul>
 					<p>To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator(attendeeId, callback)</a>.</p>
 					<p>To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator(attendeeId)</a>.</p>
 					<a href="#5c-signal-strength-change-optional" id="5c-signal-strength-change-optional" style="color: inherit; text-decoration: none;">

--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -223,6 +223,29 @@
 						<h3>Does the SDK support remote mute where one attendee can mute another?</h3>
 					</a>
 					<p>Remote mute is the ability of one attendee in a meeting to mute another attendee. This feature is currently not supported server-side by the SDK. However, you can use <a href="https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html#9-send-and-receive-data-messages-optional">Amazon Chime SDK Data Messages</a> to send a message containing the attendee or attendees that should mute, and clients can mute themselves when they receive those messages.</p>
+					<a href="#how-do-i-get-connection-indicator-for-media-quality" id="how-do-i-get-connection-indicator-for-media-quality" style="color: inherit; text-decoration: none;">
+						<h3>How do I get connection indicator for media quality?</h3>
+					</a>
+					<p>The <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/clientmetricreport.html#getobservablevideometrics">getObservableVideoMetrics</a> API exposes video quality statistics. The <code>getObservableVideoMetrics</code> API returns following metrics:</p>
+					<pre><code>// Upstream metrics of local attendee
+<span class="hljs-built_in">videoUpstreamBitrate,</span>
+<span class="hljs-built_in">videoUpstreamPacketsSent,</span>
+<span class="hljs-built_in">videoUpstreamFramesEncodedPerSecond,</span>
+<span class="hljs-built_in">videoUpstreamGoogFrameHeight,</span> (for chromium based browsers)
+<span class="hljs-built_in">videoUpstreamGoogFrameWidth,</span>(for chromium based browsers)
+<span class="hljs-built_in">videoUpstreamFrameHeight,</span>
+<span class="hljs-built_in">videoUpstreamFrameWidth,</span>
+
+// Downstream metrics of remote attendees
+videoDownstreamBitrate
+<span class="hljs-built_in">videoDownstreamPacketLossPercent,</span>
+<span class="hljs-built_in">videoDownstreamFramesDecodedPerSecond,</span>
+<span class="hljs-built_in">videoDownstreamGoogFrameHeight,</span>
+<span class="hljs-built_in">videoDownstreamGoogFrameWidth,</span>
+<span class="hljs-built_in">videoDownstreamFrameHeight,</span>
+<span class="hljs-built_in">videoDownstreamFrameWidth,</span>
+</code></pre>
+					<p>See this <a href="https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html">guide</a> for more information.</p>
 					<a href="#demos" id="demos" style="color: inherit; text-decoration: none;">
 						<h2>Demos</h2>
 					</a>

--- a/docs/modules/qualitybandwidth_connectivity.html
+++ b/docs/modules/qualitybandwidth_connectivity.html
@@ -194,11 +194,11 @@
 							</tr>
 					</tbody></table>
 					<blockquote>
-						<p>Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled. This is currently only implemented for Chrome.</p>
+						<p>Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled.</p>
 						<p>You get the following WebRTC stats in the video stats widget:</p>
-						<p>Upstream video information: Resolution, Bitrate (kbps), Packets Sent, Frame Rate (fps).</p>
-						<p>Downstream video information: Resolution, Bitrate (kbps), Packet Loss (%), Frame Rate (fps).</p>
-						<p>You can check the implementation in the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts">demo app</a> to build your own custom widget (look for <code>getAndShowWebRTCStats</code> method in the demo). This video stats widget is built using the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideocontroller.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a> and the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L76">metricsDidReceive</a> APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.</p>
+						<p>Upstream video information: Frame height, Frame width, Bitrate (bps), Packets Sent, Frame Rate (fps).</p>
+						<p>Downstream video information: Frame height, Frame width, Bitrate (bps), Packet Loss (%), Frame Rate (fps).</p>
+						<p>You can check the implementation in the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts">demo app</a> to build your own custom widget (look for <code>getObservableVideoMetrics</code> method in the demo). This video stats widget is built using the <a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/clientmetricreport.html#getobservablevideometrics">getObservableVideoMetrics</a> and the <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideoobserver/AudioVideoObserver.ts#L76">metricsDidReceive</a> APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.</p>
 					</blockquote>
 					<a href="#events-for-monitoring-currently-active-simulast-layers" id="events-for-monitoring-currently-active-simulast-layers" style="color: inherit; text-decoration: none;">
 						<h3>Events for monitoring currently active simulast layers</h3>

--- a/guides/03_API_Overview.md
+++ b/guides/03_API_Overview.md
@@ -174,6 +174,11 @@ To show speaker volume, mute state, and signal strength for each attendee, subsc
 
 Volume is on a scale of 0 to 1 (no volume to max volume). Signal strength is on a scale of 0 to 1 (full packet loss to no packet loss). You can use the signal strength of remote attendees to show an indication of whether an attendee is experiencing packet loss and thus may be unable to communicate at the moment.
 
+Signal strength
+* 0 - 100% loss of audio data
+* < 0.5 - Between 50% to 100% loss of audio data
+* >= 0.5 - Less than 50% loss of audio data
+
 To subscribe to an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeSubscribeToVolumeIndicator(attendeeId, callback)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator).
 
 To unsubscribe from an attendee’s volume indicator, call meetingSession.audioVideo.[realtimeUnsubscribeFromVolumeIndicator(attendeeId)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator).

--- a/guides/04_Quality_Bandwidth_Connectivity.md
+++ b/guides/04_Quality_Bandwidth_Connectivity.md
@@ -55,15 +55,15 @@ The Amazon Chime SDK for JavaScript produces several kinds of events on the [Aud
 |------------ | ------------- | ------------- |
 |[metricsDidReceive](https://github.com/aws/amazon-chime-sdk-js/blob/bf6d01e236445684601e24f3e319dede728b5113/src/audiovideoobserver/AudioVideoObserver.ts#L76) | Exposes the WebRTC getStats metrics. There may be differences among browsers as to which metrics are reported. | All |
 
-> Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled. This is currently only implemented for Chrome.
+> Note: We have built a video WebRTC statistics widget in the demo browser meeting app. This widget is shown as an overlay on the video, when the video is enabled.
 >
 > You get the following WebRTC stats in the video stats widget:
 >
-> Upstream video information: Resolution, Bitrate (kbps), Packets Sent, Frame Rate (fps).
+> Upstream video information: Frame height, Frame width, Bitrate (bps), Packets Sent, Frame Rate (fps).
 >
-> Downstream video information: Resolution, Bitrate (kbps), Packet Loss (%), Frame Rate (fps).
+> Downstream video information: Frame height, Frame width, Bitrate (bps), Packet Loss (%), Frame Rate (fps).
 >
-> You can check the implementation in the [demo app](https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts) to build your own custom widget (look for `getAndShowWebRTCStats` method in the demo). This video stats widget is built using the [getRTCPeerConnectionStats](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideocontroller.html#getrtcpeerconnectionstats) and the [metricsDidReceive](https://github.com/aws/amazon-chime-sdk-js/blob/bf6d01e236445684601e24f3e319dede728b5113/src/audiovideoobserver/AudioVideoObserver.ts#L76) APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.
+> You can check the implementation in the [demo app](https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/app/meetingV2/meetingV2.ts) to build your own custom widget (look for `getObservableVideoMetrics` method in the demo). This video stats widget is built using the [getObservableVideoMetrics](https://aws.github.io/amazon-chime-sdk-js/interfaces/clientmetricreport.html#getobservablevideometrics) and the [metricsDidReceive](https://github.com/aws/amazon-chime-sdk-js/blob/bf6d01e236445684601e24f3e319dede728b5113/src/audiovideoobserver/AudioVideoObserver.ts#L76) APIs. Through the information provided in these stats, the application can monitor key attributes and take action. For instance if the bitrate or resolution falls below a certain threshold, the user could be notified in some manner, or diagnostic reporting could take place.
 
 
 ### Events for monitoring currently active simulast layers

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -164,6 +164,30 @@ Amazon Chime SDK supports simulcast for Chromium-based browsers. See this [techn
 
 Remote mute is the ability of one attendee in a meeting to mute another attendee. This feature is currently not supported server-side by the SDK. However, you can use [Amazon Chime SDK Data Messages](https://aws.github.io/amazon-chime-sdk-js/modules/apioverview.html#9-send-and-receive-data-messages-optional) to send a message containing the attendee or attendees that should mute, and clients can mute themselves when they receive those messages.
 
+### How do I get connection indicator for media quality?
+
+The [getObservableVideoMetrics](https://aws.github.io/amazon-chime-sdk-js/interfaces/clientmetricreport.html#getobservablevideometrics) API exposes video quality statistics. The `getObservableVideoMetrics` API returns following metrics:
+```
+// Upstream metrics of local attendee
+videoUpstreamBitrate,
+videoUpstreamPacketsSent,
+videoUpstreamFramesEncodedPerSecond,
+videoUpstreamGoogFrameHeight, (for chromium based browsers)
+videoUpstreamGoogFrameWidth,(for chromium based browsers)
+videoUpstreamFrameHeight,
+videoUpstreamFrameWidth,
+
+// Downstream metrics of remote attendees
+videoDownstreamBitrate
+videoDownstreamPacketLossPercent,
+videoDownstreamFramesDecodedPerSecond,
+videoDownstreamGoogFrameHeight,
+videoDownstreamGoogFrameWidth,
+videoDownstreamFrameHeight,
+videoDownstreamFrameWidth,
+```
+See this [guide](https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html) for more information. 
+
 ## Demos
 
 ### I want to build a React application that uses the Amazon Chime SDK. Do you have a sample application that I can reference?


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/1322
**Description of changes:**
Add documentation for signal strength values.
Add documentation for video quality indicators.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/a


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

