### PR TITLE
Add metrics for event ingestion

### DIFF
--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -157,6 +157,7 @@ exports.log_event_ingestion = async (event, context) => {
         message,
         timestamp: log.timestampMs
       });
+      addEventIngestionMetricsToCloudWatch(log, meetingId, attendeeId);
     }
     return logEvents;
   });
@@ -312,4 +313,27 @@ function addSignalMetricsToCloudWatch(logMsg, meetingId, attendeeId) {
       putMetric(metricName, metricValue, meetingId, attendeeId);
     }
   }
+}
+
+function addEventIngestionMetricsToCloudWatch(log, meetingId, attendeeId) {
+  const putMetric =
+    metricScope(metrics => (metricName, metricValue, meetingId, attendeeId) => {
+      metrics.setProperty('MeetingId', meetingId);
+      metrics.setProperty('AttendeeId', attendeeId);
+      metrics.putMetric(metricName, metricValue);
+    });
+  const { logLevel, message } = log;
+  let errorMetricValue = 0;
+  let retryMetricValue = 0;
+  let ingestionTriggerSuccessMetricValue = 0;
+  if (logLevel === 'ERROR') {
+    errorMetricValue = 1;
+  } else if (logLevel === 'WARN' && message.match(/Retry (count)? limit reached/g)) {
+    retryMetricValue = 1;
+  } else if (message.includes('send successful')) {
+    ingestionTriggerSuccessMetricValue = 1;
+  }
+  putMetric('EventIngestionTriggerSuccess', ingestionTriggerSuccessMetricValue, meetingId, attendeeId);
+  putMetric('EventIngestionError', errorMetricValue, meetingId, attendeeId);
+  putMetric('EventIngestionRetryCountLimitReached', retryMetricValue, meetingId, attendeeId);
 }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- This adds metrics based on logs posted by POSTLogger for the event ingestion.
- We add a success, a retry and a error metric using `aws-embedded-metrics` `putMetric` function.
- This is just the serverless demo change.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes. But, this is just a demo change.
2. How did you test these changes? I deployed the serverless demo to my AWS account and checked if the metrics appear in the AWS CW metrics for my account when the deployed demo is ran a couple of times.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Browser meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

