### PR TITLE
Fix race condition in Safari when disconnect and connect stream from video element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix race condition in Safari when disconnect and connect stream from video element.
 
 ## [2.15.0] - 2021-08-04
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -819,7 +819,7 @@ export class DemoMeetingApp
     );
 
     const buttonMute = document.getElementById('button-microphone');
-    buttonMute.addEventListener('mousedown', _e => {
+    buttonMute.addEventListener('click', _e => {
       if (this.toggleButton('button-microphone')) {
         this.audioVideo.realtimeUnmuteLocalAudio();
       } else {

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -39,7 +39,7 @@
       }
     },
     "../..": {
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L108">src/videotile/DefaultVideoTile.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L111">src/videotile/DefaultVideoTile.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L198">src/videotile/DefaultVideoTile.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L201">src/videotile/DefaultVideoTile.ts:201</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -185,7 +185,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L152">src/videotile/DefaultVideoTile.ts:152</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L155">src/videotile/DefaultVideoTile.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -227,7 +227,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L254">src/videotile/DefaultVideoTile.ts:254</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L257">src/videotile/DefaultVideoTile.ts:257</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ImageData</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -245,7 +245,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L121">src/videotile/DefaultVideoTile.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L124">src/videotile/DefaultVideoTile.ts:124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -263,7 +263,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratioobserver.html">DevicePixelRatioObserver</a>.<a href="../interfaces/devicepixelratioobserver.html#devicepixelratiochanged">devicePixelRatioChanged</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L135">src/videotile/DefaultVideoTile.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L138">src/videotile/DefaultVideoTile.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -287,7 +287,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#id">id</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L140">src/videotile/DefaultVideoTile.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L143">src/videotile/DefaultVideoTile.ts:143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -305,7 +305,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L236">src/videotile/DefaultVideoTile.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L239">src/videotile/DefaultVideoTile.ts:239</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -323,7 +323,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L222">src/videotile/DefaultVideoTile.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L225">src/videotile/DefaultVideoTile.ts:225</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -341,7 +341,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#state">state</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L144">src/videotile/DefaultVideoTile.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L147">src/videotile/DefaultVideoTile.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -359,7 +359,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#stateref">stateRef</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L148">src/videotile/DefaultVideoTile.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L151">src/videotile/DefaultVideoTile.ts:151</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videotilestate.html" class="tsd-signature-type">VideoTileState</a></h4>
@@ -377,7 +377,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L245">src/videotile/DefaultVideoTile.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L248">src/videotile/DefaultVideoTile.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L229">src/videotile/DefaultVideoTile.ts:229</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videotile/DefaultVideoTile.ts#L232">src/videotile/DefaultVideoTile.ts:232</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -150,7 +150,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   }
 
   requiresVideoElementWorkaround(): boolean {
-    return this.isSafari();
+    return this.isSafari() && this.majorVersion() === 12;
   }
 
   requiresNoExactMediaStreamConstraints(): boolean {

--- a/src/videotile/DefaultVideoTile.ts
+++ b/src/videotile/DefaultVideoTile.ts
@@ -98,8 +98,11 @@ export default class DefaultVideoTile implements DevicePixelRatioObserver, Video
       // Need to yield the message loop before clearing `srcObject` to
       // prevent Safari from crashing.
       if (new DefaultBrowserBehavior().requiresVideoElementWorkaround()) {
+        const prevSrcObject = videoElement.srcObject;
         AsyncScheduler.nextTick(() => {
-          videoElement.srcObject = null;
+          if (videoElement.srcObject === prevSrcObject) {
+            videoElement.srcObject = null;
+          }
         });
       } else {
         videoElement.srcObject = null;

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -216,7 +216,6 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().name()).to.eq('safari');
       expect(new DefaultBrowserBehavior().isSupported()).to.be.true;
       expect(new DefaultBrowserBehavior().screenShareUnsupported()).to.be.true;
-      expect(new DefaultBrowserBehavior().requiresVideoElementWorkaround()).to.be.true;
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(13);
       expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
       expect(new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()).to.be.false;
@@ -280,6 +279,7 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().isSupported()).to.be.true;
       expect(new DefaultBrowserBehavior().screenShareUnsupported()).to.be.true;
       expect(new DefaultBrowserBehavior().majorVersion()).to.eq(12);
+      expect(new DefaultBrowserBehavior().requiresVideoElementWorkaround()).to.be.true;
       expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
       expect(new DefaultBrowserBehavior().requiresUnifiedPlan()).to.be.false;

--- a/test/videotile/DefaultVideoTile.test.ts
+++ b/test/videotile/DefaultVideoTile.test.ts
@@ -181,8 +181,8 @@ describe('DefaultVideoTile', () => {
       expect(tileControllerSpy.called).to.be.true;
     });
 
-    it('binds a video stream in Safari', done => {
-      domMockBehavior.browserName = 'safari';
+    it('binds a video stream in Safari 12', done => {
+      domMockBehavior.browserName = 'safari12';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
       tile = new DefaultVideoTile(tileId, true, tileController, monitor);
       const videoElement = videoElementFactory.create();
@@ -236,7 +236,7 @@ describe('DefaultVideoTile', () => {
     });
 
     it('unbinds a video stream in Safari', done => {
-      domMockBehavior.browserName = 'safari';
+      domMockBehavior.browserName = 'safari12';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
       tile = new DefaultVideoTile(tileId, true, tileController, monitor);
       const videoElement = videoElementFactory.create();
@@ -269,6 +269,28 @@ describe('DefaultVideoTile', () => {
       expect(tileControllerSpy.called).to.be.true;
       new TimeoutScheduler(10).start(() => {
         expect(videoElement.srcObject).to.be.null;
+        done();
+      });
+    });
+
+    it('does not set srcObject to null for safari12 if it already changes to a new stream', done => {
+      domMockBehavior.browserName = 'safari12';
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      tile = new DefaultVideoTile(tileId, true, tileController, monitor);
+      const videoElement = videoElementFactory.create();
+      tile.bindVideoElement(videoElement);
+      // @ts-ignore
+      const mockVideoStream2 = new MediaStream();
+      // @ts-ignore
+      mockVideoStream2.addTrack(new MediaStreamTrack('mockVideoStream2', 'video'));
+
+      tile.bindVideoStream('attendee', true, mockVideoStream, 1, 1, 1);
+      tile.bindVideoStream(null, true, null, null, null, null);
+      tile.bindVideoStream('attendee', true, mockVideoStream2, 2, 2, 1);
+
+      expect(tileControllerSpy.called).to.be.true;
+      new TimeoutScheduler(10).start(() => {
+        expect(videoElement.srcObject).to.equal(mockVideoStream2);
         done();
       });
     });


### PR DESCRIPTION
**Issue:**
In Safari, calling `disconnectVideoStreamFromVideoElement` then call `connectVideoStreamToVideoElement` can cause the new video stream to not show up. This is because of a workaround we put in for Safari to wait for the next tick before resetting the `srcObject` property of  the videoElement to null to avoid crashing for Safari 12 and earlier. However, if another video stream is set to `srcObject` before, then this will clear out the new value.
 
**Description of changes:**
- Update the code to only do the workaround for Safari 12 as the crashing can no longer be reproduced in Safari 13 or later.
- Update the workaround to only set the `srcObject` to null if it is the same stream we want to remove.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
    - Joined a meeting in Safari
    - In the preview window, switched the video quality and verified that the video preview showed up.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
Yes, the meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

