### PR TITLE
Trace `getRTCPeerConnectionStats()` and `hasStartedLocalVideoTile()` with DEBUG level logs to reduce  INFO logging noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Clarify why not use default downlink policy with simulcast.
+- Trace `getRTCPeerConnectionStats()` and `hasStartedLocalVideoTile()` with DEBUG level logs instead of INFO to reduce logging noise.
 
 ### Removed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1380,6 +1380,9 @@ export class DemoMeetingApp
   }
 
   showVideoWebRTCStats(videoMetricReport: { [id: string]: { [id: string]: {} } }): void {
+    if (this.availablelTileSize() === 0) {
+      return;
+    }
     const videoTiles = this.audioVideo.getAllVideoTiles();
     if (videoTiles.length === 0) {
       return;
@@ -3249,7 +3252,11 @@ export class DemoMeetingApp
     } else {
       this.updateProperty(pauseStateElement, 'innerText', '');
     }
-    this.showTile(tileElement, tileState);
+    if (tileState.localTile && !tileState.active && !tileState.paused) {
+      this.hideTile(tileIndex);
+    } else {
+      this.showTile(tileElement, tileState);
+    }
     this.updateGridClasses();
     this.layoutFeaturedTile();
   }

--- a/docs/classes/defaultaudiovideofacade.html
+++ b/docs/classes/defaultaudiovideofacade.html
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L27">src/audiovideofacade/DefaultAudioVideoFacade.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L28">src/audiovideofacade/DefaultAudioVideoFacade.ts:28</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -228,7 +228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L477">src/audiovideofacade/DefaultAudioVideoFacade.ts:477</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L487">src/audiovideofacade/DefaultAudioVideoFacade.ts:487</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/transcriptioncontroller.html" class="tsd-signature-type">TranscriptionController</a></h4>
@@ -249,7 +249,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L447">src/audiovideofacade/DefaultAudioVideoFacade.ts:447</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L453">src/audiovideofacade/DefaultAudioVideoFacade.ts:453</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -273,7 +273,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L354">src/audiovideofacade/DefaultAudioVideoFacade.ts:354</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L360">src/audiovideofacade/DefaultAudioVideoFacade.ts:360</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -297,7 +297,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L37">src/audiovideofacade/DefaultAudioVideoFacade.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L38">src/audiovideofacade/DefaultAudioVideoFacade.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#addvideotile">addVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L144">src/audiovideofacade/DefaultAudioVideoFacade.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L150">src/audiovideofacade/DefaultAudioVideoFacade.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a></h4>
@@ -339,7 +339,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#bindaudioelement">bindAudioElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L67">src/audiovideofacade/DefaultAudioVideoFacade.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L73">src/audiovideofacade/DefaultAudioVideoFacade.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -363,7 +363,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L78">src/audiovideofacade/DefaultAudioVideoFacade.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L84">src/audiovideofacade/DefaultAudioVideoFacade.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -390,7 +390,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#capturevideotile">captureVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L166">src/audiovideofacade/DefaultAudioVideoFacade.ts:166</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L172">src/audiovideofacade/DefaultAudioVideoFacade.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -414,7 +414,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudioinputdevice">chooseAudioInputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L333">src/audiovideofacade/DefaultAudioVideoFacade.ts:333</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L339">src/audiovideofacade/DefaultAudioVideoFacade.ts:339</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +438,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#chooseaudiooutputdevice">chooseAudioOutputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L348">src/audiovideofacade/DefaultAudioVideoFacade.ts:348</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L354">src/audiovideofacade/DefaultAudioVideoFacade.ts:354</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -462,7 +462,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputdevice">chooseVideoInputDevice</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L338">src/audiovideofacade/DefaultAudioVideoFacade.ts:338</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L344">src/audiovideofacade/DefaultAudioVideoFacade.ts:344</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -486,7 +486,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L391">src/audiovideofacade/DefaultAudioVideoFacade.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L397">src/audiovideofacade/DefaultAudioVideoFacade.ts:397</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -519,7 +519,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L364">src/audiovideofacade/DefaultAudioVideoFacade.ts:364</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L370">src/audiovideofacade/DefaultAudioVideoFacade.ts:370</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/removableanalysernode.html" class="tsd-signature-type">RemovableAnalyserNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -537,7 +537,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getallremotevideotiles">getAllRemoteVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L132">src/audiovideofacade/DefaultAudioVideoFacade.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L138">src/audiovideofacade/DefaultAudioVideoFacade.ts:138</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -555,7 +555,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getallvideotiles">getAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L138">src/audiovideofacade/DefaultAudioVideoFacade.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L144">src/audiovideofacade/DefaultAudioVideoFacade.ts:144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -573,7 +573,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getlocalvideotile">getLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L110">src/audiovideofacade/DefaultAudioVideoFacade.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L116">src/audiovideofacade/DefaultAudioVideoFacade.ts:116</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videotile.html" class="tsd-signature-type">VideoTile</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -591,7 +591,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getrtcpeerconnectionstats">getRTCPeerConnectionStats</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L62">src/audiovideofacade/DefaultAudioVideoFacade.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L63">src/audiovideofacade/DefaultAudioVideoFacade.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -615,7 +615,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L471">src/audiovideofacade/DefaultAudioVideoFacade.ts:471</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L481">src/audiovideofacade/DefaultAudioVideoFacade.ts:481</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videosource.html" class="tsd-signature-type">VideoSource</a><span class="tsd-signature-symbol">[]</span></h4>
@@ -633,7 +633,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L406">src/audiovideofacade/DefaultAudioVideoFacade.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L412">src/audiovideofacade/DefaultAudioVideoFacade.ts:412</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -651,7 +651,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#getvideotile">getVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L126">src/audiovideofacade/DefaultAudioVideoFacade.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L132">src/audiovideofacade/DefaultAudioVideoFacade.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -675,7 +675,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#hasstartedlocalvideotile">hasStartedLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L99">src/audiovideofacade/DefaultAudioVideoFacade.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L105">src/audiovideofacade/DefaultAudioVideoFacade.ts:105</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -693,7 +693,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L315">src/audiovideofacade/DefaultAudioVideoFacade.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L321">src/audiovideofacade/DefaultAudioVideoFacade.ts:321</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -717,7 +717,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L327">src/audiovideofacade/DefaultAudioVideoFacade.ts:327</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L333">src/audiovideofacade/DefaultAudioVideoFacade.ts:333</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -741,7 +741,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L321">src/audiovideofacade/DefaultAudioVideoFacade.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L327">src/audiovideofacade/DefaultAudioVideoFacade.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -765,7 +765,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L385">src/audiovideofacade/DefaultAudioVideoFacade.ts:385</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L391">src/audiovideofacade/DefaultAudioVideoFacade.ts:391</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -789,7 +789,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L432">src/audiovideofacade/DefaultAudioVideoFacade.ts:432</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L438">src/audiovideofacade/DefaultAudioVideoFacade.ts:438</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -807,7 +807,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#pausevideotile">pauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L116">src/audiovideofacade/DefaultAudioVideoFacade.ts:116</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L122">src/audiovideofacade/DefaultAudioVideoFacade.ts:122</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -831,7 +831,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L210">src/audiovideofacade/DefaultAudioVideoFacade.ts:210</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L216">src/audiovideofacade/DefaultAudioVideoFacade.ts:216</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -849,7 +849,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L236">src/audiovideofacade/DefaultAudioVideoFacade.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L242">src/audiovideofacade/DefaultAudioVideoFacade.ts:242</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -867,7 +867,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L216">src/audiovideofacade/DefaultAudioVideoFacade.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L222">src/audiovideofacade/DefaultAudioVideoFacade.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -885,7 +885,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L265">src/audiovideofacade/DefaultAudioVideoFacade.ts:265</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L271">src/audiovideofacade/DefaultAudioVideoFacade.ts:271</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -915,7 +915,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L196">src/audiovideofacade/DefaultAudioVideoFacade.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L202">src/audiovideofacade/DefaultAudioVideoFacade.ts:202</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -938,7 +938,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L172">src/audiovideofacade/DefaultAudioVideoFacade.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L178">src/audiovideofacade/DefaultAudioVideoFacade.ts:178</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -988,7 +988,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L287">src/audiovideofacade/DefaultAudioVideoFacade.ts:287</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L293">src/audiovideofacade/DefaultAudioVideoFacade.ts:293</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1029,7 +1029,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L255">src/audiovideofacade/DefaultAudioVideoFacade.ts:255</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L261">src/audiovideofacade/DefaultAudioVideoFacade.ts:261</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1070,7 +1070,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L227">src/audiovideofacade/DefaultAudioVideoFacade.ts:227</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L233">src/audiovideofacade/DefaultAudioVideoFacade.ts:233</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1111,7 +1111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L274">src/audiovideofacade/DefaultAudioVideoFacade.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L280">src/audiovideofacade/DefaultAudioVideoFacade.ts:280</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1155,7 +1155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L201">src/audiovideofacade/DefaultAudioVideoFacade.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L207">src/audiovideofacade/DefaultAudioVideoFacade.ts:207</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1197,7 +1197,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L242">src/audiovideofacade/DefaultAudioVideoFacade.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L248">src/audiovideofacade/DefaultAudioVideoFacade.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1224,7 +1224,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L221">src/audiovideofacade/DefaultAudioVideoFacade.ts:221</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L227">src/audiovideofacade/DefaultAudioVideoFacade.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1242,7 +1242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L282">src/audiovideofacade/DefaultAudioVideoFacade.ts:282</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L288">src/audiovideofacade/DefaultAudioVideoFacade.ts:288</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1266,7 +1266,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L247">src/audiovideofacade/DefaultAudioVideoFacade.ts:247</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L253">src/audiovideofacade/DefaultAudioVideoFacade.ts:253</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1292,7 +1292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L184">src/audiovideofacade/DefaultAudioVideoFacade.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L190">src/audiovideofacade/DefaultAudioVideoFacade.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1342,7 +1342,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L291">src/audiovideofacade/DefaultAudioVideoFacade.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L297">src/audiovideofacade/DefaultAudioVideoFacade.ts:297</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1383,7 +1383,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L260">src/audiovideofacade/DefaultAudioVideoFacade.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L266">src/audiovideofacade/DefaultAudioVideoFacade.ts:266</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1424,7 +1424,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L232">src/audiovideofacade/DefaultAudioVideoFacade.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L238">src/audiovideofacade/DefaultAudioVideoFacade.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1465,7 +1465,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L206">src/audiovideofacade/DefaultAudioVideoFacade.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L212">src/audiovideofacade/DefaultAudioVideoFacade.ts:212</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1507,7 +1507,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removeallvideotiles">removeAllVideoTiles</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L161">src/audiovideofacade/DefaultAudioVideoFacade.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L167">src/audiovideofacade/DefaultAudioVideoFacade.ts:167</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1525,7 +1525,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L452">src/audiovideofacade/DefaultAudioVideoFacade.ts:452</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L458">src/audiovideofacade/DefaultAudioVideoFacade.ts:458</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1549,7 +1549,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L359">src/audiovideofacade/DefaultAudioVideoFacade.ts:359</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L365">src/audiovideofacade/DefaultAudioVideoFacade.ts:365</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1573,7 +1573,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removelocalvideotile">removeLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L105">src/audiovideofacade/DefaultAudioVideoFacade.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L111">src/audiovideofacade/DefaultAudioVideoFacade.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1591,7 +1591,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L42">src/audiovideofacade/DefaultAudioVideoFacade.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L43">src/audiovideofacade/DefaultAudioVideoFacade.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1615,7 +1615,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removevideotile">removeVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L150">src/audiovideofacade/DefaultAudioVideoFacade.ts:150</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L156">src/audiovideofacade/DefaultAudioVideoFacade.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1639,7 +1639,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#removevideotilesbyattendeeid">removeVideoTilesByAttendeeId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L155">src/audiovideofacade/DefaultAudioVideoFacade.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L161">src/audiovideofacade/DefaultAudioVideoFacade.ts:161</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1663,7 +1663,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#setaudioprofile">setAudioProfile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L47">src/audiovideofacade/DefaultAudioVideoFacade.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L48">src/audiovideofacade/DefaultAudioVideoFacade.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1687,7 +1687,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#setcontentaudioprofile">setContentAudioProfile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L412">src/audiovideofacade/DefaultAudioVideoFacade.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L418">src/audiovideofacade/DefaultAudioVideoFacade.ts:418</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1710,7 +1710,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L380">src/audiovideofacade/DefaultAudioVideoFacade.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L386">src/audiovideofacade/DefaultAudioVideoFacade.ts:386</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1745,7 +1745,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L52">src/audiovideofacade/DefaultAudioVideoFacade.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L53">src/audiovideofacade/DefaultAudioVideoFacade.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1774,7 +1774,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L417">src/audiovideofacade/DefaultAudioVideoFacade.ts:417</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L423">src/audiovideofacade/DefaultAudioVideoFacade.ts:423</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1798,7 +1798,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L423">src/audiovideofacade/DefaultAudioVideoFacade.ts:423</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L429">src/audiovideofacade/DefaultAudioVideoFacade.ts:429</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1825,7 +1825,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startlocalvideotile">startLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L88">src/audiovideofacade/DefaultAudioVideoFacade.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L94">src/audiovideofacade/DefaultAudioVideoFacade.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -1843,7 +1843,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L370">src/audiovideofacade/DefaultAudioVideoFacade.ts:370</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L376">src/audiovideofacade/DefaultAudioVideoFacade.ts:376</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1867,7 +1867,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L57">src/audiovideofacade/DefaultAudioVideoFacade.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L58">src/audiovideofacade/DefaultAudioVideoFacade.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1885,7 +1885,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L442">src/audiovideofacade/DefaultAudioVideoFacade.ts:442</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L448">src/audiovideofacade/DefaultAudioVideoFacade.ts:448</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1903,7 +1903,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stoplocalvideotile">stopLocalVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L94">src/audiovideofacade/DefaultAudioVideoFacade.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L100">src/audiovideofacade/DefaultAudioVideoFacade.ts:100</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -1921,7 +1921,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L375">src/audiovideofacade/DefaultAudioVideoFacade.ts:375</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L381">src/audiovideofacade/DefaultAudioVideoFacade.ts:381</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1944,7 +1944,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L295">src/audiovideofacade/DefaultAudioVideoFacade.ts:295</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L301">src/audiovideofacade/DefaultAudioVideoFacade.ts:301</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2018,7 +2018,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unbindaudioelement">unbindAudioElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L73">src/audiovideofacade/DefaultAudioVideoFacade.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L79">src/audiovideofacade/DefaultAudioVideoFacade.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2036,7 +2036,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unbindvideoelement">unbindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L83">src/audiovideofacade/DefaultAudioVideoFacade.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L89">src/audiovideofacade/DefaultAudioVideoFacade.ts:89</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2060,7 +2060,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L437">src/audiovideofacade/DefaultAudioVideoFacade.ts:437</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L443">src/audiovideofacade/DefaultAudioVideoFacade.ts:443</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -2078,7 +2078,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideofacade.html">AudioVideoFacade</a>.<a href="../interfaces/audiovideofacade.html#unpausevideotile">unpauseVideoTile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L121">src/audiovideofacade/DefaultAudioVideoFacade.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L127">src/audiovideofacade/DefaultAudioVideoFacade.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2101,7 +2101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L310">src/audiovideofacade/DefaultAudioVideoFacade.ts:310</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/audiovideofacade/DefaultAudioVideoFacade.ts#L316">src/audiovideofacade/DefaultAudioVideoFacade.ts:316</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/audiovideofacade/DefaultAudioVideoFacade.ts
+++ b/src/audiovideofacade/DefaultAudioVideoFacade.ts
@@ -17,6 +17,7 @@ import RemovableAnalyserNode from '../devicecontroller/RemovableAnalyserNode';
 import VideoInputDevice from '../devicecontroller/VideoInputDevice';
 import VideoQualitySettings from '../devicecontroller/VideoQualitySettings';
 import { isVideoTransformDevice } from '../devicecontroller/VideoTransformDevice';
+import LogLevel from '../logger/LogLevel';
 import RealtimeController from '../realtimecontroller/RealtimeController';
 import type VolumeIndicatorCallback from '../realtimecontroller/VolumeIndicatorCallback';
 import TranscriptionController from '../transcript/TranscriptionController';
@@ -60,7 +61,12 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
   }
 
   getRTCPeerConnectionStats(selector?: MediaStreamTrack): Promise<RTCStatsReport> {
-    this.trace('getRTCPeerConnectionStats', selector ? selector.id : null);
+    this.trace(
+      'getRTCPeerConnectionStats',
+      selector ? selector.id : null,
+      undefined,
+      LogLevel.DEBUG
+    );
     return this.audioVideoController.getRTCPeerConnectionStats(selector);
   }
 
@@ -98,7 +104,7 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
 
   hasStartedLocalVideoTile(): boolean {
     const result = this.videoTileController.hasStartedLocalVideoTile();
-    this.trace('hasStartedLocalVideoTile', null, result);
+    this.trace('hasStartedLocalVideoTile', null, result, LogLevel.DEBUG);
     return result;
   }
 
@@ -455,7 +461,7 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private trace(name: string, input?: any, output?: any): void {
+  private trace(name: string, input?: any, output?: any, logLevel = LogLevel.INFO): void {
     const meetingId = this.audioVideoController.configuration.meetingId;
     const attendeeId = this.audioVideoController.configuration.credentials.attendeeId;
     let s = `API/DefaultAudioVideoFacade/${meetingId}/${attendeeId}/${name}`;
@@ -465,7 +471,11 @@ export default class DefaultAudioVideoFacade implements AudioVideoFacade {
     if (typeof output !== 'undefined') {
       s += ` -> ${JSON.stringify(output)}`;
     }
-    this.audioVideoController.logger.info(s);
+    if (logLevel === LogLevel.DEBUG) {
+      this.audioVideoController.logger.debug(s);
+    } else {
+      this.audioVideoController.logger.info(s);
+    }
   }
 
   getRemoteVideoSources(): VideoSource[] {


### PR DESCRIPTION
**Issue #:**
- Info level logs print a lot of `getRTCPeerConnectionStats` -> `null` and similarly for `hasStartedLocalVideoTile()`.
- This creates a lot of noise in INFO level logging which is not needed.
- [Demo only] Local video `div` never closes even when local video is stopped.

**Description of changes:**
- Trace `getRTCPeerConnectionStats()` and `hasStartedLocalVideoTile()` with DEBUG level logs
- Use `availablelTileSize()` demo function to show stats only when videos
are turned on and available.
- Fix `videoTileDidUpdate()` in demo to correctly close local video tile. Currently, the `div` containing the local video tile never closes, the video closes but the `div` is still visible, this fixes that. This is due to `videoTileDidUpdate` sending us update like 4 times and we never hide the local video tile when the tile state becomes in-active. We call `stopLocalVideoTile` which does not hide the video tile. Only time we hide the tile currently in the demo is in `videoTileWasRemoved` AudioVideoObserver which is only called when one calls `removeLocalVideoTile()`. We do not call `removeLocalVideoTile()` in the demo.
- Optimize the WebRTC stats show in demo when at least 1 video is available.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes.
2. How did you test these changes?
- Join the demo browser meeting selecting only INFO level logs.
- Checked and see these traces do not appear now with INFO level logs.
- Join a meeting with DEBUG level logging, checked and see these `getRTCPeerConnectionStats()` and `hasStartedLocalVideoTile()` trace logs.
- Joined a meeting, turned a local video, turned it off and the `div` is not visible anymore.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, the demo browser meeting.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

