### PR TITLE
Update documentation for the browser demo

### DIFF
--- a/demos/browser/README.md
+++ b/demos/browser/README.md
@@ -43,8 +43,8 @@ For messaging session, make sure your role policy contains `chime:Connect` and `
 
 1. Navigate to the `demos/browser` folder: `cd demos/browser`
 
-2. Start the demo application in 'hot reload' mode: `npm run start:hot`
-Note: The first time when the demo is run there might be a dependency error. Please run `npm run start` first as that will install the required dependencies. After that, `npm run start:hot` should not throw any errors.
+2. Start the demo application: `npm run start`
+> Note: Once the demo is run for the first time, you can run the application in hot reload mode by calling `npm run start:hot`.
 
 3. Open http://localhost:8080 in your browser.
 

--- a/demos/browser/README.md
+++ b/demos/browser/README.md
@@ -44,6 +44,7 @@ For messaging session, make sure your role policy contains `chime:Connect` and `
 1. Navigate to the `demos/browser` folder: `cd demos/browser`
 
 2. Start the demo application in 'hot reload' mode: `npm run start:hot`
+Note: The first time when the demo is run there might be a dependency error. Please run `npm run start` first as that will install the required dependencies. After that, `npm run start:hot` should not throw any errors.
 
 3. Open http://localhost:8080 in your browser.
 


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:** Updated the documentation to reflect that there might be a dependency issue when the repository is first cloned. `npm run start:hot` runs into a dependency issue due to this. To get around the missing dependencies, the user should run `npm run start` the first time and after that they should be able to use `npm run start:hot`

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? There are no code changes.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

