### PR TITLE
Fix deploy script for canaries and non-meeting apps

### DIFF
--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -242,12 +242,14 @@ spawnOrFail('sam', ['package', '--s3-bucket', `${bucket}`,
                     `--output-template-file`, `build/packaged.yaml`,
                     '--region',  `${region}`]);
 console.log('Deploying serverless application');
-spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--stack-name', `${stack}`,
-                    '--parameter-overrides', `UseEventBridge=${useEventBridge} ChimeEndpoint=${chimeEndpoint} ChimeServicePrincipal=${chimeServicePrincipal} ChimeMediaCaptureS3BucketPrefix=${captureOutputPrefix}`,
-                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`, '--no-fail-on-empty-changeset'], null, !disablePrintingLogs);
+let parameterOverrides = `UseEventBridge=${useEventBridge} ChimeEndpoint=${chimeEndpoint} ChimeServicePrincipal=${chimeServicePrincipal}`
 if (app === 'meetingV2' && captureOutputPrefix) {
+    parameterOverrides += ` ChimeMediaCaptureS3BucketPrefix=${captureOutputPrefix}`;
     createCaptureS3Buckets(captureOutputPrefix, mediaCaptureRegions);
 }
+spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--stack-name', `${stack}`,
+                    '--parameter-overrides', parameterOverrides,
+                    '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`, '--no-fail-on-empty-changeset'], null, !disablePrintingLogs);
 if (enableTerminationProtection) {
   spawnOrFail('aws', ['cloudformation', 'update-termination-protection', '--enable-termination-protection', '--stack-name', `${stack}`], null, false);
 }

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -17,6 +17,7 @@ Parameters:
     Type: String
   ChimeMediaCaptureS3BucketPrefix:
     Description: Prefix of S3 bucket to write capture artifacts.  The bucket name will be suffixed with the region.
+    Default: ""
     Type: String
 Conditions:
   ShouldUseEventBridge: !Equals [true, !Ref UseEventBridge]
@@ -353,34 +354,6 @@ Resources:
             Resource: !GetAtt MeetingNotificationsQueue.Arn
       Queues:
         - Ref: MeetingNotificationsQueue
-  ChimeMediaCaptureS3Bucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub "${AWS::StackName}-captureartifacts"
-      LifecycleConfiguration:
-        Rules:
-          - ExpirationInDays: 1
-            Status: Enabled
-  ChimeMediaCaptureS3BucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    DeletionPolicy: Retain
-    Properties:
-      Bucket: !Ref ChimeMediaCaptureS3Bucket
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: AWSChimeMediaCaptureBucketPolicy
-            Action:
-              - 's3:PutObject'
-              - 's3:PutObjectAcl'
-            Effect: Allow
-            Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
-                - !Ref ChimeMediaCaptureS3Bucket
-                - /*
-            Principal:
-              Service: !Ref ChimeServicePrincipal
   ChimeBrowserLogs:
     Type: AWS::Logs::LogGroup
   ChimeBrowserMeetingEventLogs:

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -9,17 +9,17 @@ cd $GITHUB_WORKSPACE/demos/serverless
 npm ci
 
 echo "Deploying to alpha stage for canary"
-npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -t -l
+npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -o chime-sdk-demo-canary -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker -t -l
 
 echo "Deploying to gamma stage for canary that talks to prod Chime endpoint"
 export AWS_ACCESS_KEY_ID=$GAMMA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$GAMMA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -t -l
+npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -o chime-sdk-demo-gamma-canary -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -t -l
 
 echo "Deploying to beta stage for canary that talks to gamma Chime endpoint"
 export AWS_ACCESS_KEY_ID=$BETA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$BETA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-beta-canary -s chime-sdk-demo-beta-canary -c $GAMMA_CHIME_ENDPOINT -t -l
+npm run deploy -- -b chime-sdk-demo-beta-canary -s chime-sdk-demo-beta-canary -o chime-sdk-demo-beta-canary -p $GAMMA_CHIME_SERIVCE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-beta-canary -s chime-sdk-meeting-readiness-checker-beta-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -t -l


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

* Apps other than the meetings app don't care about S3 buckets so we don't need to provide one
* The SAM template was creating an additional S3 bucket that was not used, so removed it
* Some additional parameters are now required to deploy the canaries in order to use media capture with them

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Deployed the meeting readiness checker and the meetings app using the same paramters
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

