### PR TITLE
Fix priority-based downlink policy default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
-
-### Added
+## [Unreleased]
+### Added 
 
 ### Changed
 
@@ -15,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Stop `activeDevice` video track before selecting a new device to prevent `NotReadableError` when calling `getUserMedia` for a new video input device.
+- Fix priority-based downlink policy default behavior.
 
 ## [2.14.0] - 2021-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added 
 
 ### Changed

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -261,7 +261,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L226">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L227">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L412">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L413">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:413</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceivestreams">calculateOptimalReceiveStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L274">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L275">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -377,7 +377,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L217">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L218">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L235">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:235</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +438,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L230">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L231">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:231</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setvideoprioritybasedpolicyconfigs">setVideoPriorityBasedPolicyConfigs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L245">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -530,7 +530,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L178">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -555,7 +555,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L212">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L213">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -345,7 +345,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#chooseremotevideosources">chooseRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L58">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L56">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L226">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L227">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L412">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L413">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:413</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L274">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L275">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:275</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L217">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L218">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L235">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:235</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -417,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L230">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L231">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:231</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -458,7 +458,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L245">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L178">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -529,7 +529,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L212">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L213">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:213</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
@@ -45,8 +45,6 @@ export default class VideoAdaptiveProbePolicy extends VideoPriorityBasedPolicy {
     if (containsContent) {
       this.videoPreferences = newPreferences.build();
       this.videoPreferencesUpdated = true;
-    } else {
-      this.videoPreferences = undefined;
     }
   }
 

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -156,8 +156,9 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
 
   updateIndex(videoIndex: VideoStreamIndex): void {
     this.videoIndex = videoIndex;
-    if (this.videoPreferences === undefined) {
+    if (!this.videoPreferences || this.videoPreferences.isEmpty()) {
       this.updateDefaultVideoPreferences();
+      this.videoPreferences = this.defaultVideoPreferences;
     }
   }
 
@@ -813,8 +814,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     chosenStreams: VideoStreamDescription[]
   ): VideoStreamDescription {
     let upgradeStream: VideoStreamDescription;
-    const videoPreferences: VideoPreferences =
-      this.videoPreferences || this.defaultVideoPreferences;
+    const videoPreferences: VideoPreferences = this.videoPreferences;
 
     const highestPriority = videoPreferences.highestPriority();
     let nextPriority;

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -114,7 +114,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     this.optimalNonPausedReceiveStreams = [];
     this.subscribedReceiveSet = new DefaultVideoStreamIdSet();
     this.subscribedReceiveStreams = [];
-    this.videoPreferences = VideoPreferences.default();
+    this.videoPreferences = undefined;
     this.defaultVideoPreferences = undefined;
     this.shouldPauseTiles = true;
     this.pausedStreamIds = new DefaultVideoStreamIdSet();
@@ -143,7 +143,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
   // which would require not using the internal keyword
 
   chooseRemoteVideoSources(preferences: VideoPreferences): void {
-    if (this.videoPreferences.equals(preferences)) {
+    if (this.videoPreferences?.equals(preferences)) {
       return;
     }
     this.videoPreferences = preferences;
@@ -156,7 +156,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
 
   updateIndex(videoIndex: VideoStreamIndex): void {
     this.videoIndex = videoIndex;
-    if (!this.videoPreferences || this.videoPreferences.isEmpty()) {
+    if (!this.videoPreferences) {
       this.updateDefaultVideoPreferences();
       this.videoPreferences = this.defaultVideoPreferences;
     }
@@ -275,7 +275,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
   protected calculateOptimalReceiveStreams(): void {
     const chosenStreams: VideoStreamDescription[] = [];
     const remoteInfos: VideoStreamDescription[] = this.videoIndex.remoteStreamDescriptions();
-    if (remoteInfos.length === 0 || this.videoPreferences?.isEmpty()) {
+    if (remoteInfos.length === 0 || !this.videoPreferences || this.videoPreferences.isEmpty()) {
       this.optimalReceiveStreams = [];
       return;
     }
@@ -1012,6 +1012,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
       )}  bw attendees { ${Array.from(this.pausedBwAttendeeIds).join(' ')} }\n`;
     }
 
+    /* istanbul ignore else */
     if (this.videoPreferences) {
       logString += `bwe:   preferences: ${JSON.stringify(this.videoPreferences)}`;
     }

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -250,13 +250,15 @@ describe('VideoPriorityBasedPolicy', () => {
       policy.updateIndex(videoStreamIndex);
       const metricReport = new DefaultClientMetricReport(logger);
       metricReport.globalMetricReport = new GlobalMetricReport();
+      // This is lower than the default kbps so it should use it due to startup period
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2400 * 1000;
       policy.updateMetrics(metricReport);
       let resub = policy.wantsResubscribe();
-      expect(resub).to.equal(false);
+      expect(resub).to.equal(true);
       let received = policy.chooseSubscriptions();
-      expect(received.array()).to.deep.equal([]);
+      expect(received.array()).to.deep.equal([2, 4, 6, 8]);
 
+      // No startup period now so we should use 2400 kbps for bandwidth estimate but should not trigger resubscribe
       incrementTime(6100);
       metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 2400 * 1000;
       policy.updateMetrics(metricReport);

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -202,6 +202,10 @@ describe('VideoPriorityBasedPolicy', () => {
   });
 
   describe('chooseRemoteVideoSources', () => {
+    it('Can be called if videoPreferences is undefined', () => {
+      policy.chooseRemoteVideoSources(VideoPreferences.prepare().build());
+    });
+
     it('observer should get called only when added', async () => {
       class MockObserver implements VideoDownlinkObserver {
         tileWillBePausedByDownlinkPolicy = sinon.stub();


### PR DESCRIPTION
**Issue:**
Currently, if priority-based downlink policy is enabled, the default behavior (i.e., builders would not manually choose any video using `chooseRemoteVideoSources`) does not work and would cause none of the remote videos to be rendered.

**Description of changes:**
Update the logic for default priority downlink policy:
- Initialize the `videoPreferences` variable to undefined instead of empty set to differentiate between initial value and when builders can set to not subscribe any remote video.
- Assign default video preference after populate it if the videoPreferences is undefined.
- Change the `VideoAdaptiveProbePolicy` to not set videoPreferences to undefined.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
 - Unit test
 - Test in React meeting demo using the example for video priority downlink policy setup given in this doc https://github.com/aws/amazon-chime-sdk-component-library-react/blob/master/src/providers/MeetingProvider/docs/MeetingProvider.stories.mdx which uses the default behavior and verify that users can see each other remote video.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes but need to modify the meeting demo since it manually set the video priority, 
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

