### PR TITLE
Remove unused meeting session status codes from the meeting event gui…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- Improve the meeting event guide
+
 ## [2.13.0] - 2021-06-29
 
 ### Added

--- a/docs/enums/meetingsessionstatuscode.html
+++ b/docs/enums/meetingsessionstatuscode.html
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Attendee<wbr>Removed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 24</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L155">src/meetingsession/MeetingSessionStatusCode.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L157">src/meetingsession/MeetingSessionStatusCode.ts:157</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">Audio<wbr>Device<wbr>Switched<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 20</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L135">src/meetingsession/MeetingSessionStatusCode.ts:135</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L137">src/meetingsession/MeetingSessionStatusCode.ts:137</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">Connection<wbr>Health<wbr>Reconnect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 17</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L119">src/meetingsession/MeetingSessionStatusCode.ts:119</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L121">src/meetingsession/MeetingSessionStatusCode.ts:121</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 					<div class="tsd-signature tsd-kind-icon">ICEGathering<wbr>Timeout<wbr>Workaround<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 16</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L114">src/meetingsession/MeetingSessionStatusCode.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L116">src/meetingsession/MeetingSessionStatusCode.ts:116</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 					<div class="tsd-signature tsd-kind-icon">IncompatibleSDP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 21</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L140">src/meetingsession/MeetingSessionStatusCode.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L142">src/meetingsession/MeetingSessionStatusCode.ts:142</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 					<div class="tsd-signature tsd-kind-icon">No<wbr>Attendee<wbr>Present<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 23</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L150">src/meetingsession/MeetingSessionStatusCode.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L152">src/meetingsession/MeetingSessionStatusCode.ts:152</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -374,7 +374,7 @@
 					<div class="tsd-signature tsd-kind-icon">Realtime<wbr>Api<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 18</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L124">src/meetingsession/MeetingSessionStatusCode.ts:124</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L126">src/meetingsession/MeetingSessionStatusCode.ts:126</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -389,14 +389,16 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Bad<wbr>Request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 12</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L89">src/meetingsession/MeetingSessionStatusCode.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L91">src/meetingsession/MeetingSessionStatusCode.ts:91</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
 							<p>The Chime SDK for JavaScript failed to establish a signaling connection because
 								you or someone else deleted the attendee using the DeleteAttendee API action
-								in your server application.
+								in your server application. You also should not use the attendee response from
+								the ended meeting that you created with the same ClientRequestToken parameter
+								before.
 							<a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteAttendee.html">https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteAttendee.html</a></p>
 						</div>
 					</div>
@@ -407,7 +409,7 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Internal<wbr>Server<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 13</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L95">src/meetingsession/MeetingSessionStatusCode.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L97">src/meetingsession/MeetingSessionStatusCode.ts:97</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -423,7 +425,7 @@
 					<div class="tsd-signature tsd-kind-icon">Signaling<wbr>Request<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 14</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L100">src/meetingsession/MeetingSessionStatusCode.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L102">src/meetingsession/MeetingSessionStatusCode.ts:102</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -438,7 +440,7 @@
 					<div class="tsd-signature tsd-kind-icon">State<wbr>Machine<wbr>Transition<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L106">src/meetingsession/MeetingSessionStatusCode.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L108">src/meetingsession/MeetingSessionStatusCode.ts:108</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -454,7 +456,7 @@
 					<div class="tsd-signature tsd-kind-icon">TURNCredentials<wbr>Forbidden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 22</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L145">src/meetingsession/MeetingSessionStatusCode.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L147">src/meetingsession/MeetingSessionStatusCode.ts:147</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -485,7 +487,7 @@
 					<div class="tsd-signature tsd-kind-icon">Task<wbr>Failed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 19</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L129">src/meetingsession/MeetingSessionStatusCode.ts:129</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/meetingsession/MeetingSessionStatusCode.ts#L131">src/meetingsession/MeetingSessionStatusCode.ts:131</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/meetingevents.html
+++ b/docs/modules/meetingevents.html
@@ -137,6 +137,7 @@ meetingSession.audioVideo.addObserver(observer);
   }
 }
 </code></pre>
+					<br>
 					<a href="#meeting-events-and-attributes" id="meeting-events-and-attributes" style="color: inherit; text-decoration: none;">
 						<h2>Meeting events and attributes</h2>
 					</a>
@@ -158,7 +159,7 @@ meetingSession.audioVideo.addObserver(observer);
 							</tr>
 							<tr>
 								<td><code>meetingStartFailed</code></td>
-								<td>The meeting failed to start.</td>
+								<td>The meeting failed to start due to the following failure <a href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html">MeetingSessionStatusCode</a>: <br><ul><li><code>AudioCallAtCapacity</code></li><li><code>MeetingEnded</code></li><li><code>SignalingBadRequest</code></li><li><code>TaskFailed</code></li></ul>For more information, see the <a href="#meeting-error-messages">&quot;Meeting error messages&quot; section</a>.</td>
 							</tr>
 							<tr>
 								<td><code>meetingEnded</code></td>
@@ -166,7 +167,7 @@ meetingSession.audioVideo.addObserver(observer);
 							</tr>
 							<tr>
 								<td><code>meetingFailed</code></td>
-								<td>The meeting ended with one of the following failure <a href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html">MeetingSessionStatusCode</a>: <br><ul><li><code>AudioAuthenticationRejected</code></li><li><code>AudioCallAtCapacity</code></li><li><code>AudioDisconnected</code></li><li><code>AudioInternalServerError</code></li><li><code>AudioServiceUnavailable</code></li><li><code>ConnectionHealthReconnect</code></li><li><code>ICEGatheringTimeoutWorkaround</code></li><li><code>NoAttendeePresent</code></li><li><code>RealtimeApiFailed</code></li><li><code>SignalingBadRequest</code></li><li><code>SignalingInternalServerError</code></li><li><code>SignalingRequestFailed</code></li><li><code>StateMachineTransitionFailed</code></li><li><code>TaskFailed</code></li><li><code>VideoCallAtSourceCapacity</code></li></ul></td>
+								<td>The meeting ended with one of the following failure <a href="https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html">MeetingSessionStatusCode</a>: <br><ul><li><code>AudioAttendeeRemoved</code></li><li><code>AudioJoinedFromAnotherDevice</code></li><li><code>RealtimeApiFailed</code></li><li><code>TaskFailed</code></li></ul>For more information, see the <a href="#meeting-error-messages">&quot;Meeting error messages&quot; section</a>.</td>
 							</tr>
 							<tr>
 								<td><code>attendeePresenceReceived</code></td>
@@ -197,6 +198,7 @@ meetingSession.audioVideo.addObserver(observer);
 								<td>The camera selection failed.</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#standard-attributes" id="standard-attributes" style="color: inherit; text-decoration: none;">
 						<h3>Standard attributes</h3>
 					</a>
@@ -238,7 +240,7 @@ meetingSession.audioVideo.addObserver(observer);
 							</tr>
 							<tr>
 								<td><code>meetingHistory</code></td>
-								<td>The list of the meeting-history states. For more information, see the &quot;The meeting history attribute&quot; section.</td>
+								<td>The list of the meeting-history states. For more information, see the <a href="#the-meeting-history-attribute">&quot;The meeting history attribute&quot; section</a>.</td>
 							</tr>
 							<tr>
 								<td><code>meetingId</code></td>
@@ -265,6 +267,7 @@ meetingSession.audioVideo.addObserver(observer);
 								<td>The local time, in milliseconds since 00:00:00 UTC on 1 January 1970, at which an event occurred.<br><br>Unit: Milliseconds</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#meeting-attributes" id="meeting-attributes" style="color: inherit; text-decoration: none;">
 						<h3>Meeting attributes</h3>
 					</a>
@@ -299,7 +302,7 @@ meetingSession.audioVideo.addObserver(observer);
 							</tr>
 							<tr>
 								<td><code>meetingErrorMessage</code></td>
-								<td>The error message that explains why the meeting has failed. For more information, see the &quot;Meeting error messages&quot; section.</td>
+								<td>The error message that explains why the meeting has failed. For more information, see the <a href="#meeting-error-messages">&quot;Meeting error messages&quot; section</a>.</td>
 								<td><code>meetingStartFailed</code>, <code>meetingFailed</code></td>
 							</tr>
 							<tr>
@@ -328,6 +331,7 @@ meetingSession.audioVideo.addObserver(observer);
 								<td><code>meetingStartSucceeded</code>, <code>meetingStartFailed</code>, <code>meetingEnded</code>, <code>meetingFailed</code></td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#device-attributes" id="device-attributes" style="color: inherit; text-decoration: none;">
 						<h3>Device attributes</h3>
 					</a>
@@ -342,15 +346,16 @@ meetingSession.audioVideo.addObserver(observer);
 						</thead>
 						<tbody><tr>
 								<td><code>audioInputErrorMessage</code></td>
-								<td>The error message that explains why the microphone selection failed. For more information, see the &quot;Device error messages&quot; section.</td>
+								<td>The error message that explains why the microphone selection failed. For more information, see the <a href="#device-error-messages">&quot;Device error messages&quot; section</a>.</td>
 								<td><code>audioInputFailed</code></td>
 							</tr>
 							<tr>
 								<td><code>videoInputErrorMessage</code></td>
-								<td>The error message that explains why the camera selection failed. For more information, see the &quot;Device error messages&quot; section.</td>
+								<td>The error message that explains why the camera selection failed. For more information, see the <a href="#device-error-messages">&quot;Device error messages&quot; section</a>.</td>
 								<td><code>videoInputFailed</code></td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#the-meeting-history-attribute" id="the-meeting-history-attribute" style="color: inherit; text-decoration: none;">
 						<h3>The meeting history attribute</h3>
 					</a>
@@ -440,6 +445,7 @@ meetingSession.audioVideo.addObserver(observer);
 								<td>The camera was removed. You called <code>meetingSession.audioVideo.chooseVideoInputDevice</code> with <code>null</code>.</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#meeting-error-messages" id="meeting-error-messages" style="color: inherit; text-decoration: none;">
 						<h3>Meeting error messages</h3>
 					</a>
@@ -455,9 +461,19 @@ meetingSession.audioVideo.addObserver(observer);
 							</tr>
 						</thead>
 						<tbody><tr>
+								<td>The attendee couldn&#39;t join because the meeting was at capacity.</td>
+								<td>AudioCallAtCapacity</td>
+								<td>Ensure that the number of attendees does not exceed the maximum limit (250). See the <a href="https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-limits">Amazon Chime SDK quotas</a>. You can also track the number of attendees in your server application using the <a href="https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-notifications.html">Amazon Chime SDK event notifications</a>.</td>
+							</tr>
+							<tr>
 								<td>The meeting already ended.</td>
 								<td>MeetingEnded</td>
 								<td>Ensure that you or someone else have not deleted a meeting using the <a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html">DeleteMeeting</a> API action in your server application. A meeting also automatically ends after a period of inactivity. See the <a href="https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-mtgs.html">Chime SDK developer guide</a> for details.</td>
+							</tr>
+							<tr>
+								<td>The signaling connection was closed with code (close code) and reason: (reason)</td>
+								<td>SignalingBadRequest</td>
+								<td>Ensure that you do not use the deleted attendee&#39;s response in the <code>DefaultMeetingSession</code> object to start the meeting. You also should not use the attendee response from the ended meeting that you created with the same <code>ClientRequestToken</code> parameter before.</td>
 							</tr>
 							<tr>
 								<td>1. WebSocket connection failed<br>2. OpenSignalingConnectionTask got canceled while waiting to open signaling connection</td>
@@ -470,6 +486,7 @@ meetingSession.audioVideo.addObserver(observer);
 								<td>Ensure that either you do not use your application in split-tunneling scenarios or your application always requests microphone permissions before beginning ICE. See the <a href="https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-cannot-join-meeting-in-firefox-with-no-audio-and-video-permission-due-to-no-ice-candidates-were-gathered-error-is-this-a-known-issue">Chime SDK for JavaScript FAQs</a>.</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<p>The Chime SDK for JavaScript also raises the <code>meetingFailed</code> event containing the <code>meetingErrorMessage</code> attribute if the meeting stops due to an error.
 					The following table lists common error messages from a stopped meeting.</p>
 					<table>
@@ -498,9 +515,10 @@ meetingSession.audioVideo.addObserver(observer);
 							<tr>
 								<td>1. WebSocket connection failed<br>2. OpenSignalingConnectionTask got canceled while waiting to open signaling connection</td>
 								<td>TaskFailed</td>
-								<td>Ensure that you have a stable internet connection. The Chime SDK for JavaScript might fail to reconnect after disconnected from the meeting.</td>
+								<td>Ensure that you have a stable internet connection. You can also follow the <a href="https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html">Quality, Bandwidth, and Connectivity guide</a> to monitor network connectivity and suggest mitigations.</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#device-error-messages" id="device-error-messages" style="color: inherit; text-decoration: none;">
 						<h3>Device error messages</h3>
 					</a>
@@ -521,11 +539,12 @@ meetingSession.audioVideo.addObserver(observer);
 								<td>Ensure that you do not use the media devices in other browser tabs or applications. A hardware error may also occur at the operating system or browser. If the problem persists, restart the browser and try again.</td>
 							</tr>
 					</tbody></table>
+					<br>
 					<a href="#example" id="example" style="color: inherit; text-decoration: none;">
 						<h2>Example</h2>
 					</a>
-					<p><a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless">The Chime SDK serverless demo</a> uses Amazon CloudWatch Logs to collect, process, and analyze meeting events. For more information, see <a href="https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless#meeting-dashboard">the Meeting Dashboard section</a> on the serverless demo page.</p>
-					<p><a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=Meeting%20Events%20feedback">Give feedback on this guide</a></p>
+					<p>Follow the instructions in the <a href="https://aws.amazon.com/blogs/business-productivity/monitoring-and-troubleshooting-with-amazon-chime-sdk-meeting-events">Monitoring and troubleshooting with Amazon Chime SDK meeting events</a> blog post to create your Amazon CloudWatch dashboard.
+					<a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=Meeting%20Events%20feedback">Give feedback on this guide</a></p>
 				</div>
 			</section>
 		</div>

--- a/guides/06_Meeting_Events.md
+++ b/guides/06_Meeting_Events.md
@@ -79,6 +79,8 @@ eventDidReceive(name, attributes) {
 }
 ```
 
+<br>
+
 ## Meeting events and attributes
 
 The Chime SDK for JavaScript sends these meeting events.
@@ -87,9 +89,9 @@ The Chime SDK for JavaScript sends these meeting events.
 |--                    |--
 |`meetingStartRequested` |The meeting will start.
 |`meetingStartSucceeded` |The meeting started.
-|`meetingStartFailed`    |The meeting failed to start.
+|`meetingStartFailed`    |The meeting failed to start due to the following failure [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html): <br><ul><li>`AudioCallAtCapacity`</li><li>`MeetingEnded`</li><li>`SignalingBadRequest`</li><li>`TaskFailed`</li></ul>For more information, see the ["Meeting error messages" section](#meeting-error-messages).
 |`meetingEnded`          |The meeting ended.
-|`meetingFailed`         |The meeting ended with one of the following failure [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html): <br><ul><li>`AudioAuthenticationRejected`</li><li>`AudioCallAtCapacity`</li><li>`AudioDisconnected`</li><li>`AudioInternalServerError`</li><li>`AudioServiceUnavailable`</li><li>`ConnectionHealthReconnect`</li><li>`ICEGatheringTimeoutWorkaround`</li><li>`NoAttendeePresent`</li><li>`RealtimeApiFailed`</li><li>`SignalingBadRequest`</li><li>`SignalingInternalServerError`</li><li>`SignalingRequestFailed`</li><li>`StateMachineTransitionFailed`</li><li>`TaskFailed`</li><li>`VideoCallAtSourceCapacity`</li></ul>
+|`meetingFailed`         |The meeting ended with one of the following failure [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html): <br><ul><li>`AudioAttendeeRemoved`</li><li>`AudioJoinedFromAnotherDevice`</li><li>`RealtimeApiFailed`</li><li>`TaskFailed`</li></ul>For more information, see the ["Meeting error messages" section](#meeting-error-messages).
 |`attendeePresenceReceived`   |The attendee joined the meeting with the microphone.
 |`audioInputSelected`    |The microphone was selected.
 |`audioInputUnselected`  |The microphone was removed. You called `meetingSession.audioVideo.chooseAudioInputDevice` with `null`.
@@ -97,6 +99,8 @@ The Chime SDK for JavaScript sends these meeting events.
 |`videoInputSelected`    |The camera was selected.
 |`videoInputUnselected`  |The camera was removed. You called `meetingSession.audioVideo.chooseVideoInputDevice` with `null`.
 |`videoInputFailed`      |The camera selection failed.
+
+<br>
 
 ### Standard attributes
 
@@ -111,13 +115,15 @@ The Chime SDK for JavaScript sends a meeting event with attributes. These standa
 |`deviceName`|The manufacturer and model name of the computer or mobile device. `Unavailable` indicates that the device name can't be found.
 |`externalMeetingId`|The Amazon Chime SDK external meeting ID.
 |`externalUserId`|The Amazon Chime SDK external user ID that can indicate an identify managed by your application.
-|`meetingHistory`|The list of the meeting-history states. For more information, see the "The meeting history attribute" section.
+|`meetingHistory`|The list of the meeting-history states. For more information, see the ["The meeting history attribute" section](#the-meeting-history-attribute).
 |`meetingId`|The Amazon Chime SDK meeting ID.
 |`osName`|The operating system.
 |`osVersion`|The version of the operating system.
 |`sdkName`|The Amazon Chime SDK name, such as `amazon-chime-sdk-js`.
 |`sdkVersion`|The Amazon Chime SDK version.
 |`timestampMs`|The local time, in milliseconds since 00:00:00 UTC on 1 January 1970, at which an event occurred.<br><br>Unit: Milliseconds
+
+<br>
 
 ### Meeting attributes
 
@@ -129,12 +135,14 @@ The following table describes attributes for a meeting.
 |`iceGatheringDurationMs`|The time taken for connection's ICE gathering state to complete.<br><br>Unit: Milliseconds|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`maxVideoTileCount`|The maximum number of simultaneous video tiles shared during the meeting. This includes a local tile (your video), remote tiles, and content shares.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`meetingDurationMs`|The time that elapsed between the beginning (`AudioVideoObserver.audioVideoDidStart`) and the end (`AudioVideoObserver.audioVideoDidStop`) of the meeting.<br><br>Unit: Milliseconds|`meetingEnded`, `meetingFailed`
-|`meetingErrorMessage`|The error message that explains why the meeting has failed. For more information, see the "Meeting error messages" section. |`meetingStartFailed`, `meetingFailed`
+|`meetingErrorMessage`|The error message that explains why the meeting has failed. For more information, see the ["Meeting error messages" section](#meeting-error-messages). |`meetingStartFailed`, `meetingFailed`
 |`meetingStartDurationMs`|The time that elapsed between the start request `meetingSession.audioVideo.start` and the beginning of the meeting `AudioVideoObserver.audioVideoDidStart`.<br><br>Unit: Milliseconds|`meetingStartSucceeded`, `meetingEnded`, `meetingFailed`
 |`meetingStatus`|The meeting status when the meeting ended or failed. Note that this attribute indicates an enum name in [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-js/enums/meetingsessionstatuscode.html), such as `Left` or `MeetingEnded`.|`meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`poorConnectionCount`|The number of times the significant packet loss occurred during the meeting. Per count, you receive `AudioVideoObserver.connectionDidBecomePoor` or `AudioVideoObserver.connectionDidSuggestStopVideo`.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`retryCount`|The number of connection retries performed during the meeting.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`signalingOpenDurationMs`|The time taken for opening a WebSocket connection.<br><br>Unit: Milliseconds|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+
+<br>
 
 ### Device attributes
 
@@ -142,8 +150,10 @@ The following table describes attributes for the microphone and camera.
 
 |Attribute|Description|Included in
 |--|--|--
-|`audioInputErrorMessage`|The error message that explains why the microphone selection failed. For more information, see the "Device error messages" section.|`audioInputFailed`
-|`videoInputErrorMessage`|The error message that explains why the camera selection failed. For more information, see the "Device error messages" section.|`videoInputFailed`
+|`audioInputErrorMessage`|The error message that explains why the microphone selection failed. For more information, see the ["Device error messages" section](#device-error-messages).|`audioInputFailed`
+|`videoInputErrorMessage`|The error message that explains why the camera selection failed. For more information, see the ["Device error messages" section](#device-error-messages).|`videoInputFailed`
+
+<br>
 
 ### The meeting history attribute
 
@@ -192,6 +202,8 @@ The following table lists available states.
 |`videoInputSelected`|The camera was selected.
 |`videoInputUnselected`|The camera was removed. You called `meetingSession.audioVideo.chooseVideoInputDevice` with `null`.
 
+<br>
+
 ### Meeting error messages
 
 When the meeting failed to start, the Chime SDK for JavaScript catches an error and 
@@ -200,9 +212,13 @@ The following table shows common error messages you may receive when failing to 
 
 |Messages|Status code|Suggested resolution
 |--|--|--
+|The attendee couldn't join because the meeting was at capacity.|AudioCallAtCapacity|Ensure that the number of attendees does not exceed the maximum limit (250). See the [Amazon Chime SDK quotas](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-limits). You can also track the number of attendees in your server application using the [Amazon Chime SDK event notifications](https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-notifications.html).
 |The meeting already ended.|MeetingEnded|Ensure that you or someone else have not deleted a meeting using the [DeleteMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html) API action in your server application. A meeting also automatically ends after a period of inactivity. See the [Chime SDK developer guide](https://docs.aws.amazon.com/chime/latest/dg/mtgs-sdk-mtgs.html) for details.
+|The signaling connection was closed with code (close code) and reason: (reason)|SignalingBadRequest|Ensure that you do not use the deleted attendee's response in the `DefaultMeetingSession` object to start the meeting. You also should not use the attendee response from the ended meeting that you created with the same `ClientRequestToken` parameter before.
 |1. WebSocket connection failed<br>2. OpenSignalingConnectionTask got canceled while waiting to open signaling connection|TaskFailed|Ensure that you have a stable internet connection.
 |no ice candidates were gathered|TaskFailed|Ensure that either you do not use your application in split-tunneling scenarios or your application always requests microphone permissions before beginning ICE. See the [Chime SDK for JavaScript FAQs](https://aws.github.io/amazon-chime-sdk-js/modules/faqs.html#i-cannot-join-meeting-in-firefox-with-no-audio-and-video-permission-due-to-no-ice-candidates-were-gathered-error-is-this-a-known-issue).
+
+<br>
 
 The Chime SDK for JavaScript also raises the `meetingFailed` event containing the `meetingErrorMessage` attribute if the meeting stops due to an error.
 The following table lists common error messages from a stopped meeting.
@@ -212,7 +228,9 @@ The following table lists common error messages from a stopped meeting.
 |The meeting ended because attendee removed.|AudioAttendeeRemoved|Ensure that you or someone else have not called the [DeleteMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html) API action in your server application to delete the attendee present in the meeting.
 |The attendee joined from another device.|AudioJoinedFromAnotherDevice|Ensure that you do not use the same attendee response from the [CreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html), [BatchCreateAttendee](https://docs.aws.amazon.com/chime/latest/APIReference/API_BatchCreateAttendee.html), or [CreateMeetingWithAttendees](https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateMeetingWithAttendees.html) API action in two or more meetings simultaneously.
 |(An error message from your real-time callback)|RealtimeApiFailed| Ensure that the callback you passed to the real-time API, such as `meetingSession.audioVideo.realtimeSubscribeToVolumeIndicator`, does not throw an exception.
-|1. WebSocket connection failed<br>2. OpenSignalingConnectionTask got canceled while waiting to open signaling connection|TaskFailed|Ensure that you have a stable internet connection. The Chime SDK for JavaScript might fail to reconnect after disconnected from the meeting.
+|1. WebSocket connection failed<br>2. OpenSignalingConnectionTask got canceled while waiting to open signaling connection|TaskFailed|Ensure that you have a stable internet connection. You can also follow the [Quality, Bandwidth, and Connectivity guide](https://aws.github.io/amazon-chime-sdk-js/modules/qualitybandwidth_connectivity.html) to monitor network connectivity and suggest mitigations.
+
+<br>
 
 ### Device error messages
 
@@ -223,6 +241,8 @@ The `audioInputErrorMessage` and `videoInputErrorMessage` may indicate the brows
 |1. TypeError: Failed to execute 'getUserMedia' on 'MediaDevices': At least one of audio and video must be requested<br>2. NotAllowedError: The request is not allowed by the user agent or the platform in the current context.<br>3. TypeError: Type error|Ensure that you allow permission to the media devices. Also, the browser should have access to the media devices.
 |NotReadableError: Could not start video source|Ensure that you do not use the media devices in other browser tabs or applications. A hardware error may also occur at the operating system or browser. If the problem persists, restart the browser and try again.
 
+<br>
+
 ## Example
 
-[The Chime SDK serverless demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) uses Amazon CloudWatch Logs to collect, process, and analyze meeting events. For more information, see [the Meeting Dashboard section](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless#meeting-dashboard) on the serverless demo page.
+Follow the instructions in the [Monitoring and troubleshooting with Amazon Chime SDK meeting events](https://aws.amazon.com/blogs/business-productivity/monitoring-and-troubleshooting-with-amazon-chime-sdk-meeting-events) blog post to create your Amazon CloudWatch dashboard.

--- a/src/meetingsession/MeetingSessionStatusCode.ts
+++ b/src/meetingsession/MeetingSessionStatusCode.ts
@@ -83,7 +83,9 @@ export enum MeetingSessionStatusCode {
   /**
    * The Chime SDK for JavaScript failed to establish a signaling connection because
    * you or someone else deleted the attendee using the DeleteAttendee API action
-   * in your server application.
+   * in your server application. You also should not use the attendee response from
+   * the ended meeting that you created with the same ClientRequestToken parameter
+   * before.
    * https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteAttendee.html
    */
   SignalingBadRequest = 12,


### PR DESCRIPTION
…de and improve explanations

**Issue #:**
N/A

**Description of changes:**
- Remove unused meeting session status codes from the meeting event guide
- Add descriptions for `SignalingBadRequest` and improve error descriptions

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Review the generated HTML files
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

