### PR TITLE
[Demo] Fix priority downlink policy initialization in demo app

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1466,7 +1466,7 @@ export class DemoMeetingApp
     }
     configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = this.enableSimulcast;
     if (this.usePriorityBasedDownlinkPolicy) {
-      this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger);
+      this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger, this.videoPriorityBasedPolicyConfig);
       configuration.videoDownlinkBandwidthPolicy = this.priorityBasedDownlinkPolicy;
       this.priorityBasedDownlinkPolicy.addObserver(this);
     }
@@ -1477,10 +1477,6 @@ export class DemoMeetingApp
       deviceController,
       this.eventReporter
     );
-    if (this.usePriorityBasedDownlinkPolicy) {
-      this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger, this.videoPriorityBasedPolicyConfig);
-      configuration.videoDownlinkBandwidthPolicy = this.priorityBasedDownlinkPolicy;
-    }
 
     if ((document.getElementById('fullband-speech-mono-quality') as HTMLInputElement).checked) {
       this.meetingSession.audioVideo.setAudioProfile(AudioProfile.fullbandSpeechMono());


### PR DESCRIPTION
**Description of changes:**
PR #1404 caused the demo to initialize the priority downlink policy twice. The second initialization is after DefaultMeetingSession where we bind `TileController` to the downlink policy. This causes the warning `tileController not found!` keeps being thrown for every wantResubscribe calls when there is a video in the call.

**Testing**

1. Have you successfully run `npm run build:release` locally? N/A
2. How did you test these changes? 
   1. Enabled priority downlink policy and joined a meeting with someone shares their video 
   2. Verified that there is no `tileController not found!` warning being thrown in the console log.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? yes, the meeting demo
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

