### PR TITLE
Remove setup test to copy run-test script

### DIFF
--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -56,12 +56,7 @@ jobs:
       - name: Install Kite
         run: integration/js/script/install-kite
       - name: Setup
-        # Temporarily we need to copy the run-test script over from 2.9.0. Can be removed after 2.10.0 is released
-        run: |
-          cp integration/js/script/run-test integration/js/script/run-test.bku
-          git checkout tags/v${{ steps.prev.outputs.prev_version }}
-          cp integration/js/script/run-test.bku integration/js/script/run-test
-          chmod +x integration/js/script/run-test
+        run: git checkout tags/v${{ steps.prev.outputs.prev_version }}
       - name: Clean Install
         run: npm ci
       - name: Run Audio Integration Test


### PR DESCRIPTION
This is not required now as we have the run-test script since 2.10.0

**Issue #:**

**Description of changes:**
- Remove setup test to copy run-test script as it is added since 2.10.0.

**Testing**

1. Have you successfully run `npm run build:release` locally? NA.
2. How did you test these changes? NA.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No, this is for previous version check which will be checked once the run the triggered based on the cron scheduler in the github workflow..
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

