### PR TITLE
Add how-to instruction for view-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add events ingestion to report meeting events to Amazon Chime backend.
   Check [Client Event Ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clienteventingestion.html) for more information.
+- [Documentation] Add documentation for view-only mode.
 
 ### Changed
 
 ### Removed
 
 ### Fixed
-
 
 ## [2.12.0] - 2021-06-23
 
@@ -26,8 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Documentation] Add documentation for `getObservableVideoMetrics`.
 - [Documentation] Update FAQ and public documentation to add more information on SignalingBadRequest related error codes.
 - [Documentation] Rephrase the terms in the status code documentations.
-- Add events ingestion to report meeting events to Amazon Chime backend.
-  Check [Client Event Ingestion guide](https://aws.github.io/amazon-chime-sdk-js/modules/clienteventingestion.html) for more information.
 
 ### Changed
 
@@ -44,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.11.0] - 2021-06-04
 
 ### Added
+
 - Bind tileController during the initialization of DefaultAudioVideoController for VideoPriorityBasedPolicy.
 - Add more debug logging for choose input device. 
 - Add the meeting and device error sections in the meeting-event guide.
@@ -63,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove deprecated unwired webrtc constraints from device controller and peer connection construction.
 - Removed unnecessary restriction on VideoPriorityBasedPolicy to always subscribe to at least one stream.
+
 ### Fixed
 
 - Fixed missing upstream video metrics for Firefox browsers.

--- a/docs/modules/apioverview.html
+++ b/docs/modules/apioverview.html
@@ -111,6 +111,43 @@
 					</a>
 					<p>When obtaining devices to configure, the browser may initially decline to provide device labels due to privacy restrictions. However, without device labels the application user will not be able to select devices by name. When no labels are present, the device-label trigger is run. The default implementation of the device-label trigger requests permission to the mic and camera. If the user grants permission, the device labels will become available.</p>
 					<p>You can override the behavior of the device-label trigger by calling meetingSession.audioVideo.<a href="https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger">setDeviceLabelTrigger(trigger)</a>.</p>
+					<a href="#implement-a-view-onlyobserverspectator-experience" id="implement-a-view-onlyobserverspectator-experience" style="color: inherit; text-decoration: none;">
+						<h4>Implement a view-only/observer/spectator experience</h4>
+					</a>
+					<p>To enable a view-only experience, you need to control the device permission prompts for audio and video. We suggest that you implement it based on <code>deviceLabelsTrigger</code>. By following this, you can achieve it with just little changes.</p>
+					<p>Note: The view-only mode doesn&#39;t impact the ability to view content or listen to audio in your meeting experience.</p>
+					<p>To suppress device permission prompts, let <code>deviceLabelTrigger</code> return an empty <code>MediaStream</code> before joining the meeting. Since it&#39;s an empty stream, the device permission prompts can&#39;t be triggered.</p>
+					<p>Note: Chrome and Safari don&#39;t expose the <code>deviceId</code> without granting device permission, but Firefox do. In Firefox, if you try to select the device with <code>deviceId</code>, the device permission prompts will be triggered.</p>
+					<p>To invoke device permission prompts, let <code>deviceLabelTrigger</code> return a <code>MediaStream</code> that contains your desired device kind. You can trigger it to grant device permission to the browser. After that, list and select the devices to regain the access to devices.</p>
+					<pre><code class="language-js"><span class="hljs-comment">// Suppress devices</span>
+audioVideo.setDeviceLabelTrigger(<span class="hljs-function">() =&gt;</span> <span class="hljs-built_in">Promise</span>.resolve(<span class="hljs-keyword">new</span> MediaStream()));
+
+audioVideo.start();
+
+<span class="hljs-comment">// Invoke devices</span>
+audioVideo.setDeviceLabelTrigger(<span class="hljs-keyword">async</span> () =&gt;
+  <span class="hljs-keyword">await</span> navigator.mediaDevices.getUserMedia({ <span class="hljs-attr">audio</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">video</span>: <span class="hljs-literal">true</span> })
+);
+<span class="hljs-keyword">const</span> audioInputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listAudioInputDevices();
+<span class="hljs-keyword">const</span> audioOutputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listAudioOutputDevices();
+<span class="hljs-keyword">const</span> videoInputDevices = <span class="hljs-keyword">await</span> meetingSession.audioVideo.listVideoInputDevices();
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioInputDevice(audioInputDevice.deviceId);
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDevice.deviceId);
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseVideoInputDevice(videoInputDevices.deviceId);
+</code></pre>
+					<a href="#safari-user-are-not-able-to-join-the-meeting-in-view-only-mode" id="safari-user-are-not-able-to-join-the-meeting-in-view-only-mode" style="color: inherit; text-decoration: none;">
+						<h4>Safari user are not able to join the meeting in view-only mode</h4>
+					</a>
+					<p>Safari users may not be able to successfully join the meeting in view-only mode, due to this known issue <a href="https://github.com/aws/amazon-chime-sdk-js/issues/474">#474</a>. Since we are still working on this, you can fix it locally by allowing Safari&#39;s Autoplay. The specific steps are:</p>
+					<ol>
+						<li>Open your application in the Safari app on your Mac.</li>
+						<li>Choose Safari &gt; Settings for This Website.
+						You can also Control-click in the Smart Search field, then choose Settings for This Website.</li>
+						<li>Hold the pointer to the right of Auto-Play, then click the pop-up menu and choose the option:<ul>
+								<li>Allow All Auto-Play: Lets videos on this website play automatically.</li>
+							</ul>
+						</li>
+					</ol>
 					<a href="#2b-register-a-device-change-observer-optional" id="2b-register-a-device-change-observer-optional" style="color: inherit; text-decoration: none;">
 						<h3>2b. Register a device-change observer (optional)</h3>
 					</a>

--- a/guides/03_API_Overview.md
+++ b/guides/03_API_Overview.md
@@ -48,6 +48,46 @@ When obtaining devices to configure, the browser may initially decline to provid
 
 You can override the behavior of the device-label trigger by calling meetingSession.audioVideo.[setDeviceLabelTrigger(trigger)](https://aws.github.io/amazon-chime-sdk-js/interfaces/audiovideofacade.html#setdevicelabeltrigger).
 
+#### Implement a view-only/observer/spectator experience
+
+To enable a view-only experience, you need to control the device permission prompts for audio and video. We suggest that you implement it based on `deviceLabelsTrigger`. By following this, you can achieve it with just little changes.
+
+Note: The view-only mode doesn't impact the ability to view content or listen to audio in your meeting experience.
+
+To suppress device permission prompts, let `deviceLabelTrigger` return an empty `MediaStream` before joining the meeting. Since it's an empty stream, the device permission prompts can't be triggered.
+
+Note: Chrome and Safari don't expose the `deviceId` without granting device permission, but Firefox do. In Firefox, if you try to select the device with `deviceId`, the device permission prompts will be triggered.
+
+To invoke device permission prompts, let `deviceLabelTrigger` return a `MediaStream` that contains your desired device kind. You can trigger it to grant device permission to the browser. After that, list and select the devices to regain the access to devices.
+
+```js
+// Suppress devices
+audioVideo.setDeviceLabelTrigger(() => Promise.resolve(new MediaStream()));
+
+audioVideo.start();
+
+// Invoke devices
+audioVideo.setDeviceLabelTrigger(async () => 
+  await navigator.mediaDevices.getUserMedia({ audio: true, video: true })
+);
+const audioInputDevices = await meetingSession.audioVideo.listAudioInputDevices();
+const audioOutputDevices = await meetingSession.audioVideo.listAudioOutputDevices();
+const videoInputDevices = await meetingSession.audioVideo.listVideoInputDevices();
+await meetingSession.audioVideo.chooseAudioInputDevice(audioInputDevice.deviceId);
+await meetingSession.audioVideo.chooseAudioOutputDevice(audioOutputDevice.deviceId);
+await meetingSession.audioVideo.chooseVideoInputDevice(videoInputDevices.deviceId);
+```
+
+#### Safari user are not able to join the meeting in view-only mode
+
+Safari users may not be able to successfully join the meeting in view-only mode, due to this known issue [#474](https://github.com/aws/amazon-chime-sdk-js/issues/474). Since we are still working on this, you can fix it locally by allowing Safari's Autoplay. The specific steps are:
+
+1. Open your application in the Safari app on your Mac.
+2. Choose Safari > Settings for This Website.
+  You can also Control-click in the Smart Search field, then choose Settings for This Website.
+3. Hold the pointer to the right of Auto-Play, then click the pop-up menu and choose the option:
+    * Allow All Auto-Play: Lets videos on this website play automatically.
+
 ### 2b. Register a device-change observer (optional)
 
 You can receive events about changes to available devices by implementing a [DeviceChangeObserver](https://aws.github.io/amazon-chime-sdk-js/interfaces/devicechangeobserver.html) and registering the observer with the device controller.


### PR DESCRIPTION
**Issue #:**
Need to add how-to doc for view-only mode.

**Description of changes:**
Add how-to instruction for view-only mode.

**Testing**
1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes? 
N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

