### PR TITLE
Demo enhancements: PPS, Voice Focus complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Exposed Amazon Voice Focus model complexity as a type in order to support
+  showcasing complexity limitation in the meeting demo.
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exposed Amazon Voice Focus model complexity as a type in order to support
   showcasing complexity limitation in the meeting demo.
+- Packet-per-second (PPS) logging is now enabled in the meeting demo by
+  default. If the browser sends an incorrect packet rate, this will be logged
+  as an error in the console.
 
 ### Changed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -84,7 +84,7 @@ let SHOULD_DIE_ON_FATALS = (() => {
   return fatalYes || (isLocal && !fatalNo);
 })();
 
-let DEBUG_LOG_PPS = false;
+let DEBUG_LOG_PPS = true;
 
 let fatal: (e: Error) => void;
 
@@ -1044,7 +1044,15 @@ export class DemoMeetingApp
           const now = Date.now();
           const deltat = now - start;
           const deltap = entry.packetsSent - packets;
-          console.info('PPS:', (1000 * deltap) / deltat);
+          const pps = (1000 * deltap) / deltat;
+
+          let overage = 0;
+          if ((pps > 52) || (pps < 47)) {
+            console.error('PPS:', pps, `(${++overage})`);
+          } else {
+            overage = 0;
+            console.debug('PPS:', pps);
+          }
           start = now;
           packets = entry.packetsSent;
           return;

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -20,15 +20,19 @@ import {
   DefaultAudioVideoController,
   DefaultBrowserBehavior,
   DefaultDeviceController,
+  DefaultMeetingEventReporter,
   DefaultMeetingSession,
   DefaultModality,
   DefaultVideoTransformDevice,
   Device,
   DeviceChangeObserver,
   EventAttributes,
+  EventIngestionConfiguration,
   EventName,
+  EventReporter,
   LogLevel,
   Logger,
+  MeetingEventsClientConfiguration,
   MeetingSession,
   MeetingSessionConfiguration,
   MeetingSessionPOSTLogger,
@@ -36,6 +40,7 @@ import {
   MeetingSessionStatusCode,
   MeetingSessionVideoAvailability,
   MultiLogger,
+  NoOpEventReporter,
   NoOpVideoFrameProcessor,
   RemovableAnalyserNode,
   SimulcastLayers,
@@ -48,19 +53,16 @@ import {
   VideoPreference,
   VideoPreferences,
   VideoPriorityBasedPolicy,
+  VideoPriorityBasedPolicyConfig,
   VideoSource,
   VideoTileState,
   VoiceFocusDeviceTransformer,
+  VoiceFocusModelComplexity,
   VoiceFocusPaths,
+  VoiceFocusSpec,
   VoiceFocusTransformDevice,
   isAudioTransformDevice,
-  VideoPriorityBasedPolicyConfig,
-  NoOpEventReporter,
-  EventReporter,
   isDestroyable,
-  MeetingEventsClientConfiguration,
-  EventIngestionConfiguration,
-  DefaultMeetingEventReporter
 } from 'amazon-chime-sdk-js';
 
 import CircularCut from './videofilter/CircularCut';
@@ -148,6 +150,8 @@ const VOICE_FOCUS_SPEC = {
   revisionID: VOICE_FOCUS_REVISION_ID,
   paths: VOICE_FOCUS_PATHS,
 };
+
+const MAX_VOICE_FOCUS_COMPLEXITY: VoiceFocusModelComplexity | undefined = undefined;
 
 type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'Segmentation' | 'None';
 
@@ -460,7 +464,7 @@ export class DemoMeetingApp
         logger,
       });
       if (this.supportsVoiceFocus) {
-        this.voiceFocusTransformer = await this.getVoiceFocusDeviceTransformer();
+        this.voiceFocusTransformer = await this.getVoiceFocusDeviceTransformer(MAX_VOICE_FOCUS_COMPLEXITY);
         this.supportsVoiceFocus =
           this.voiceFocusTransformer && this.voiceFocusTransformer.isSupported();
         if (this.supportsVoiceFocus) {
@@ -2383,14 +2387,33 @@ export class DemoMeetingApp
     return value;
   }
 
-  private async getVoiceFocusDeviceTransformer(): Promise<VoiceFocusDeviceTransformer> {
+  private async getVoiceFocusDeviceTransformer(maxComplexity?: VoiceFocusModelComplexity): Promise<VoiceFocusDeviceTransformer> {
     if (this.voiceFocusTransformer) {
       return this.voiceFocusTransformer;
     }
+
+    function exceeds(configured: VoiceFocusModelComplexity): boolean {
+      const max = Number.parseInt(maxComplexity.substring(1), 10);
+      const complexity = Number.parseInt(configured.substring(1), 10);
+      return complexity > max;
+    }
+
     const logger = new ConsoleLogger('SDK', LogLevel.DEBUG);
-    const transformer = await VoiceFocusDeviceTransformer.create(VOICE_FOCUS_SPEC, { logger });
-    this.voiceFocusTransformer = transformer;
-    return transformer;
+
+    // Find out what it will actually execute, and cap it if needed.
+    const spec: VoiceFocusSpec = { ...VOICE_FOCUS_SPEC };
+    const config = await VoiceFocusDeviceTransformer.configure(spec, { logger });
+
+    let transformer;
+    if (maxComplexity && config.supported && exceeds(config.model.variant)) {
+      logger.info(`Downgrading VF to ${maxComplexity}`);
+      spec.variant = maxComplexity;
+      transformer = VoiceFocusDeviceTransformer.create(spec, { logger });
+    } else {
+      transformer = VoiceFocusDeviceTransformer.create(spec, { logger }, config);
+    }
+
+    return this.voiceFocusTransformer = await transformer;
   }
 
   private async createVoiceFocusDevice(inner: Device): Promise<VoiceFocusTransformDevice | Device> {
@@ -2404,7 +2427,7 @@ export class DemoMeetingApp
     }
 
     try {
-      const transformer = await this.getVoiceFocusDeviceTransformer();
+      const transformer = await this.getVoiceFocusDeviceTransformer(MAX_VOICE_FOCUS_COMPLEXITY);
       const vf: VoiceFocusTransformDevice = await transformer.createTransformDevice(inner);
       if (vf) {
         return (this.voiceFocusDevice = vf);

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,7 @@ import VideoUplinkBandwidthPolicy from './videouplinkbandwidthpolicy/VideoUplink
 import VoiceFocusConfig from './voicefocus/VoiceFocusConfig';
 import VoiceFocusDeviceOptions from './voicefocus/VoiceFocusDeviceOptions';
 import VoiceFocusDeviceTransformer from './voicefocus/VoiceFocusDeviceTransformer';
+import VoiceFocusModelComplexity from './voicefocus/VoiceFocusModelComplexity';
 import VoiceFocusPaths from './voicefocus/VoiceFocusPaths';
 import VoiceFocusSpec from './voicefocus/VoiceFocusSpec';
 import VoiceFocusTransformDevice from './voicefocus/VoiceFocusTransformDevice';
@@ -560,6 +561,7 @@ export {
   VoiceFocusConfig,
   VoiceFocusDeviceOptions,
   VoiceFocusDeviceTransformer,
+  VoiceFocusModelComplexity,
   VoiceFocusPaths,
   VoiceFocusSpec,
   VoiceFocusTransformDevice,

--- a/src/voicefocus/VoiceFocusModelComplexity.ts
+++ b/src/voicefocus/VoiceFocusModelComplexity.ts
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* istanbul ignore next */
+import { ModelVariant as VoiceFocusModelComplexity } from '../../libs/voicefocus/types';
+
+// Barrelizer re-export, assemble!
+export default VoiceFocusModelComplexity;


### PR DESCRIPTION
**Description of changes:**

Two separate commits, pushed together for convenience:

1. Make it possible to limit Amazon Voice Focus complexity in the meeting demo. This illustrates how a builder might exercise some tighter control by using the separate configuration API exposed by `VoiceFocusDeviceTransformer`. Manually tested by flipping the new constant in `meetingV2.ts`.
2. Improve PPS logging in the demo app. This enables debug-level logging by default, with error-level logging if packets-per-second exceeds a reasonable range. Chrome seems to get this wrong a lot when under CPU pressure, so this is a first step towards getting visibility here.

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

Demo-only changes, so no.

> 2. How did you test these changes?

By hand in the demo app.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

Yes.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

An internal type is now exposed.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

