### PR TITLE
Instantiate event reporting in demo to pass POST logger in DEBUG mode

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1444,37 +1444,36 @@ export class DemoMeetingApp
     if (!ingestionURL) {
       return eventReporter;
     }
-    if (this.enableEventReporting) {
-      const eventReportingLogger = new ConsoleLogger('SDKEventIngestion', LogLevel.INFO);
-      const meetingEventClientConfig = new MeetingEventsClientConfiguration(
-        configuration.meetingId,
-        configuration.credentials.attendeeId,
-        configuration.credentials.joinToken
-      );
-      const eventIngestionConfiguration = new EventIngestionConfiguration(
-        meetingEventClientConfig,
-        ingestionURL
-      );
-      if (this.isLocalHost()) {
-        eventReporter = new DefaultMeetingEventReporter(eventIngestionConfiguration, eventReportingLogger);
-      } else {
-        await this.createLogStream(configuration, 'create_browser_event_ingestion_log_stream');
-        const eventReportingPOSTLogger = new MeetingSessionPOSTLogger(
-          'SDKEventIngestion',
-          configuration,
-          DemoMeetingApp.LOGGER_BATCH_SIZE,
-          DemoMeetingApp.LOGGER_INTERVAL_MS,
-          `${DemoMeetingApp.BASE_URL}log_event_ingestion`,
-          LogLevel.DEBUG
-        );
-        const multiEventReportingLogger = new MultiLogger(
-          eventReportingLogger,
-          eventReportingPOSTLogger,
-        );
-        eventReporter = new DefaultMeetingEventReporter(eventIngestionConfiguration, multiEventReportingLogger);
-      }
+    if (!this.enableEventReporting) {
+      return new NoOpEventReporter();
+    }
+    const eventReportingLogger = new ConsoleLogger('SDKEventIngestion', LogLevel.INFO);
+    const meetingEventClientConfig = new MeetingEventsClientConfiguration(
+      configuration.meetingId,
+      configuration.credentials.attendeeId,
+      configuration.credentials.joinToken
+    );
+    const eventIngestionConfiguration = new EventIngestionConfiguration(
+      meetingEventClientConfig,
+      ingestionURL
+    );
+    if (this.isLocalHost()) {
+      eventReporter = new DefaultMeetingEventReporter(eventIngestionConfiguration, eventReportingLogger);
     } else {
-      eventReporter = new NoOpEventReporter();
+      await this.createLogStream(configuration, 'create_browser_event_ingestion_log_stream');
+      const eventReportingPOSTLogger = new MeetingSessionPOSTLogger(
+        'SDKEventIngestion',
+        configuration,
+        DemoMeetingApp.LOGGER_BATCH_SIZE,
+        DemoMeetingApp.LOGGER_INTERVAL_MS,
+        `${DemoMeetingApp.BASE_URL}log_event_ingestion`,
+        LogLevel.DEBUG
+      );
+      const multiEventReportingLogger = new MultiLogger(
+        eventReportingLogger,
+        eventReportingPOSTLogger,
+      );
+      eventReporter = new DefaultMeetingEventReporter(eventIngestionConfiguration, multiEventReportingLogger);
     }
     return eventReporter;
   }

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -153,12 +153,10 @@ exports.log_event_ingestion = async (event, context) => {
     for (let i = 0; i < logs.length; i++) {
       const log = logs[i];
       const message = `[${log.logLevel}] [meeting: ${meetingId}] [attendee: ${attendeeId}]: ${log.message}`;
-      if (message.includes('Event Reporting')) {
-        logEvents.push({
-          message,
-          timestamp: log.timestampMs
-        });
-      }
+      logEvents.push({
+        message,
+        timestamp: log.timestampMs
+      });
     }
     return logEvents;
   });


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Currently, the meeting session is created a POST logger in DEBUG mode,
hence all debug logs will make a POST request with the POST logger.
The filtering whether the debug log is related to event reporting was
handled in serverless handler. Instead, setup the event reporter in demo
to pass the POST logger just for it and not the entire meeting session.
This avoids POST request throttling with so many debug log requests.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Deployed the demo app and tested if only event reporting logs are getting posted to the log group and not all. 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? The browser meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

