### PR TITLE
Update setting media region to handle beta stage for meeting readiness checker

### DIFF
--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -608,8 +608,16 @@ export class DemoMeetingApp {
   setMediaRegion(): void {
     new AsyncScheduler().start(
       async (): Promise<void> => {
+        let nearestMediaRegion = null;
         try {
-          const nearestMediaRegion = await this.getNearestMediaRegion();
+          const query = new URLSearchParams(document.location.search);
+          const stage = query.get('stage');
+          if (stage === 'beta') {
+            const regions = ['us-east-1', 'ap-south-1', 'us-west-2'];
+            nearestMediaRegion = regions[Math.floor(Math.random()*regions.length)];
+          } else {
+          nearestMediaRegion = await this.getNearestMediaRegion();
+          }
           if (nearestMediaRegion === '' || nearestMediaRegion === null) {
             throw new Error('Nearest Media Region cannot be null or empty');
           }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Update setting media region to handle beta stage for meeting readiness checker  app.  Add a query param support for selecting region according to stage.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
   Deployed the browser meeting readiness checker app. Appended query param ?stage=beta and tested whether the region is selected correctly and meeting could be joined successfully.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Meeting readiness checker app
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No, just demo change.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

