### PR TITLE
Add a resource monitor to output a log message when setTimeout drifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `audioInputMuteStateChanged` to the `DeviceChangeObserver` interface. This is called whenever the device is changed or is muted or unmuted, allowing applications to adapt to OS-level mute state for input devices.
+- Add a resource monitor to output a warning message when the setTimeout execution time drifts.
 
 ### Changed
 

--- a/docs/classes/monitortask.html
+++ b/docs/classes/monitortask.html
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L46">src/task/MonitorTask.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L49">src/task/MonitorTask.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -180,7 +180,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L35">src/task/MonitorTask.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L37">src/task/MonitorTask.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#connectionhealthdidchange">connectionHealthDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L264">src/task/MonitorTask.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L270">src/task/MonitorTask.ts:270</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L339">src/task/MonitorTask.ts:339</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L345">src/task/MonitorTask.ts:345</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -307,7 +307,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#metricsdidreceive">metricsDidReceive</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L186">src/task/MonitorTask.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L192">src/task/MonitorTask.ts:192</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L65">src/task/MonitorTask.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L69">src/task/MonitorTask.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -393,7 +393,7 @@
 								<p>Implementation of <a href="../interfaces/task.html">Task</a>.<a href="../interfaces/task.html#run">run</a></p>
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L79">src/task/MonitorTask.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L84">src/task/MonitorTask.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -436,7 +436,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videoreceivebandwidthdidchange">videoReceiveBandwidthDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L138">src/task/MonitorTask.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L144">src/task/MonitorTask.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -463,7 +463,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videosendhealthdidchange">videoSendHealthDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L102">src/task/MonitorTask.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L108">src/task/MonitorTask.ts:108</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -490,7 +490,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L95">src/task/MonitorTask.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/task/MonitorTask.ts#L101">src/task/MonitorTask.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/script/barrelize.js
+++ b/script/barrelize.js
@@ -43,6 +43,10 @@ const ignoredTypes = [
   // Events ingestion internal functions.
   'flattenEventAttributes',
 
+  // Resource monitor
+  'ResourceMonitor',
+  'DefaultResourceMonitor',
+
   // Ignore utils
   'Utils'
 ];

--- a/src/resourcemonitor/DefaultResourceMonitor.ts
+++ b/src/resourcemonitor/DefaultResourceMonitor.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import Logger from '../logger/Logger';
+import ResourceMonitor from '../resourcemonitor/ResourceMonitor';
+import AsyncScheduler from '../scheduler/AsyncScheduler';
+import IntervalScheduler from '../scheduler/IntervalScheduler';
+
+/**
+ * [[DefaultResourceMonitor]] uses an execution time of the setTimeout with a zero delay
+ * to estimate resource consumption. If the execution time exceeds the given threshold,
+ * this monitor outputs a log message.
+ * @internal
+ */
+export default class DefaultResourceMonitor implements ResourceMonitor {
+  private readonly intervalScheduler: IntervalScheduler;
+
+  private count: number = 0;
+  private timestampMs: number = 0;
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly dataPoints: number = 3,
+    private readonly intervalMs: number = 5000,
+    private readonly thresholdMs: number = 100,
+    private readonly waitTimeMs: number = 30000
+  ) {
+    this.intervalScheduler = new IntervalScheduler(this.intervalMs);
+  }
+
+  start(): void {
+    this.intervalScheduler.start(() => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+
+      const start = performance.now();
+      new AsyncScheduler().start(() => {
+        const elapsed = performance.now() - start;
+        this.logger.debug(`resource monitor: ${elapsed}`);
+
+        if (elapsed >= this.thresholdMs) {
+          this.count += 1;
+        } else {
+          this.count = 0;
+        }
+
+        if (this.count >= this.dataPoints && Date.now() - this.timestampMs > this.waitTimeMs) {
+          this.logger.info('insufficient resources');
+          this.timestampMs = Date.now();
+        }
+      });
+    });
+  }
+
+  stop(): void {
+    this.intervalScheduler.stop();
+  }
+}

--- a/src/resourcemonitor/ResourceMonitor.ts
+++ b/src/resourcemonitor/ResourceMonitor.ts
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * [[ResourceMonitor]] monitors resource consumption.
+ * @internal
+ */
+export default interface ResourceMonitor {
+  /**
+   * Starts the resource monitor.
+   */
+  start(): void;
+
+  /**
+   * Stops the resource monitor.
+   */
+  stop(): void;
+}

--- a/src/task/MonitorTask.ts
+++ b/src/task/MonitorTask.ts
@@ -17,6 +17,8 @@ import Maybe from '../maybe/Maybe';
 import MeetingSessionStatus from '../meetingsession/MeetingSessionStatus';
 import MeetingSessionStatusCode from '../meetingsession/MeetingSessionStatusCode';
 import RemovableObserver from '../removableobserver/RemovableObserver';
+import DefaultResourceMonitor from '../resourcemonitor/DefaultResourceMonitor';
+import ResourceMonitor from '../resourcemonitor/ResourceMonitor';
 import SignalingClientEvent from '../signalingclient/SignalingClientEvent';
 import SignalingClientEventType from '../signalingclient/SignalingClientEventType';
 import SignalingClientObserver from '../signalingclientobserver/SignalingClientObserver';
@@ -44,6 +46,7 @@ export default class MonitorTask
   private currentAvailableStreamAvgBitrates: ISdkBitrateFrame = null;
   private hasSignalingError: boolean = false;
   private presenceHandlerCalled: boolean = false;
+  private readonly resourceMonitor: ResourceMonitor;
 
   constructor(
     private context: AudioVideoControllerState,
@@ -60,6 +63,7 @@ export default class MonitorTask
       { ...connectionHealthPolicyConfiguration },
       this.initialConnectionHealthData.clone()
     );
+    this.resourceMonitor = new DefaultResourceMonitor(context.logger);
   }
 
   removeObserver(): void {
@@ -74,6 +78,7 @@ export default class MonitorTask
       this.realtimeAttendeeIdPresenceHandler
     );
     this.context.signalingClient.removeObserver(this);
+    this.resourceMonitor.stop();
   }
 
   async run(): Promise<void> {
@@ -90,6 +95,7 @@ export default class MonitorTask
     this.context.connectionMonitor.start();
     this.context.statsCollector.start(this.context.signalingClient, this.context.videoStreamIndex);
     this.context.signalingClient.registerObserver(this);
+    this.resourceMonitor.start();
   }
 
   videoTileDidUpdate(_tileState: VideoTileState): void {

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -799,6 +799,7 @@ describe('DefaultAudioVideoController', () => {
       spy1.restore();
       spy2.restore();
       spy3.restore();
+      await stop();
     });
 
     it('can be started and take a bandwidth update with update transceiver controller method', async () => {
@@ -819,6 +820,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.handleHasBandwidthPriority(true);
       expect(spy.calledTwice).to.be.true;
       spy.restore();
+      await stop();
     });
 
     it('can be started and stopped multiple times with transceiver controller set correctly', async function () {

--- a/test/resourcemonitor/DefaultResourceMonitor.test.ts
+++ b/test/resourcemonitor/DefaultResourceMonitor.test.ts
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
+import LogLevel from '../../src/logger/LogLevel';
+import NoOpLogger from '../../src/logger/NoOpLogger';
+import DefaultResourceMonitor from '../../src/resourcemonitor/DefaultResourceMonitor';
+import { wait } from '../../src/utils/Utils';
+import DOMMockBehavior from '../dommock/DOMMockBehavior';
+import DOMMockBuilder from '../dommock/DOMMockBuilder';
+
+describe('DefaultResourceMonitor', () => {
+  const expect: Chai.ExpectStatic = chai.expect;
+
+  let domMockBuilder: DOMMockBuilder;
+  let domMockBehavior: DOMMockBehavior;
+  let resourceMonitor: DefaultResourceMonitor;
+  let logger: NoOpLogger;
+
+  beforeEach(() => {
+    domMockBehavior = new DOMMockBehavior();
+    domMockBuilder = new DOMMockBuilder(domMockBehavior);
+    logger = new NoOpLogger(LogLevel.DEBUG);
+  });
+
+  afterEach(() => {
+    domMockBuilder.cleanup();
+  });
+
+  describe('start', () => {
+    it('warns when the execution time exceeds the threshold', async () => {
+      const dataPoints = 3;
+      const debugSpy = sinon.spy(logger, 'debug');
+      const warnSpy = sinon.spy(logger, 'warn');
+      resourceMonitor = new DefaultResourceMonitor(logger, dataPoints, 10, 0);
+      resourceMonitor.start();
+      await wait(50);
+      resourceMonitor.stop();
+      expect(debugSpy.callCount).to.greaterThan(dataPoints);
+      expect(warnSpy.calledWith('insufficient resources'));
+      debugSpy.restore();
+      warnSpy.restore();
+    });
+
+    it('does not warn if the execution time does not exceed the threshold', async () => {
+      const spy = sinon.spy(logger, 'warn');
+      resourceMonitor = new DefaultResourceMonitor(logger, 1, 10, Infinity);
+      resourceMonitor.start();
+      await wait(50);
+      resourceMonitor.stop();
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+
+    it('does not calculate the execution time if the document is not visible', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any)['document'].visibilityState = 'hidden';
+      const spy = sinon.spy(logger, 'debug');
+      resourceMonitor = new DefaultResourceMonitor(logger, 1, 10, 0);
+      resourceMonitor.start();
+      await wait(50);
+      resourceMonitor.stop();
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+  });
+
+  describe('stop', () => {
+    it('stops before calcluating the execution time', async () => {
+      const spy = sinon.spy(logger, 'debug');
+      resourceMonitor = new DefaultResourceMonitor(logger);
+      resourceMonitor.start();
+      resourceMonitor.stop();
+      expect(spy.called).to.be.false;
+    });
+  });
+});

--- a/test/task/MonitorTask.test.ts
+++ b/test/task/MonitorTask.test.ts
@@ -204,6 +204,7 @@ describe('MonitorTask', () => {
       domMockBuilder.cleanup();
       domMockBuilder = null;
     }
+    context.removableObservers?.[0]?.removeObserver();
   });
 
   describe('run', () => {


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Add an internal resource monitor that approximates a CPU overload.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Ran the demo app in CPU overload and ensured that the demo output a message.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, the meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No, only an internal class and interface.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

