### PR TITLE
Fix simulcast guide that adaptive probe downlink policy is not enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix priority-based downlink policy to not unpaused tiles that are not paused by the policy.
 - Fix empty video tiles when using priority-based downlink policy.
+- Fix simulcast guide that adaptive probe downlink policy is not enabled by default.
 
 ## [2.16.1] - 2021-08-23
 

--- a/docs/modules/simulcast.html
+++ b/docs/modules/simulcast.html
@@ -76,7 +76,11 @@
 					<p>In multi-party video calls, attendees can enable the simulcast feature to enhance the overall video quality. Simulcast is a standardized technique where the video publishers create multiple renditions, or layers, of the same video source and video subscribers have the flexibility to choose the rendition that best fits their needs based on such factors as available bandwidth, compute and screen size.
 					The uplink policy controls the configuration of the renditions through camera capture and encoding parameters. The simulcast-enabled uplink policy is <a href="https://aws.github.io/amazon-chime-sdk-js/classes/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.</p>
 					<p>Simulcast is currently disabled by default. To enable it <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers">MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers">MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers</a> must both be set. With those set to true, the simulcast uplink policy will be automatically selected. We currently do not allow overriding the uplink policy when enable simulcast is set to true. Currently, only Chrome 76 and above is supported.</p>
-					<p>The <a href="https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html">VideoAdaptiveProbePolicy</a> downlink policy adaptively subscribes to the best simulcast layer and is automatically selected if <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers">MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers">MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers</a> are set to true.</p>
+					<p>The <a href="https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html">VideoAdaptiveProbePolicy</a>
+						downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default
+					<a href="https://aws.github.io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html">AllHighestDownlinkPolicy</a>.</p>
+					<p>If you want more fine-grained control of which simulcast layer to subscribe, please use <a href="https://aws.github.io/amazon-chime-sdk-js/classes/videoprioritybasedpolicy">VideoPriorityBasedPolicy</a>. More details about priority-based downlink policy can be
+					found <a href="https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html">here</a>.</p>
 					<a href="#details" id="details" style="color: inherit; text-decoration: none;">
 						<h2>Details</h2>
 					</a>
@@ -186,6 +190,9 @@
 					in the created <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html">MeetingSessionConfiguration</a>.</p>
 					<pre><code class="language-javascript">configuration.enableUnifiedPlanForChromiumBasedBrowsers = <span class="hljs-literal">true</span>;
 configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = <span class="hljs-literal">true</span>;
+
+<span class="hljs-comment">//Specify the apdative probe downlink policy</span>
+configuration.videoDownlinkBandwidthPolicy = <span class="hljs-keyword">new</span> VideoAdaptiveProbePolicy(logger);
 </code></pre>
 					<p>Now create a meeting session with the simulcast enabled meeting session configuration.</p>
 					<pre><code class="language-javascript"><span class="hljs-comment">// In the examples below, you will use this meetingSession object.</span>

--- a/guides/05_Simulcast.md
+++ b/guides/05_Simulcast.md
@@ -5,7 +5,12 @@ The uplink policy controls the configuration of the renditions through camera ca
 
 Simulcast is currently disabled by default. To enable it [MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers) and [MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers) must both be set. With those set to true, the simulcast uplink policy will be automatically selected. We currently do not allow overriding the uplink policy when enable simulcast is set to true. Currently, only Chrome 76 and above is supported.
 
-The [VideoAdaptiveProbePolicy](https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html) downlink policy adaptively subscribes to the best simulcast layer and is automatically selected if [MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers) and [MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers) are set to true.
+The [VideoAdaptiveProbePolicy](https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html) 
+downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default 
+[AllHighestDownlinkPolicy](https://aws.github.io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html).
+
+If you want more fine-grained control of which simulcast layer to subscribe, please use [VideoPriorityBasedPolicy](https://aws.github.io/amazon-chime-sdk-js/classes/videoprioritybasedpolicy). More details about priority-based downlink policy can be 
+found [here](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).
 
 ## Details
 
@@ -83,6 +88,9 @@ in the created [MeetingSessionConfiguration](https://aws.github.io/amazon-chime-
 ```javascript
 configuration.enableUnifiedPlanForChromiumBasedBrowsers = true;
 configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
+
+//Specify the apdative probe downlink policy
+configuration.videoDownlinkBandwidthPolicy = new VideoAdaptiveProbePolicy(logger);
 ```
 
 Now create a meeting session with the simulcast enabled meeting session configuration.


### PR DESCRIPTION
**Issue #1524 :**

**Description of changes:**
Update simulcast guide that adaptive probe downlink policy is not enabled by default and you need to initialize it.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

