### PR TITLE
[Demo] Handle 'region' query param in demo

### DIFF
--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -609,7 +609,9 @@ export class DemoMeetingApp {
     new AsyncScheduler().start(
       async (): Promise<void> => {
         try {
-          const nearestMediaRegion = await this.getNearestMediaRegion();
+          const query = new URLSearchParams(document.location.search);
+          const region = query.get('region');
+          const nearestMediaRegion = region ? region : await this.getNearestMediaRegion();
           if (nearestMediaRegion === '' || nearestMediaRegion === null) {
             throw new Error('Nearest Media Region cannot be null or empty');
           }

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -995,16 +995,10 @@ export class DemoMeetingApp
   setMediaRegion(): void {
     AsyncScheduler.nextTick(
       async (): Promise<void> => {
-        let nearestMediaRegion = null;
         try {
           const query = new URLSearchParams(document.location.search);
-          const stage = query.get('stage');
-          if (stage === 'beta') {
-            const regions = ['us-east-1', 'ap-south-1', 'us-west-2'];
-            nearestMediaRegion = regions[Math.floor(Math.random()*regions.length)];
-          } else {
-            nearestMediaRegion = await this.getNearestMediaRegion();
-          }
+          const region = query.get('region');
+          const nearestMediaRegion = region ? region : await this.getNearestMediaRegion();
           if (nearestMediaRegion === '' || nearestMediaRegion === null) {
             throw new Error('Nearest Media Region cannot be null or empty');
           }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Add ability in demo to select the region when passed as a query parameter to meetingV2 and readiness demo apps.

**Testing**

1. Have you successfully run `npm run build:release` locally? Demo change only.
2. How did you test these changes?
- Run the meetingV2 and readiness checker demo app by adding ?region=us-east-1 and check whether the selected region in app is us-east-1.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? meetingV2 browser demo app and meeting readiness checker demo app.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

