### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Create a messaging session in your client application to receive messages from A
 
 ```js
 import * as AWS from 'aws-sdk/global';
-import * as Chime from 'aws-sdk/clients/chime';
+import Chime from 'aws-sdk/clients/chime';
 
 import {
   ConsoleLogger,

--- a/docs/index.html
+++ b/docs/index.html
@@ -244,7 +244,7 @@ chime.endpoint = <span class="hljs-keyword">new</span> AWS.Endpoint(<span class=
 				</a>
 				<p>Create a messaging session in your client application to receive messages from Amazon Chime SDK for Messaging.</p>
 				<pre><code class="language-js"><span class="hljs-keyword">import</span> * <span class="hljs-keyword">as</span> AWS <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;aws-sdk/global&#x27;</span>;
-<span class="hljs-keyword">import</span> * <span class="hljs-keyword">as</span> Chime <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;aws-sdk/clients/chime&#x27;</span>;
+<span class="hljs-keyword">import</span> Chime <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;aws-sdk/clients/chime&#x27;</span>;
 
 <span class="hljs-keyword">import</span> {
   ConsoleLogger,


### PR DESCRIPTION
**Issue #:** #1384

**Description of changes:**
Update the readme since the wildcard imports breaks when compiled to vanilla JS. So change the 
`import * as Chime from 'aws-sdk/clients/chime';` to `import Chime from 'aws-sdk/clients/chime';`

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? It's just a readme change
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Nope
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

