### PR TITLE
Filter browser errors to put correct error metric

### DIFF
--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -385,7 +385,15 @@ function addEventIngestionMetricsToCloudWatch(log, meetingId, attendeeId) {
   let errorMetricValue = 0;
   let retryMetricValue = 0;
   let ingestionTriggerSuccessMetricValue = 0;
-  if (logLevel === 'ERROR') {
+  // Filter out browser errors which happen due to page unload.
+  // We cannot handle these failures in realtime, hence filter out.
+  if (
+    logLevel === 'ERROR' &&
+    (
+      !message.includes('NetworkError when attempting to fetch resource') ||
+      !message.includes('error reading OK response AbortError')
+    )
+  ) {
     errorMetricValue = 1;
   } else if (logLevel === 'WARN' && message.match(/Retry (count)? limit reached/g)) {
     retryMetricValue = 1;


### PR DESCRIPTION
**Issue #:**
- Browsers will error out when a page unloads resulting into `NetworkError` or `AbortError`.
- This currently happens in event ingestion when a `meetingEnded` event is triggered which gets ingested in Chrome and Safari and is attempted with `sendBeacon` in FireFox. But still Chrome gives a `NetworkError`, since in the demo we re-direct to home page from in-meeting page when an attendee leaves or ends a meeting.
- These are not actual event ingestion errors and we cannot handle these in realtime as we would have to make the error handling synchronous leading to bad user experience.

**Description of changes:**
- When putting metric, filter the specific `NetworkError` and `AbortError`.
- We can add these metrics if needed later as well.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Deployed serverless meeting demo will help test once merged as canary runs will put metrics accordingly.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Deployed existing browser meeting demo will test this.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

