### PR TITLE
Fix response call for starting and ending media capture in /demos/serverless lambda handlers

### DIFF
--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -170,7 +170,7 @@ exports.start_capture = async (event, context) => {
   }).promise();
   await putCapturePipeline(event.queryStringParameters.title, pipelineInfo)
 
-  response(response, 201, 'application/json', JSON.stringify(pipelineInfo));
+  return response(201, 'application/json', JSON.stringify(pipelineInfo));
 };
 
 exports.end_capture = async (event, context) => {
@@ -180,9 +180,9 @@ exports.end_capture = async (event, context) => {
     await chime.deleteMediaCapturePipeline({
       MediaPipelineId: pipelineInfo.MediaCapturePipeline.MediaPipelineId
     }).promise();
-    response(response, 200, 'application/json', JSON.stringify({}));
+    return response(200, 'application/json', JSON.stringify({}));
   } else {
-    response(response, 500, 'application/json', JSON.stringify({msg: "No pipeline to stop for this meeting"}))
+    return response(500, 'application/json', JSON.stringify({msg: "No pipeline to stop for this meeting"}))
   }
 };
 


### PR DESCRIPTION
**Description of changes:**
Fixed response call in `start_capture` and `end_capture` lambda handlers for `ChimeSdkStartCaptureLambda` and `ChimeSdkEndCaptureLambda` respectively.
- Removed `response` from response() call, as per the function definition
- Added return before response

**Testing**
1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Deployed demo meeting app and tested start and end media capture response in browser
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Meeting app
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

