### PR TITLE
Add NPM Release Integration Test and Backwards Compatibility Test on release branch only

### DIFF
--- a/.github/script/get-current-version
+++ b/.github/script/get-current-version
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+const pjson = require('../../package.json');
+console.log(pjson.version);

--- a/.github/workflows/audio-integration.yml
+++ b/.github/workflows/audio-integration.yml
@@ -23,6 +23,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/content-share-integration.yml
+++ b/.github/workflows/content-share-integration.yml
@@ -23,6 +23,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/data-message-integration.yml
+++ b/.github/workflows/data-message-integration.yml
@@ -23,6 +23,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/meeting-end-integration.yml
+++ b/.github/workflows/meeting-end-integration.yml
@@ -23,6 +23,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/meeting-readiness-integration.yml
+++ b/.github/workflows/meeting-readiness-integration.yml
@@ -24,6 +24,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/messaging-integration.yml
+++ b/.github/workflows/messaging-integration.yml
@@ -24,6 +24,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -1,9 +1,15 @@
-name: Previous Version Integration Tests Workflow
+# For the backwards compatibility test, this should be run on the release branch only as part. 
+# The release branch should not be tagged with the new version yet (that happens when we create a Github Release)
+# so we can checkout the latest tag and install the new version tarball into the demo. 
+# For example, if we're about to release v2.14.0, first create a tarball (the relase commit should bump the pacakge.json version to v2.14.0) 
+# then check out the previous v2.13.0 demo using the v2.13.0 tag, then navigate to the v2.13.0 demo and install the v2.14.0 amazon-chime-sdk-js tarball.
+# Then run the entire integration test suite on the demo.
+name: Backwards Compatibility Test
 
 on:
-  schedule:
-    # More information on cron https://crontab.guru/
-    - cron: '0 1 * * *'
+  pull_request:
+    branches:
+      - master
 
 env:
   SELENIUM_GRID_PROVIDER: saucelabs
@@ -14,9 +20,10 @@ env:
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
 
 jobs:
-  prev-version-integ:
-    name: Previous Version Integration Tests
+  release-integ-test:
+    name: Run Backwards Compatible Integration Tests with Release Tarball
     runs-on: ubuntu-latest
+    if: ${{ github.head_ref == 'release' }}
 
     steps:
       - name: Setup Node.js - 14.x
@@ -27,12 +34,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get previous version
-        id: prev
+      - name: Pack the Chime SDK and install the tarball into the previous version Demo
         run: |
-          prev_version=$(.github/script/get-prev-version)
-          echo "Previous version:" $prev_version
-          echo ::set-output name=prev_version::$prev_version
+          current_version=$(.github/script/get-current-version)
+          echo "Packing current version:" $current_version
+          npm run build
+          npm pack
+          previousVersion=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))
+          git checkout $previousVersion
+          cd ./demos/browser
+          npm uninstall amazon-chime-sdk-js
+          npm install ../../amazon-chime-sdk-js-$current_version.tgz
       - name: Create a Job ID
         id: create-job-id
         uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c
@@ -55,15 +67,6 @@ jobs:
           tunnelIdentifier: ${{ steps.create-job-id.outputs.uuid }}
       - name: Install Kite
         run: integration/js/script/install-kite
-      - name: Setup
-        run: git checkout tags/v${{ steps.prev.outputs.prev_version }}
-      - name: Pack the Chime SDK and install the tarball into the Demo
-        run: |
-          npm run build
-          npm pack
-          cd demos/browser
-          npm uninstall amazon-chime-sdk-js
-          npm install ../../amazon-chime-sdk-js-${{ steps.prev.outputs.prev_version }}.tgz
       - name: Clean Install
         run: npm ci
       - name: Run Audio Integration Test

--- a/.github/workflows/video-integration.yml
+++ b/.github/workflows/video-integration.yml
@@ -23,6 +23,15 @@
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current-version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |

--- a/.github/workflows/video-test-app-integration.yml
+++ b/.github/workflows/video-test-app-integration.yml
@@ -17,12 +17,20 @@
     integ-video:
       name: Video Test App Integration Test
       runs-on: ubuntu-latest
-
       steps:
         - name: Checkout Package
           uses: actions/checkout@v2
           with:
             fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
         - name: Check if needed to run
           id: test_needed
           run: |


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
1. Change the integration tests to actually generate a tarball and then use the tarball in the meeting demo before running integration tests.
2. Add Backwards compatibility workflow ONLY for the release branch. It will check out the previous meeting demo and install the new SDK tarball into the meeting demo and then run the full integ test suite


**Testing**

1. Have you successfully run `npm run build:release` locally? yes
2. How did you test these changes?
Locally, via Github Actions
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
n/a
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n/a
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n/a


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

