### PR TITLE
Clarify why not use default downlink policy with simulcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new optional API `getVideoTileForAttendeeId` in `VideoTileController` and raise the `tileWillBePausedByDownlinkPolicy` event for empty video tiles.
 
 ### Changed
+- Clarify why not use default downlink policy with simulcast.
 
 ### Removed
 

--- a/docs/modules/simulcast.html
+++ b/docs/modules/simulcast.html
@@ -77,8 +77,10 @@
 					The uplink policy controls the configuration of the renditions through camera capture and encoding parameters. The simulcast-enabled uplink policy is <a href="https://aws.github.io/amazon-chime-sdk-js/classes/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.</p>
 					<p>Simulcast is currently disabled by default. To enable it <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers">MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers</a> and <a href="https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers">MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers</a> must both be set. With those set to true, the simulcast uplink policy will be automatically selected. We currently do not allow overriding the uplink policy when enable simulcast is set to true. Currently, only Chrome 76 and above is supported.</p>
 					<p>The <a href="https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html">VideoAdaptiveProbePolicy</a>
-						downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default
-					<a href="https://aws.github.io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html">AllHighestDownlinkPolicy</a>.</p>
+						downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default downlink
+						policy. The default downlink policy [AllHighestDownlinkPolicy](<a href="https://aws.github">https://aws.github</a>.
+						io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html) just subscribes to the highest video stream
+					available and does not choose optimal simulcast layer according to bandwidth condition.</p>
 					<p>If you want more fine-grained control of which simulcast layer to subscribe, please use <a href="https://aws.github.io/amazon-chime-sdk-js/classes/videoprioritybasedpolicy">VideoPriorityBasedPolicy</a>. More details about priority-based downlink policy can be
 					found <a href="https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html">here</a>.</p>
 					<a href="#details" id="details" style="color: inherit; text-decoration: none;">

--- a/guides/05_Simulcast.md
+++ b/guides/05_Simulcast.md
@@ -6,8 +6,10 @@ The uplink policy controls the configuration of the renditions through camera ca
 Simulcast is currently disabled by default. To enable it [MeetingSessionConfiguration.enableUnifiedPlanForChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enableunifiedplanforchromiumbasedbrowsers) and [MeetingSessionConfiguration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers](https://aws.github.io/amazon-chime-sdk-js/classes/meetingsessionconfiguration.html#enablesimulcastforunifiedplanchromiumbasedbrowsers) must both be set. With those set to true, the simulcast uplink policy will be automatically selected. We currently do not allow overriding the uplink policy when enable simulcast is set to true. Currently, only Chrome 76 and above is supported.
 
 The [VideoAdaptiveProbePolicy](https://aws.github.io/amazon-chime-sdk-js/classes/videoadaptiveprobepolicy.html) 
-downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default 
-[AllHighestDownlinkPolicy](https://aws.github.io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html).
+downlink policy adaptively subscribes to the best simulcast layer and should be used instead of the default downlink 
+policy. The default downlink policy [AllHighestDownlinkPolicy](https://aws.github.
+io/amazon-chime-sdk-js/classes/allhighestvideobandwidthpolicy.html) just subscribes to the highest video stream 
+available and does not choose optimal simulcast layer according to bandwidth condition.
 
 If you want more fine-grained control of which simulcast layer to subscribe, please use [VideoPriorityBasedPolicy](https://aws.github.io/amazon-chime-sdk-js/classes/videoprioritybasedpolicy). More details about priority-based downlink policy can be 
 found [here](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html).


### PR DESCRIPTION
**Description of changes:**
Follow up to PR #1539 to clarify why we do not want to use all highest downlink policy with simulcast
**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? N/A
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? N/A
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

