### PR TITLE
Fix Maven installation script

### DIFF
--- a/integration/js/script/install-kite
+++ b/integration/js/script/install-kite
@@ -7,8 +7,13 @@ git clone https://github.com/webrtc/KITE.git
 cd KITE
 git checkout e9296165cd24bea92cddb59f2bf211c99f764d58
 
-chmod -R +x scripts/linux
-printf "n\n3.6.3" | ./scripts/linux/installMaven.sh
+wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip
+unzip apache-maven-3.6.3-bin.zip
+
+mv apache-maven-3.6.3 ~
+
+
+rm -f apache-maven-3.6.3-bin.zip
 #This is a temporary hack since maven 3.8.1 which is the default for GitHub Action VM does not work with kite
 export PATH=~/apache-maven-3.6.3/bin:$PATH
 source ~/.bashrc


### PR DESCRIPTION
**Description of changes:**
The maven installation script is broken as the previous URL to download maven no longer works. Update to use the new URL and remove the usage from KITE repo.
**Testing**

1. Have you successfully run `npm run build:release` locally? N/A
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

