### PR TITLE
Replaced any type for real-time data messages with generic types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 
 ### Added
+- Added strict types for the real-time messaging. 
 
 ### Changed
 

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -70,7 +70,6 @@ import SimulcastTransceiverController from '../transceivercontroller/SimulcastTr
 import VideoOnlyTransceiverController from '../transceivercontroller/VideoOnlyTransceiverController';
 import DefaultVideoCaptureAndEncodeParameter from '../videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter';
 import AllHighestVideoBandwidthPolicy from '../videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy';
-import VideoPriorityBasedPolicy from '../videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy';
 import VideoSource from '../videosource/VideoSource';
 import DefaultVideoStreamIdSet from '../videostreamidset/DefaultVideoStreamIdSet';
 import DefaultVideoStreamIndex from '../videostreamindex/DefaultVideoStreamIndex';
@@ -151,9 +150,6 @@ export default class DefaultAudioVideoController
     this._audioMixController = new DefaultAudioMixController(this._logger);
     this.meetingSessionContext.logger = this._logger;
     this._eventController = new DefaultEventController(this, eventReporter);
-    if (configuration.videoDownlinkBandwidthPolicy instanceof VideoPriorityBasedPolicy) {
-      configuration.videoDownlinkBandwidthPolicy.bindToTileController(this._videoTileController);
-    }
   }
 
   async destroy(): Promise<void> {

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -18,6 +18,7 @@ import VideoInputDevice from '../devicecontroller/VideoInputDevice';
 import VideoQualitySettings from '../devicecontroller/VideoQualitySettings';
 import { isVideoTransformDevice } from '../devicecontroller/VideoTransformDevice';
 import RealtimeController from '../realtimecontroller/RealtimeController';
+import RealtimeDataMessage from '../realtimecontroller/RealtimeDataMessage';
 import type VolumeIndicatorCallback from '../realtimecontroller/VolumeIndicatorCallback';
 import VideoSource from '../videosource/VideoSource';
 import VideoTile from '../videotile/VideoTile';
@@ -261,11 +262,7 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     this.trace('realtimeUnsubscribeToLocalSignalStrengthChange');
   }
 
-  realtimeSendDataMessage(
-    topic: string, // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: Uint8Array | string | any,
-    lifetimeMs?: number
-  ): void {
+  realtimeSendDataMessage(topic: string, data: RealtimeDataMessage, lifetimeMs?: number): void {
     this.realtimeController.realtimeSendDataMessage(topic, data, lifetimeMs);
     this.trace('realtimeSendDataMessage');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,8 @@ import PingPongObserver from './pingpongobserver/PingPongObserver';
 import RealtimeAttendeePositionInFrame from './realtimecontroller/RealtimeAttendeePositionInFrame';
 import RealtimeController from './realtimecontroller/RealtimeController';
 import RealtimeControllerFacade from './realtimecontroller/RealtimeControllerFacade';
+import RealtimeDataMessage from './realtimecontroller/RealtimeDataMessage';
+import RealtimeDataMessageHandlerCallback from './realtimecontroller/RealtimeDataMessageHandlerCallback';
 import RealtimeState from './realtimecontroller/RealtimeState';
 import RealtimeVolumeIndicator from './realtimecontroller/RealtimeVolumeIndicator';
 import ReceiveAudioInputTask from './task/ReceiveAudioInputTask';
@@ -475,6 +477,8 @@ export {
   RealtimeAttendeePositionInFrame,
   RealtimeController,
   RealtimeControllerFacade,
+  RealtimeDataMessage,
+  RealtimeDataMessageHandlerCallback,
   RealtimeState,
   RealtimeVolumeIndicator,
   ReceiveAudioInputTask,

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -4,6 +4,8 @@
 import DataMessage from '../datamessage/DataMessage';
 import RealtimeAttendeePositionInFrame from './RealtimeAttendeePositionInFrame';
 import RealtimeController from './RealtimeController';
+import RealtimeDataMessage from './RealtimeDataMessage';
+import RealtimeDataMessageHandlerCallback from './RealtimeDataMessageHandlerCallback';
 import RealtimeState from './RealtimeState';
 import RealtimeVolumeIndicator from './RealtimeVolumeIndicator';
 import type VolumeIndicatorCallback from './VolumeIndicatorCallback';
@@ -53,7 +55,7 @@ import type VolumeIndicatorCallback from './VolumeIndicatorCallback';
  *    [[realtimeIsLocalAudioMuted]] still returns true.
  */
 export default class DefaultRealtimeController implements RealtimeController {
-  private readonly state: RealtimeState = new RealtimeState();
+  private readonly state = new RealtimeState();
 
   realtimeSetLocalAttendeeId(attendeeId: string, externalUserId: string): void {
     this.state.localAttendeeId = attendeeId;
@@ -352,10 +354,7 @@ export default class DefaultRealtimeController implements RealtimeController {
     }
   }
 
-  realtimeSubscribeToSendDataMessage(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (topic: string, data: Uint8Array | string | any, lifetimeMs?: number) => void
-  ): void {
+  realtimeSubscribeToSendDataMessage(callback: RealtimeDataMessageHandlerCallback): void {
     try {
       this.state.sendDataMessageCallbacks.push(callback);
     } catch (e) {
@@ -363,10 +362,7 @@ export default class DefaultRealtimeController implements RealtimeController {
     }
   }
 
-  realtimeUnsubscribeFromSendDataMessage(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (topic: string, data: Uint8Array | string | any, lifetimeMs?: number) => void
-  ): void {
+  realtimeUnsubscribeFromSendDataMessage(callback: RealtimeDataMessageHandlerCallback): void {
     try {
       const index = this.state.sendDataMessageCallbacks.indexOf(callback);
       if (index !== -1) {
@@ -377,11 +373,7 @@ export default class DefaultRealtimeController implements RealtimeController {
     }
   }
 
-  realtimeSendDataMessage(
-    topic: string,
-    data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    lifetimeMs?: number
-  ): void {
+  realtimeSendDataMessage(topic: string, data: RealtimeDataMessage, lifetimeMs?: number): void {
     try {
       for (const fn of this.state.sendDataMessageCallbacks) {
         fn(topic, data, lifetimeMs);

--- a/src/realtimecontroller/RealtimeController.ts
+++ b/src/realtimecontroller/RealtimeController.ts
@@ -3,6 +3,8 @@
 
 import DataMessage from '../datamessage/DataMessage';
 import RealtimeAttendeePositionInFrame from './RealtimeAttendeePositionInFrame';
+import RealtimeDataMessage from './RealtimeDataMessage';
+import RealtimeDataMessageHandlerCallback from './RealtimeDataMessageHandlerCallback';
 import type VolumeIndicatorCallback from './VolumeIndicatorCallback';
 
 /**
@@ -197,25 +199,19 @@ export default interface RealtimeController {
   /**
    * Subscribe to local send message event
    */
-  realtimeSubscribeToSendDataMessage( // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (topic: string, data: Uint8Array | string | any, lifetimeMs?: number) => void
+  realtimeSubscribeToSendDataMessage(
+    callback: (topic: string, data: RealtimeDataMessage, lifetimeMs?: number) => void
   ): void;
 
   /**
    * Unsubscribe from local send message event
    */
-  realtimeUnsubscribeFromSendDataMessage( // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    callback: (topic: string, data: Uint8Array | string | any, lifetimeMs?: number) => void
-  ): void;
+  realtimeUnsubscribeFromSendDataMessage(callback: RealtimeDataMessageHandlerCallback): void;
 
   /**
    * Send message via data channel
    */
-  realtimeSendDataMessage(
-    topic: string,
-    data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    lifetimeMs?: number
-  ): void;
+  realtimeSendDataMessage(topic: string, data: RealtimeDataMessage, lifetimeMs?: number): void;
 
   /**
    * Subscribe to receiving message on a topic

--- a/src/realtimecontroller/RealtimeControllerFacade.ts
+++ b/src/realtimecontroller/RealtimeControllerFacade.ts
@@ -3,6 +3,7 @@
 
 import DataMessage from '../datamessage/DataMessage';
 import RealtimeAttendeePositionInFrame from './RealtimeAttendeePositionInFrame';
+import RealtimeDataMessage from './RealtimeDataMessage';
 import type VolumeIndicatorCallback from './VolumeIndicatorCallback';
 
 export default interface RealtimeControllerFacade {
@@ -40,11 +41,7 @@ export default interface RealtimeControllerFacade {
   ): void;
   realtimeSubscribeToLocalSignalStrengthChange(callback: (signalStrength: number) => void): void;
   realtimeUnsubscribeToLocalSignalStrengthChange(callback: (signalStrength: number) => void): void;
-  realtimeSendDataMessage(
-    topic: string,
-    data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    lifetimeMs?: number
-  ): void;
+  realtimeSendDataMessage(topic: string, data: RealtimeDataMessage, lifetimeMs?: number): void;
   realtimeSubscribeToReceiveDataMessage(
     topic: string,
     callback: (dataMessage: DataMessage) => void

--- a/src/realtimecontroller/RealtimeDataMessage.ts
+++ b/src/realtimecontroller/RealtimeDataMessage.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type RealtimeDataMessage = Uint8Array | string;
+
+export default RealtimeDataMessage;

--- a/src/realtimecontroller/RealtimeDataMessageHandlerCallback.ts
+++ b/src/realtimecontroller/RealtimeDataMessageHandlerCallback.ts
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import RealtimeDataMessage from './RealtimeDataMessage';
+
+type RealtimeDataMessageHandlerCallback = (
+  topic: string,
+  data: RealtimeDataMessage,
+  lifetimeMs?: number
+) => void;
+
+export default RealtimeDataMessageHandlerCallback;

--- a/src/realtimecontroller/RealtimeState.ts
+++ b/src/realtimecontroller/RealtimeState.ts
@@ -3,6 +3,7 @@
 
 import DataMessage from '../datamessage/DataMessage';
 import RealtimeAttendeePositionInFrame from './RealtimeAttendeePositionInFrame';
+import RealtimeDataMessageHandlerCallback from './RealtimeDataMessageHandlerCallback';
 import RealtimeVolumeIndicator from './RealtimeVolumeIndicator';
 import type VolumeIndicatorCallback from './VolumeIndicatorCallback';
 
@@ -86,11 +87,7 @@ export default class RealtimeState {
   /**
    * Callbacks to trigger when sending message
    */
-  sendDataMessageCallbacks: ((
-    topic: string, // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: Uint8Array | string | any,
-    lifetimeMs?: number
-  ) => void)[] = [];
+  sendDataMessageCallbacks: RealtimeDataMessageHandlerCallback[] = [];
 
   /**
    * Callbacks to listen for receiving message from data channel based on given topic

--- a/src/task/SendAndReceiveDataMessagesTask.ts
+++ b/src/task/SendAndReceiveDataMessagesTask.ts
@@ -3,6 +3,7 @@
 
 import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
 import DataMessage from '../datamessage/DataMessage';
+import RealtimeDataMessage from '../realtimecontroller/RealtimeDataMessage';
 import RemovableObserver from '../removableobserver/RemovableObserver';
 import SignalingClientEvent from '../signalingclient/SignalingClientEvent';
 import SignalingClientEventType from '../signalingclient/SignalingClientEventType';
@@ -60,7 +61,7 @@ export default class SendAndReceiveDataMessagesTask
 
   sendDataMessageHandler = (
     topic: string,
-    data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    data: RealtimeDataMessage,
     lifetimeMs?: number
   ): void => {
     if (this.context.signalingClient.ready()) {

--- a/src/websocketadapter/DefaultWebSocketAdapter.ts
+++ b/src/websocketadapter/DefaultWebSocketAdapter.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Logger from '../logger/Logger';
+import RealtimeDataMessage from '../realtimecontroller/RealtimeDataMessage';
 import Versioning from '../versioning/Versioning';
 import WebSocketAdapter from './WebSocketAdapter';
 import WebSocketReadyState from './WebSocketReadyState';
@@ -16,7 +17,7 @@ export default class DefaultWebSocketAdapter implements WebSocketAdapter {
     this.connection.binaryType = 'arraybuffer';
   }
 
-  send(message: Uint8Array | string): boolean {
+  send(message: RealtimeDataMessage): boolean {
     if (!this.connection) {
       this.logger.error('WebSocket not yet created or already destroyed.');
       return false;
@@ -28,6 +29,7 @@ export default class DefaultWebSocketAdapter implements WebSocketAdapter {
       } else {
         this.connection.send(message);
       }
+
       return true;
     } catch (err) {
       this.logger.debug(

--- a/src/websocketadapter/WebSocketAdapter.ts
+++ b/src/websocketadapter/WebSocketAdapter.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import RealtimeDataMessage from '../realtimecontroller/RealtimeDataMessage';
 import WebSocketReadyState from './WebSocketReadyState';
 
 /** Adapter for WebSocket implementations */
@@ -21,7 +22,7 @@ export default interface WebSocketAdapter {
    * @param send byte or string message to send
    * @returns Whether the data was queued for sending
    */
-  send(message: Uint8Array | string): boolean;
+  send(message: RealtimeDataMessage): boolean;
 
   /**
    * Close the WebSocket connection.

--- a/test/realtimecontroller/DefaultRealtimeController.test.ts
+++ b/test/realtimecontroller/DefaultRealtimeController.test.ts
@@ -9,6 +9,8 @@ import DataMessage from '../../src/datamessage/DataMessage';
 import DefaultRealtimeController from '../../src/realtimecontroller/DefaultRealtimeController';
 import RealtimeAttendeePositionInFrame from '../../src/realtimecontroller/RealtimeAttendeePositionInFrame';
 import RealtimeController from '../../src/realtimecontroller/RealtimeController';
+import RealtimeDataMessage from '../../src/realtimecontroller/RealtimeDataMessage';
+import RealtimeDataMessageHandlerCallback from '../../src/realtimecontroller/RealtimeDataMessageHandlerCallback';
 
 // @ts-ignore
 class PseudoMediaStreamTrack implements MediaStreamTrack {
@@ -949,9 +951,9 @@ describe('DefaultRealtimeController', () => {
       const rt: RealtimeController = new DefaultRealtimeController();
       let callbackIndex = 0;
       let resultTopic, resultData, resultLifetimeMs;
-      const callback = (
+      const callback: RealtimeDataMessageHandlerCallback = (
         topic: string,
-        data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        data: RealtimeDataMessage,
         lifetimeMs?: number
       ): void => {
         callbackIndex++;
@@ -976,9 +978,10 @@ describe('DefaultRealtimeController', () => {
       const rt: RealtimeController = new DefaultRealtimeController();
       let callbackIndex = 0;
       let resultTopic, resultData, resultLifetimeMs;
-      const callback = (
+
+      const callback: RealtimeDataMessageHandlerCallback = (
         topic: string,
-        data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        data: RealtimeDataMessage,
         lifetimeMs?: number
       ): void => {
         callbackIndex++;
@@ -1162,9 +1165,9 @@ describe('DefaultRealtimeController', () => {
       const LocalSignalStrengthChangeCallback = (_signalStrength: number): void => {
         callbacksRemoved = false;
       };
-      const SendDataMessageCallback = (
+      const SendDataMessageCallback: RealtimeDataMessageHandlerCallback = (
         _topic: string,
-        _data: Uint8Array | string | any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        _data: RealtimeDataMessage,
         _lifetimeMs?: number
       ): void => {
         callbacksRemoved = false;

--- a/test/task/SendAndReceiveDataMessagesTask.test.ts
+++ b/test/task/SendAndReceiveDataMessagesTask.test.ts
@@ -148,7 +148,7 @@ describe('SendAndReceiveDataMessagesTask', () => {
 
     const topic = 'topic';
     const data = { subject: 'test', message: 'test message' };
-    context.realtimeController.realtimeSendDataMessage(topic, data, 100);
+    context.realtimeController.realtimeSendDataMessage(topic, JSON.stringify(data), 100);
 
     const dataMessageFrame = makeSendDataMessageFrame(
       topic,


### PR DESCRIPTION
**Description of changes:**
- Replaced `any` type of data message with strict types.
- Got rid of `any` type to have strict types.
- Removed type definition duplicates and control message type in one place.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
I extended tests with new types.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
It can be used in any demo application, which uses test messages with JSON types.

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.