### PR TITLE
Add log to know if retrying was attempted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packet-per-second (PPS) logging is now enabled in the meeting demo by
   default. If the browser sends an incorrect packet rate, this will be logged
   as an error in the console.
+- Add a warning log in `InMemoryJSONEventBuffer`'s `send` function when retrying starts.
 
 ### Changed
 - Update `InMemoryJSONEventBuffer` to retry with backoff.

--- a/docs/classes/inmemoryjsoneventbuffer.html
+++ b/docs/classes/inmemoryjsoneventbuffer.html
@@ -188,7 +188,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/destroyable.html">Destroyable</a>.<a href="../interfaces/destroyable.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/eventbuffer/InMemoryJSONEventBuffer.ts#L580">src/eventbuffer/InMemoryJSONEventBuffer.ts:580</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/eventbuffer/InMemoryJSONEventBuffer.ts#L583">src/eventbuffer/InMemoryJSONEventBuffer.ts:583</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/src/eventbuffer/InMemoryJSONEventBuffer.ts
+++ b/src/eventbuffer/InMemoryJSONEventBuffer.ts
@@ -476,6 +476,9 @@ export default class InMemoryJSONEventBuffer implements EventBuffer<EventData>, 
         if (response.ok || !InMemoryJSONEventBuffer.SENDING_FAILURE_CODES.has(response.status)) {
           return response;
         } else {
+          this.logger.warn(
+            `Will retry sending failure for ${data} due to status code ${response.status}.`
+          );
           retryCount++;
           /* istanbul ignore else */
           if (retryCount < this.retryCountLimit) {


### PR DESCRIPTION
**Issue #:**
- There is no way to when retrying starts. I missed adding this log in last PR.

**Description of changes:**
- Adds a WARN log when retrying is attempted.

**Testing**

1. Have you successfully run `npm run build:release` locally? Just logging update.
2. How did you test these changes? Tested as part of console logging unit test run.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Just a logging update.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

