### PR TITLE
[TEST] Add Github environments step to trigger CI Workflow

### DIFF
--- a/.github/workflows/audio-integration.yml
+++ b/.github/workflows/audio-integration.yml
@@ -17,6 +17,8 @@
     integ-audio:
       name: Audio Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build and Run Unit Tests
     runs-on: ubuntu-latest
+    environment: 
+      name: CI Workflow
+
 
     steps:
       - name: Checkout Package

--- a/.github/workflows/content-share-integration.yml
+++ b/.github/workflows/content-share-integration.yml
@@ -17,6 +17,8 @@
     integ-content-share:
       name: Content Share Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/data-message-integration.yml
+++ b/.github/workflows/data-message-integration.yml
@@ -17,6 +17,8 @@
     integ-data-message:
       name: Data Message Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/meeting-end-integration.yml
+++ b/.github/workflows/meeting-end-integration.yml
@@ -17,6 +17,8 @@
     integ-meeting-end:
       name: Meeting End Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/meeting-readiness-integration.yml
+++ b/.github/workflows/meeting-readiness-integration.yml
@@ -18,6 +18,8 @@
     integ-meeting-readiness:
       name: Meeting Readiness Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/messaging-integration.yml
+++ b/.github/workflows/messaging-integration.yml
@@ -18,6 +18,8 @@
     integ-messaging:
       name: Messaging Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -17,6 +17,8 @@ jobs:
   prev-version-integ:
     name: Previous Version Integration Tests
     runs-on: ubuntu-latest
+    environment: 
+      name: CI Workflow
 
     steps:
       - name: Setup Node.js - 14.x

--- a/.github/workflows/video-integration.yml
+++ b/.github/workflows/video-integration.yml
@@ -17,6 +17,8 @@
     integ-video:
       name: Video Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package

--- a/.github/workflows/video-test-app-integration.yml
+++ b/.github/workflows/video-test-app-integration.yml
@@ -17,6 +17,8 @@
     integ-video:
       name: Video Test App Integration Test
       runs-on: ubuntu-latest
+      environment: 
+        name: CI Workflow
 
       steps:
         - name: Checkout Package


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Add a step to require the Github Environment to be deployed before the CI workflow begins - this will allow external contributors to run the CI workflow without having access to the Github secrets.

**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes? By submitting this PR and seeing the CI workflow pass.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

