### PR TITLE
Do not throw error when seleting None video

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -555,7 +555,6 @@ export class DemoMeetingApp
             );
           } catch (err) {
             fatal(err);
-            this.log('no video input device selected');
           }
           await this.openAudioOutputFromSelection();
           this.hideProgress('progress-authenticate');
@@ -664,7 +663,6 @@ export class DemoMeetingApp
         await this.openVideoInputFromSelection(videoInput.value, true);
       } catch (err) {
         fatal(err);
-        this.log('no video input device selected');
       }
     });
 
@@ -686,7 +684,6 @@ export class DemoMeetingApp
         await this.openVideoInputFromSelection(videoInput.value, true);
       } catch (err) {
         fatal(err);
-        this.log('no video input device selected');
       }
     });
 
@@ -814,7 +811,6 @@ export class DemoMeetingApp
             this.audioVideo.startLocalVideoTile();
           } catch (err) {
             fatal(err);
-            this.log('no video input device selected');
           }
         } else {
           this.audioVideo.stopLocalVideoTile();
@@ -1032,7 +1028,7 @@ export class DemoMeetingApp
     );
   }
 
-  
+
 
   toggleButton(button: string, state?: 'on' | 'off'): boolean {
     if (state === 'on') {
@@ -2077,7 +2073,6 @@ export class DemoMeetingApp
           await this.openVideoInputFromSelection(name, false);
         } catch (err) {
           fatal(err);
-          this.log('no video input device selected');
         }
       }
     );
@@ -2275,7 +2270,7 @@ export class DemoMeetingApp
         fatal(e);
         this.log(`failed to chooseVideoInputDevice ${device}`, e);
       }
-      throw new Error('no video device selected');
+      this.log('no video device selected');
     }
     try {
       await this.audioVideo.chooseVideoInputDevice(device);

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "../..": {
-      "version": "2.11.0",
+      "version": "2.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",
@@ -6170,15 +6170,16 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.1",
-      "license": "MIT",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
         "http-cache-semantics": "^4.0.0",
         "keyv": "^4.0.0",
         "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
+        "normalize-url": "^6.0.1",
         "responselike": "^2.0.0"
       },
       "engines": {
@@ -11261,10 +11262,14 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "4.5.0",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-api": {
@@ -13137,8 +13142,9 @@
       "license": "ISC"
     },
     "node_modules/set-getter": {
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
       "dependencies": {
         "to-object-path": "^0.3.0"
       },
@@ -19930,14 +19936,16 @@
       "version": "5.0.4"
     },
     "cacheable-request": {
-      "version": "7.0.1",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
       "requires": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
         "http-cache-semantics": "^4.0.0",
         "keyv": "^4.0.0",
         "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
+        "normalize-url": "^6.0.1",
         "responselike": "^2.0.0"
       },
       "dependencies": {
@@ -23412,7 +23420,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "npm-api": {
       "version": "1.0.1",
@@ -24667,7 +24677,9 @@
       "dev": true
     },
     "set-getter": {
-      "version": "0.1.0",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
       "requires": {
         "to-object-path": "^0.3.0"
       }

--- a/integration/js/package-lock.json
+++ b/integration/js/package-lock.json
@@ -1196,14 +1196,19 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+      "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
       "dependencies": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "debug": "~3.1.0",
         "isarray": "2.0.1"
       }
+    },
+    "node_modules/socket.io-parser/node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/socket.io-parser/node_modules/isarray": {
       "version": "2.0.1",
@@ -2528,15 +2533,20 @@
       }
     },
     "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+      "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
       "requires": {
-        "component-emitter": "1.2.1",
+        "component-emitter": "~1.3.0",
         "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",


### PR DESCRIPTION
**Description of changes:**
- Do not throw error when users select `None` video device or if there is no video input.
- Update some demo and integ test dependencies.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
- Joined the meeting demo and switch to None in both device preview and during the meeting and verified that there was no fatal error thrown.
- Joined a device with no video device and verified that there was no fatal error thrown.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

