### PR TITLE
Fix error put metric condition

### DIFF
--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -390,7 +390,7 @@ function addEventIngestionMetricsToCloudWatch(log, meetingId, attendeeId) {
   if (
     logLevel === 'ERROR' &&
     (
-      !message.includes('NetworkError when attempting to fetch resource') ||
+      !message.includes('NetworkError when attempting to fetch resource') &&
       !message.includes('error reading OK response AbortError')
     )
   ) {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- The error put metric condition should be AND instead of OR.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes? Will test once demo is deployed. This is not for JS SDK feature but for operational metric correction for event ingestion.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? The deployed browser demo metrics in CW.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

