### PR TITLE
Stop video tracks before switching video device input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+- Stop `activeDevice` video track before selecting a new device to prevent `NotReadableError` when calling `getUserMedia` for a new video input device.
+
 ## [2.14.0] - 2021-07-23
 
 ### Added
 
 - Added `VideoPriorityBasedPolicyConfig` to control video downlink policy with network event response and recovery delays. Check [User Guide for Priority-based Downlink Policy](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html#user-guide-for-priority-based-downlink-policy) for more information.
 - Amazon Chime SDK Project Board Overview and Guide.
-
 - Added 25 video tile support for demo app.
 
 ### Changed

--- a/demos/serverless/src/package-lock.json
+++ b/demos/serverless/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "aws-embedded-metrics": "^2.0.4",
-        "aws-sdk": "^2.886.0",
+        "aws-sdk": "^2.941.0",
         "uuid": "^8.3.2"
       }
     },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.934.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.934.0.tgz",
-      "integrity": "sha512-k7p08ewrKcbs0ikCLFi9OI98Iv9dMND5244xPxUIjK5BLtuT/9Gr6eSCHfN70eCQyM5Y2xG1VJP6zhpkihu9Ew==",
+      "version": "2.951.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.951.0.tgz",
+      "integrity": "sha512-YPqhdESUzd4+pSuGJcfMnG1qNVbmZjnmsa85Z9jofR1ilIpuV31onIiFHv8iubM59ETok/+zy3QOmxRSLYzFmQ==",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -165,9 +165,9 @@
       "integrity": "sha512-b4+3BC8e3DE3HdZkmzlozvS8wU45w9M+4eAd2R4Z62N+ihiCuwndEh15Yj/scCKRq/FTO3rfKnzlvUMsuJtzLg=="
     },
     "aws-sdk": {
-      "version": "2.934.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.934.0.tgz",
-      "integrity": "sha512-k7p08ewrKcbs0ikCLFi9OI98Iv9dMND5244xPxUIjK5BLtuT/9Gr6eSCHfN70eCQyM5Y2xG1VJP6zhpkihu9Ew==",
+      "version": "2.951.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.951.0.tgz",
+      "integrity": "sha512-YPqhdESUzd4+pSuGJcfMnG1qNVbmZjnmsa85Z9jofR1ilIpuV31onIiFHv8iubM59ETok/+zy3QOmxRSLYzFmQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1691">src/devicecontroller/DefaultDeviceController.ts:1691</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1679">src/devicecontroller/DefaultDeviceController.ts:1679</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1800">src/devicecontroller/DefaultDeviceController.ts:1800</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1788">src/devicecontroller/DefaultDeviceController.ts:1788</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -756,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1786">src/devicecontroller/DefaultDeviceController.ts:1786</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1774">src/devicecontroller/DefaultDeviceController.ts:1774</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -860,7 +860,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1836">src/devicecontroller/DefaultDeviceController.ts:1836</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1824">src/devicecontroller/DefaultDeviceController.ts:1824</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -1075,43 +1075,21 @@ describe('DefaultDeviceController', () => {
       }
     });
 
-    it('releases all previously-acquired audio streams', done => {
+    it('releases all previously-acquired audio streams', async () => {
       const stringDeviceIds: AudioInputDevice[] = [
         'device-id-1',
         'device-id-2',
         'device-id-3',
         'device-id-4',
       ];
-      const releasedDevices = new Set();
 
-      class TestDeviceController extends DefaultDeviceController {
-        releaseMediaStream(mediaStreamToRelease: MediaStream | null): void {
-          super.releaseMediaStream(mediaStreamToRelease);
+      const spy = sinon.spy(deviceController, 'releaseMediaStream');
+      await deviceController.chooseAudioInputDevice(stringDeviceIds[0]);
+      await deviceController.chooseAudioInputDevice(stringDeviceIds[1]);
+      await deviceController.chooseAudioInputDevice(stringDeviceIds[2]);
+      await deviceController.chooseAudioInputDevice(stringDeviceIds[3]);
 
-          if (!mediaStreamToRelease) {
-            return;
-          }
-          // @ts-ignore
-          if (mediaStreamToRelease.constraints && mediaStreamToRelease.constraints.audio) {
-            // @ts-ignore
-            releasedDevices.add(mediaStreamToRelease.constraints.audio.deviceId.exact);
-          }
-        }
-      }
-
-      deviceController = new TestDeviceController(logger);
-      domMockBehavior.asyncWaitMs = 100;
-      deviceController.chooseAudioInputDevice(stringDeviceIds[0]).then(async () => {
-        deviceController.chooseAudioInputDevice(stringDeviceIds[1]);
-        await delay(10);
-        deviceController.chooseAudioInputDevice(stringDeviceIds[2]);
-        await delay(10);
-        deviceController.chooseAudioInputDevice(stringDeviceIds[3]);
-      });
-      new TimeoutScheduler(500).start(() => {
-        expect(releasedDevices.size).to.equal(3);
-        done();
-      });
+      expect(spy.callCount).to.equal(3);
     });
 
     it('releases all previously-acquired audio streams with iOS 12', done => {
@@ -1409,13 +1387,12 @@ describe('DefaultDeviceController', () => {
       expect(spy.notCalled).to.be.true;
     });
 
-    it('releases an old stream', async () => {
+    it('releases an old stream video tracks', async () => {
       deviceController.bindToAudioVideoController(audioVideoController);
       await deviceController.chooseVideoInputDevice(stringDeviceId);
-      const stream = await deviceController.acquireVideoInputStream();
-      const spy = sinon.spy(deviceController, 'releaseMediaStream');
+      const firstStream = await deviceController.acquireVideoInputStream();
       await deviceController.chooseVideoInputDevice('new-device-id');
-      expect(spy.calledOnceWith(stream)).to.be.true;
+      expect(firstStream.getVideoTracks()[0].readyState).to.equal('ended');
     });
 
     it('restarts the local video if enabled', async () => {
@@ -1431,10 +1408,9 @@ describe('DefaultDeviceController', () => {
       audioVideoController.videoTileController.startLocalVideoTile();
 
       await deviceController.chooseVideoInputDevice(stringDeviceId);
-      const stream = await deviceController.acquireVideoInputStream();
-      const spy = sinon.spy(deviceController, 'releaseMediaStream');
+      const spy = sinon.spy(audioVideoController, 'restartLocalVideo');
       await deviceController.chooseVideoInputDevice('new-device-id');
-      expect(spy.calledOnceWith(stream)).to.be.true;
+      expect(spy.calledOnce).to.be.true;
     });
 
     it('denies the permission by browser', async () => {
@@ -1883,76 +1859,33 @@ describe('DefaultDeviceController', () => {
       const spyRMS = sinon.spy(deviceController, 'releaseMediaStream');
       domMockBehavior.asyncWaitMs = 500;
       await deviceController.chooseVideoInputDevice(null);
-      expect(spyRAD.notCalled).to.be.true;
       await deviceController.chooseVideoInputDevice(stringDeviceId);
       // @ts-ignore
-      expect(spyRAD.calledOnceWith(null)).to.be.true;
+      expect(spyRAD.notCalled).to.be.true;
       expect(spyRMS.notCalled).to.be.true;
     });
 
-    it('releases 3 video input streams acquired before no device request', done => {
-      const spy = sinon.spy(deviceController, 'releaseMediaStream');
-      let callCount = 0;
-      domMockBehavior.asyncWaitMs = 1000;
-      deviceController.chooseVideoInputDevice(stringDeviceId).then(() => {
-        callCount += 1;
-      });
-      new TimeoutScheduler(100).start(() => {
-        deviceController.chooseVideoInputDevice(stringDeviceId).then(() => {
-          callCount += 1;
-        });
-      });
-      new TimeoutScheduler(300).start(() => {
-        deviceController.chooseVideoInputDevice(stringDeviceId).then(() => {
-          callCount += 1;
-        });
-      });
-      new TimeoutScheduler(500).start(() => {
-        deviceController.chooseVideoInputDevice(null);
-      });
-      new TimeoutScheduler(1500).start(() => {
-        expect(callCount).to.equal(3);
-        expect(spy.callCount).to.equal(3);
-        done();
-      });
-    });
-
-    it('releases all previously-acquired video streams', done => {
+    it('releases all previously-acquired video streams', async () => {
       const stringDeviceIds: VideoInputDevice[] = [
         'device-id-1',
         'device-id-2',
         'device-id-3',
         'device-id-4',
       ];
-      let index = 0;
-
-      class TestDeviceController extends DefaultDeviceController {
-        releaseMediaStream(mediaStreamToRelease: MediaStream | null): void {
-          super.releaseMediaStream(mediaStreamToRelease);
-
-          if (mediaStreamToRelease) {
-            // @ts-ignore
-            expect(mediaStreamToRelease.constraints.video.deviceId.exact).to.equal(
-              stringDeviceIds[index]
-            );
-            index += 1;
-          }
-        }
-      }
-
-      deviceController = new TestDeviceController(logger);
-      domMockBehavior.asyncWaitMs = 100;
-      deviceController.chooseVideoInputDevice(stringDeviceIds[0]).then(async () => {
-        deviceController.chooseVideoInputDevice(stringDeviceIds[1]);
-        await delay(10);
-        deviceController.chooseVideoInputDevice(stringDeviceIds[2]);
-        await delay(10);
-        deviceController.chooseVideoInputDevice(stringDeviceIds[3]);
-      });
-      new TimeoutScheduler(500).start(() => {
-        expect(index).to.equal(3);
-        done();
-      });
+      await deviceController.chooseVideoInputDevice(stringDeviceIds[0]);
+      const firstStream = await deviceController.acquireVideoInputStream();
+      await deviceController.chooseVideoInputDevice(stringDeviceIds[1]);
+      const secondStream = await deviceController.acquireVideoInputStream();
+      await deviceController.chooseVideoInputDevice(stringDeviceIds[2]);
+      const thirdStream = await deviceController.acquireVideoInputStream();
+      await deviceController.chooseVideoInputDevice(stringDeviceIds[3]);
+      const fourthStream = await deviceController.acquireVideoInputStream();
+      expect(firstStream.getVideoTracks()[0].readyState).to.equal('ended');
+      expect(secondStream.getVideoTracks()[0].readyState).to.equal('ended');
+      expect(thirdStream.getVideoTracks()[0].readyState).to.equal('ended');
+      expect(fourthStream.getVideoTracks()[0].readyState).to.not.equal('ended');
+      await deviceController.chooseVideoInputDevice(null);
+      expect(fourthStream.getVideoTracks()[0].readyState).to.equal('ended');
     });
   });
 


### PR DESCRIPTION
**Issue #:**
#1316 

**Description of changes:**

Previously, we releaseActiveDevice after we call getUserMedia. With our audio device switch, we call releaseActiveDevice before getUserMedia. This change will stop the video track before calling getUserMedia for the next stream so that we don't run into the NotReadableError.

Later, we may want to look into replaceTrack() api in order to allow us to switch video tracks without having to renegotiate every time we switch video streams.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? Locally - QA tested. 
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, can be tested on the meeting demo using multiple devices. Just switch between video input devices.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? no
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

