### PR TITLE
Fix up incorrect argument in unused SDP munging function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Clarify why not use default downlink policy with simulcast.
+- Corrected argument `isUnifiedPlan` in `withBandwidthRestriction` to `isFirefox`. Also marked as deprecated since we no longer use it.
 
 ### Removed
 

--- a/docs/classes/defaultsdp.html
+++ b/docs/classes/defaultsdp.html
@@ -325,7 +325,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#preferh264ifexists">preferH264IfExists</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L269">src/sdp/DefaultSDP.ts:269</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L270">src/sdp/DefaultSDP.ts:270</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -343,7 +343,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#ssrcforvideosendingsection">ssrcForVideoSendingSection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L385">src/sdp/DefaultSDP.ts:385</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L386">src/sdp/DefaultSDP.ts:386</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -361,7 +361,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#videosendsectionhasdifferentssrc">videoSendSectionHasDifferentSSRC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L409">src/sdp/DefaultSDP.ts:409</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L410">src/sdp/DefaultSDP.ts:410</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -384,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L209">src/sdp/DefaultSDP.ts:209</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L210">src/sdp/DefaultSDP.ts:210</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -401,7 +401,7 @@
 					<a name="withbandwidthrestriction" class="tsd-anchor"></a>
 					<h3>with<wbr>Bandwidth<wbr>Restriction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">with<wbr>Bandwidth<wbr>Restriction<span class="tsd-signature-symbol">(</span>maxBitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, isUnifiedPlan<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></li>
+						<li class="tsd-signature tsd-kind-icon">with<wbr>Bandwidth<wbr>Restriction<span class="tsd-signature-symbol">(</span>maxBitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, isFirefox<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -417,7 +417,7 @@
 									<h5>maxBitrateKbps: <span class="tsd-signature-type">number</span></h5>
 								</li>
 								<li>
-									<h5>isUnifiedPlan: <span class="tsd-signature-type">boolean</span></h5>
+									<h5>isFirefox: <span class="tsd-signature-type">boolean</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>
@@ -452,7 +452,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L322">src/sdp/DefaultSDP.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L323">src/sdp/DefaultSDP.ts:323</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -476,7 +476,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/sdp.html">SDP</a>.<a href="../interfaces/sdp.html#withunifiedplanformat">withUnifiedPlanFormat</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L258">src/sdp/DefaultSDP.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/DefaultSDP.ts#L259">src/sdp/DefaultSDP.ts:259</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="defaultsdp.html" class="tsd-signature-type">DefaultSDP</a></h4>

--- a/docs/interfaces/sdp.html
+++ b/docs/interfaces/sdp.html
@@ -241,7 +241,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L78">src/sdp/SDP.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L81">src/sdp/SDP.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L68">src/sdp/SDP.ts:68</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L71">src/sdp/SDP.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L73">src/sdp/SDP.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L76">src/sdp/SDP.ts:76</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,19 +335,21 @@
 					<a name="withbandwidthrestriction" class="tsd-anchor"></a>
 					<h3>with<wbr>Bandwidth<wbr>Restriction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
-						<li class="tsd-signature tsd-kind-icon">with<wbr>Bandwidth<wbr>Restriction<span class="tsd-signature-symbol">(</span>maxBitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, isUnifiedPlan<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="sdp.html" class="tsd-signature-type">SDP</a></li>
+						<li class="tsd-signature tsd-kind-icon">with<wbr>Bandwidth<wbr>Restriction<span class="tsd-signature-symbol">(</span>maxBitrateKbps<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, isFirefox<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="sdp.html" class="tsd-signature-type">SDP</a></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L58">src/sdp/SDP.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L61">src/sdp/SDP.ts:61</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Inserts a bandwidth limitation attribute to answer SDP for setRemoteDescription and limiting client outbound maximum bitrate</p>
+									<p>Deprecated: <code>RTCRtpSender.setParameters</code> has supported setting bitrates for a while and
+									we no longer use this function in other areas of the SDK. Should remove when possible.</p>
 								</div>
+								<p>Inserts a bandwidth limitation attribute to answer SDP for setRemoteDescription and limiting client outbound maximum bitrate</p>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
@@ -355,7 +357,7 @@
 									<h5>maxBitrateKbps: <span class="tsd-signature-type">number</span></h5>
 								</li>
 								<li>
-									<h5>isUnifiedPlan: <span class="tsd-signature-type">boolean</span></h5>
+									<h5>isFirefox: <span class="tsd-signature-type">boolean</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <a href="sdp.html" class="tsd-signature-type">SDP</a></h4>
@@ -394,7 +396,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L63">src/sdp/SDP.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/sdp/SDP.ts#L66">src/sdp/SDP.ts:66</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/sdp/DefaultSDP.ts
+++ b/src/sdp/DefaultSDP.ts
@@ -190,13 +190,14 @@ export default class DefaultSDP implements SDP {
     return this.withoutCandidateType(SDPCandidateType.ServerReflexive);
   }
 
-  withBandwidthRestriction(maxBitrateKbps: number, isUnifiedPlan: boolean): DefaultSDP {
+  withBandwidthRestriction(maxBitrateKbps: number, isFirefox: boolean): DefaultSDP {
     const srcLines: string[] = this.lines();
     const dstLines: string[] = [];
     for (const line of srcLines) {
       dstLines.push(line);
       if (/^m=video/.test(line)) {
-        if (isUnifiedPlan) {
+        if (isFirefox) {
+          // https://bugzilla.mozilla.org/show_bug.cgi?id=1359854
           dstLines.push(`b=TIAS:${maxBitrateKbps * 1000}`);
         } else {
           dstLines.push(`b=AS:${maxBitrateKbps}`);

--- a/src/sdp/SDP.ts
+++ b/src/sdp/SDP.ts
@@ -53,9 +53,12 @@ export default interface SDP {
   withAudioMaxAverageBitrate(maxAverageBitrate: number): SDP;
 
   /**
+   * Deprecated: `RTCRtpSender.setParameters` has supported setting bitrates for a while and
+   * we no longer use this function in other areas of the SDK. Should remove when possible.
+   *
    * Inserts a bandwidth limitation attribute to answer SDP for setRemoteDescription and limiting client outbound maximum bitrate
    */
-  withBandwidthRestriction(maxBitrateKbps: number, isUnifiedPlan: boolean): SDP;
+  withBandwidthRestriction(maxBitrateKbps: number, isFirefox: boolean): SDP;
 
   /**
    * Munges Unified-Plan SDP from different browsers to conform to one format


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/1464

**Description of changes:** This function is not actually used anywhere so the 'fix' was simply to adjust the argument name to be accurate.  Marked as deprecated since we don't use it and really no one should, as `setParameters` is widely available now.

**Testing:**  Nothing to test, this function is unused.

1. Have you successfully run `npm run build:release` locally? y
2. How did you test these changes? Nothing to test, this function is unused.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

