### PR TITLE
Add remote attendee actions(Mute/Unmute/Kickout) in the browser demo

### DIFF
--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -28,6 +28,7 @@ function findAllElements() {
     sipAuthenticateButton: By.id('button-sip-authenticate'),
     roster: By.id('roster'),
     participants: By.css('li'),
+    participantActionsDropButton: By.id('button-roster-participant-drop'),
     switchToSipFlow: By.id('to-sip-flow'),
 
     authenticationFlow: By.id('flow-authenticate'),
@@ -200,6 +201,11 @@ class AppPage {
     await microphoneDropDown.click();
   }
 
+  async clickParticipantActionsDropButton() {
+    const participantActionsDropButton = await this.driver.findElement(elements.participantActionsDropButton);
+    await participantActionsDropButton.click();
+  }
+  
   async getNumberOfParticipantsOnRoster() {
     const roster = await this.driver.findElement(elements.roster);
     const participantElements = await this.driver.findElements(elements.participants);


### PR DESCRIPTION
**Issue #:** Remote attendee actions

**Description of changes:**
I see a lot of requests for sample code for mute/unmute functionality using data messages. Implemented code in the browser demo which gives developers an idea to implement event based actions using Chime SDK.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Manual verification of the browser demo to test the mute, kick out functionality
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? browser demo under demos/browser
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

