### PR TITLE
Cancel the SubscribeAndReceiveSubscribeAckTask when websocket connection is terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+
+### Added
+- Add a SignalClientEvent check in `SubscribeAndReceiveSubscribeAckTask` to immediately cancel the task when websocket connection is terminated.
+
+### Changed
+
+### Removed
+
+### Fixed
 
 ## [Unreleased]
 

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -412,7 +412,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1169">src/audiovideocontroller/DefaultAudioVideoController.ts:1169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1170">src/audiovideocontroller/DefaultAudioVideoController.ts:1170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -501,7 +501,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1159">src/audiovideocontroller/DefaultAudioVideoController.ts:1159</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videosource.html" class="tsd-signature-type">VideoSource</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -518,7 +518,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1118">src/audiovideocontroller/DefaultAudioVideoController.ts:1118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1119">src/audiovideocontroller/DefaultAudioVideoController.ts:1119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -542,7 +542,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1061">src/audiovideocontroller/DefaultAudioVideoController.ts:1061</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1062">src/audiovideocontroller/DefaultAudioVideoController.ts:1062</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -569,7 +569,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1147">src/audiovideocontroller/DefaultAudioVideoController.ts:1147</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1148">src/audiovideocontroller/DefaultAudioVideoController.ts:1148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -593,7 +593,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L947">src/audiovideocontroller/DefaultAudioVideoController.ts:947</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L948">src/audiovideocontroller/DefaultAudioVideoController.ts:948</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -644,7 +644,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L768">src/audiovideocontroller/DefaultAudioVideoController.ts:768</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L769">src/audiovideocontroller/DefaultAudioVideoController.ts:769</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -661,7 +661,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L815">src/audiovideocontroller/DefaultAudioVideoController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L816">src/audiovideocontroller/DefaultAudioVideoController.ts:816</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -696,7 +696,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L745">src/audiovideocontroller/DefaultAudioVideoController.ts:745</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L746">src/audiovideocontroller/DefaultAudioVideoController.ts:746</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -732,7 +732,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1153">src/audiovideocontroller/DefaultAudioVideoController.ts:1153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1154">src/audiovideocontroller/DefaultAudioVideoController.ts:1154</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -780,7 +780,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1109">src/audiovideocontroller/DefaultAudioVideoController.ts:1109</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1110">src/audiovideocontroller/DefaultAudioVideoController.ts:1110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -895,7 +895,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#update">update</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L735">src/audiovideocontroller/DefaultAudioVideoController.ts:735</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L736">src/audiovideocontroller/DefaultAudioVideoController.ts:736</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -411,7 +411,7 @@
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1169">src/audiovideocontroller/DefaultAudioVideoController.ts:1169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1170">src/audiovideocontroller/DefaultAudioVideoController.ts:1170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -503,7 +503,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1159">src/audiovideocontroller/DefaultAudioVideoController.ts:1159</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videosource.html" class="tsd-signature-type">VideoSource</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -521,7 +521,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1118">src/audiovideocontroller/DefaultAudioVideoController.ts:1118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1119">src/audiovideocontroller/DefaultAudioVideoController.ts:1119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -546,7 +546,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1061">src/audiovideocontroller/DefaultAudioVideoController.ts:1061</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1062">src/audiovideocontroller/DefaultAudioVideoController.ts:1062</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -574,7 +574,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1147">src/audiovideocontroller/DefaultAudioVideoController.ts:1147</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1148">src/audiovideocontroller/DefaultAudioVideoController.ts:1148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -599,7 +599,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L947">src/audiovideocontroller/DefaultAudioVideoController.ts:947</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L948">src/audiovideocontroller/DefaultAudioVideoController.ts:948</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -652,7 +652,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L768">src/audiovideocontroller/DefaultAudioVideoController.ts:768</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L769">src/audiovideocontroller/DefaultAudioVideoController.ts:769</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -670,7 +670,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalaudio">restartLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L815">src/audiovideocontroller/DefaultAudioVideoController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L816">src/audiovideocontroller/DefaultAudioVideoController.ts:816</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -706,7 +706,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L745">src/audiovideocontroller/DefaultAudioVideoController.ts:745</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L746">src/audiovideocontroller/DefaultAudioVideoController.ts:746</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -743,7 +743,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1153">src/audiovideocontroller/DefaultAudioVideoController.ts:1153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1154">src/audiovideocontroller/DefaultAudioVideoController.ts:1154</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -793,7 +793,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1109">src/audiovideocontroller/DefaultAudioVideoController.ts:1109</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L1110">src/audiovideocontroller/DefaultAudioVideoController.ts:1110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -902,7 +902,7 @@
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#update">update</a></p>
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#update">update</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L735">src/audiovideocontroller/DefaultAudioVideoController.ts:735</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideocontroller/DefaultAudioVideoController.ts#L736">src/audiovideocontroller/DefaultAudioVideoController.ts:736</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/subscribeandreceivesubscribeacktask.html
+++ b/docs/classes/subscribeandreceivesubscribeacktask.html
@@ -138,7 +138,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L26">src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L28">src/task/SubscribeAndReceiveSubscribeAckTask.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L24">src/task/SubscribeAndReceiveSubscribeAckTask.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L26">src/task/SubscribeAndReceiveSubscribeAckTask.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#cancel">cancel</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#cancel">cancel</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L32">src/task/SubscribeAndReceiveSubscribeAckTask.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L34">src/task/SubscribeAndReceiveSubscribeAckTask.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -295,7 +295,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L39">src/task/SubscribeAndReceiveSubscribeAckTask.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/SubscribeAndReceiveSubscribeAckTask.ts#L41">src/task/SubscribeAndReceiveSubscribeAckTask.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -723,6 +723,7 @@ export default class DefaultAudioVideoController
 
       await new SerialGroupTask(this.logger, this.wrapTaskName('AudioVideoClean'), subtasks).run();
     } catch (cleanError) {
+      /* istanbul ignore next */
       this.logger.info('fail to clean');
     }
     this.sessionStateController.perform(SessionStateControllerAction.FinishDisconnecting, () => {

--- a/src/task/SubscribeAndReceiveSubscribeAckTask.ts
+++ b/src/task/SubscribeAndReceiveSubscribeAckTask.ts
@@ -111,7 +111,7 @@ export default class SubscribeAndReceiveSubscribeAckTask extends BaseTask {
 
         handleSignalingClientEvent(event: SignalingClientEvent): void {
           if (event.isConnectionTerminated()) {
-            const message = 'SubscribeAndReceiveSubscribeAckTask connection terminated';
+            const message = `SubscribeAndReceiveSubscribeAckTask connection was terminated with code ${event.closeCode} and reason: ${event.closeReason}`;
             context.logger.warn(message);
 
             let statusCode: MeetingSessionStatusCode = MeetingSessionStatusCode.TaskFailed;

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -2590,8 +2590,14 @@ describe('DefaultAudioVideoController', () => {
 
       // Forcibly clean up the stats collector so it doesn't spam after the test runs.
       // This will _eventually_ get cleaned by the main CleanStoppedSessionTask, but that takes a while.
-      // @ts-ignore
-      await new CleanStoppedSessionTask(audioVideoController.meetingSessionContext).run();
+      let success = true;
+      try {
+        // @ts-ignore
+        await new CleanStoppedSessionTask(audioVideoController.meetingSessionContext).run();
+      } catch (error) {
+        success = false;
+      }
+      expect(success).to.be.false;
     });
 
     it('should return an array of length 0, when videoStreamIndex is not initialized', async () => {


### PR DESCRIPTION
**Issue:**
After the user joins a meeting and starts receiving RTCP messages from remote attendees, there is a chance that the user will be disconnected due to server side encryption errors and WebSocket connection will be terminated by back-end server. This happens in `SubscribeAndReceiveSubscribeAckTask` in serial group tasks of `actionUpdate` event, not the `connect` event. The connection will take 15 seconds to timeout since no WebSocket connection drop errors are caught and we have default `connectionTimeout` set to 15 seconds to wait for ack response.


**Description of changes:**
Handles connection terminated SignalingClientEvent so that SubscribeAndReceiveSubscribeAckTask promise get rejected immediately when `SignalingClientEventType` is `WebSocketFailed`, `WebSocketError`, `WebSocketClosing` and `WebSocketClosed`.

**Expected behavior:**
With this change, the `SubscribeAndReceiveSubscribeAckTask` will throw out `TaskFailed` error or `SignalingInternalServerError`, which will be handled by `handleSignalingClientEvent`. The connection will be immediately canceled and triggering reconnects accordingly.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Unit test
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

