### PR TITLE
Add video filter capability in preview screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Amazon Voice Focus will now trigger the `onCPUWarning` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
 - Amazon Voice Focus will now trigger the `voiceFocusInsufficientResources` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
 - Add retry logic in FAQs.
+- The Amazon Voice Focus support check, `VoiceFocusDeviceTransformer.isSupported`, now warns to the logger when run in an iframe, and can be configured to fail in that case.
+- Add documentation in Video Processing APIs on how to add filters in the preview window.
 
 ### Changed
 
@@ -23,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update data message limit in the API Overview guide.
 - Do not trigger real time attendee presence event for local attendee if they are not appear in audio info frame 
   during reconnection.
+- Update `startVideoPreviewForVideoInput` to support filters in the preview window.
+- Update browser demo to showcase preview filter capability.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Tags are fetched in order to correctly generate versioning metadata.
 To view code coverage results open `coverage/index.html` in your browser
 after running `npm run test`.
 
+If you run `npm run test` and the tests are running but the coverage report is not getting generated
+then you might have a resource clean up issue. In Mocha v4.0.0 or newer the implementation was changed so 
+that the Mocha processes will not force exit when the test run is complete. <br /> For example, if you have a 
+`DefaultVideoTransformDevice` in your unit test then you must call `await device.stop();` to clean up the
+resources and not run into this issue. You can also look into the usage of `done();` in the [Mocha documentation](https://mochajs.org/#asynchronous-code). 
+
 ## Generating the documentation
 
 To generate JavaScript API reference documentation run:

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -213,12 +213,17 @@
     <form id="form-devices">
       <h1 class="h3 mb-3 font-weight-normal text-center">Select devices</h1>
       <div class="row mt-3">
-        <div class="col-12 col-sm-8">
+        <div class="col-12 text-center d-sm-block video-preview">
+          <video id="video-preview" class="" style="border-radius:8px"></video>
+        </div>
+      </div>
+      <div class="row mt-3">
+        <div class="col-12">
           <label for="audio-input block">Microphone</label>
           <select id="audio-input" class="custom-select" style="width:100%"></select>
         </div>
 
-        <div class="text-center col-sm-4 d-sm-block">
+        <div class="text-center col-12 d-sm-block">
           <label>Preview</label>
           <div class="w-100 progress" style="margin-top:0.75rem">
             <div id="audio-preview" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
@@ -226,22 +231,21 @@
         </div>
       </div>
       <div class="row mt-3">
-        <div id="voice-focus-setting" class="col-12 col-sm-8 hidden">
+        <div id="voice-focus-setting" class="col-12 hidden">
           <input autocomplete="off" type="checkbox" id="add-voice-focus"></input>
           <label style="margin-left: 0.5em" for="voice-focus-setting block">Add Voice Focus</label>
         </div>
       </div>
       <div class="row mt-3">
-        <div class="col-12 col-sm-8">
+        <div class="col-12">
           <label for="video-input block">Camera</label>
           <select id="video-input" class="custom-select" style="width:100%"></select>
         </div>
-        <div class="col-sm-4 text-center d-sm-block video-preview">
-          <video id="video-preview" class="w-100 h-100" style="max-width:137px;max-height:82px;border-radius:8px"></video>
-        </div>
+        
       </div>
       <div class="row mt-3">
-        <div class="col-12 col-sm-8">
+        <div class="col-12">
+          <label for="video-input-quality block">Resolution</label>
           <select id="video-input-quality" class="custom-select" style="width:100%">
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
             <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
@@ -249,13 +253,21 @@
           </select>
         </div>
       </div>
+      <div class="row mt-3" id="video-input-filter-container">
+        <div class="col-12">
+          <label for="video-input-filter block">Video Filter</label>
+          <select id="video-input-filter" class="custom-select" style="width:100%">
+            <option value="None" selected>None</option>
+          </select>
+        </div>
+      </div>
       <div class="row mt-3">
-        <div class="col-12 col-sm-8">
+        <div class="col-12">
           <label for="audio-output block">Speaker</label>
           <select id="audio-output" class="custom-select" style="width:100%"></select>
         </div>
-        <div class="col-sm-4">
-          <button id="button-test-sound" class="btn btn-outline-secondary btn-block h-50 d-sm-block" style="margin-top:2rem">Test</button>
+        <div class="col-12">
+          <button id="button-test-sound" class="btn btn-outline-secondary btn-block h-50 d-sm-block" style="margin-top:2rem">Test Speaker</button>
         </div>
       </div>
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -76,6 +76,7 @@ import {
 import CircularCut from './videofilter/CircularCut';
 import EmojifyVideoFrameProcessor from './videofilter/EmojifyVideoFrameProcessor';
 import SegmentationProcessor from './videofilter/SegmentationProcessor';
+import ResizeProcessor from './videofilter/ResizeProcessor';
 import {
   loadBodyPixDependency,
   platformCanSupportBodyPixWithoutDegradation,
@@ -161,9 +162,9 @@ const VOICE_FOCUS_SPEC = {
 
 const MAX_VOICE_FOCUS_COMPLEXITY: VoiceFocusModelComplexity | undefined = undefined;
 
-type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'Segmentation' | 'None';
+type VideoFilterName = 'Emojify' | 'CircularCut' | 'NoOp' | 'Segmentation' | 'Resize (9/16)' | 'None';
 
-const VIDEO_FILTERS: VideoFilterName[] = ['Emojify', 'CircularCut', 'NoOp'];
+const VIDEO_FILTERS: VideoFilterName[] = ['Emojify', 'CircularCut', 'NoOp', 'Resize (9/16)'];
 
 class TestSound {
   static testAudioElement = new Audio();
@@ -651,7 +652,8 @@ export class DemoMeetingApp
 
           await this.initVoiceFocus();
           await this.populateAllDeviceLists();
-          await this.populateVideoFilterInputList();
+          await this.populateVideoFilterInputList(false);
+          await this.populateVideoFilterInputList(true);
 
           this.switchToFlow('flow-devices');
           await this.openAudioInputFromSelectionAndPreview();
@@ -751,6 +753,17 @@ export class DemoMeetingApp
       );
     });
 
+    if(!this.areVideoFiltersSupported())  {
+      document.getElementById('video-input-filter-container').style.display = 'none';
+    }
+
+    let videoInputFilter = document.getElementById('video-input-filter') as HTMLInputElement;
+    videoInputFilter.addEventListener('change', async () => {
+      this.selectedVideoFilterItem = <VideoFilterName>videoInputFilter.value;
+      this.log(`Clicking video filter: ${this.selectedVideoFilterItem}`);
+      await this.openVideoInputFromSelection(this.selectedVideoInput, true)
+    });
+
     document.getElementById('copy-sip-uri').addEventListener('click', () => {
       const sipUriElement = document.getElementById('sip-uri') as HTMLInputElement;
       sipUriElement.select();
@@ -816,8 +829,10 @@ export class DemoMeetingApp
           this.audioVideo.stopVideoPreviewForVideoInput(
             document.getElementById('video-preview') as HTMLVideoElement
           );
+          // stopVideoProcessor should be called before join; it ensures that state variables and video processor stream are cleaned / removed before joining the meeting.
+          // If stopVideoProcessor is not called then the state from preview screen will be carried into the in meeting experience and it will cause undesired side effects.
+          await this.stopVideoProcessor();
           await this.join();
-          this.audioVideo.chooseVideoInputDevice(null);
           this.hideProgress('progress-join');
           this.displayButtonStates();
           this.switchToFlow('flow-meeting');
@@ -2247,6 +2262,29 @@ export class DemoMeetingApp
     }
   }
 
+  populateVideoPreviewFilterList(
+    elementId: string,
+    genericName: string,
+    filters: VideoFilterName[]
+  ): void {
+    const list = document.getElementById(elementId) as HTMLSelectElement;
+    while (list.firstElementChild) {
+      list.removeChild(list.firstElementChild);
+    }
+    for (let i = 0; i < filters.length; i++) {
+      const option = document.createElement('option');
+      list.appendChild(option);
+      option.text = filters[i] || `${genericName} ${i + 1}`;
+      option.value = filters[i];
+    }
+    
+    if (!list.firstElementChild) {
+      const option = document.createElement('option');
+      option.text = 'Filter selection unavailable';
+      list.appendChild(option);
+    }
+  }
+
   populateInMeetingDeviceList(
     elementId: string,
     genericName: string,
@@ -2330,14 +2368,18 @@ export class DemoMeetingApp
     }
   }
 
-  private async populateVideoFilterInputList(): Promise<void> {
+  private async stopVideoProcessor(): Promise<void>  {
+    this.log('Clearing filter variables and stopping the video transform device');
+    this.chosenVideoFilter = 'None';
+    this.selectedVideoFilterItem = 'None';
+    this.chosenVideoTransformDevice?.stop();
+  }
+
+  private async populateVideoFilterInputList(isPreviewWindow: boolean): Promise<void> {
     const genericName = 'Filter';
     let filters: VideoFilterName[] = ['None'];
 
-    if (
-      this.defaultBrowserBehaviour.supportsCanvasCapturedStreamPlayback() &&
-      this.enableUnifiedPlanForChromiumBasedBrowsers
-    ) {
+    if (this.areVideoFiltersSupported()) {
       filters = filters.concat(VIDEO_FILTERS);
       if (platformCanSupportBodyPixWithoutDegradation()) {
         if (!this.loadingBodyPixDependencyPromise) {
@@ -2346,32 +2388,36 @@ export class DemoMeetingApp
         // do not use `await` to avoid blocking page loading
         this.loadingBodyPixDependencyPromise.then(() => {
           filters.push('Segmentation');
-          this.populateInMeetingDeviceList(
-            'dropdown-menu-filter',
-            genericName,
-            [],
-            filters,
-            undefined,
-            async (name: VideoFilterName) => {
-              await this.selectVideoFilterByName(name);
-            }
-          );
+          this.populateFilterList(isPreviewWindow, genericName, filters);
         }).catch(err => {
           this.log('Could not load BodyPix dependency', err);
         });
       }
     }
 
-    this.populateInMeetingDeviceList(
-      'dropdown-menu-filter',
-      genericName,
-      [],
-      filters,
-      undefined,
-      async (name: VideoFilterName) => {
-        await this.selectVideoFilterByName(name);
-      }
-    );
+    this.populateFilterList(isPreviewWindow, genericName, filters);
+  }
+
+  private async populateFilterList(isPreviewWindow: boolean, genericName: string, filters: VideoFilterName[]): Promise<void> {
+    if(isPreviewWindow) {
+      this.populateVideoPreviewFilterList(
+        'video-input-filter',
+        genericName,
+        filters
+      );
+    }
+    else  {
+      this.populateInMeetingDeviceList(
+        'dropdown-menu-filter',
+        genericName,
+        [],
+        filters,
+        undefined,
+        async (name: VideoFilterName) => {
+          await this.selectVideoFilterByName(name);
+        }
+      );
+    }
   }
 
   async populateAudioInputList(): Promise<void> {
@@ -2415,6 +2461,10 @@ export class DemoMeetingApp
         await this.selectAudioInputDeviceByName(name);
       }
     );
+  }
+
+  private areVideoFiltersSupported(): boolean {
+    return this.defaultBrowserBehaviour.supportsCanvasCapturedStreamPlayback() && this.enableUnifiedPlanForChromiumBasedBrowsers;
   }
 
   private isVoiceFocusActive(): boolean {
@@ -2865,6 +2915,10 @@ export class DemoMeetingApp
 
     if (videoFilter === 'Segmentation') {
       return new SegmentationProcessor();
+    }
+
+    if (videoFilter === 'Resize (9/16)') {
+      return new ResizeProcessor(0.5625);  // 16/9 Aspect Ratio
     }
 
     return null;

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -480,18 +480,34 @@ svg {
   }
 
   .video-preview {
-    width: auto;
-    height: 82px;
-    margin-left: 35%;
+    max-width: 100%;
+    max-height: 180px;
     margin-top: 7px;
+  }
+
+  #video-preview  {
+    max-height: 180px;
   }
 }
 
-.video-preview {
-  width: 100%;
-  height: 82px;
-  margin-left: 0;
-  margin-top: 0;
+// The following CSS is added to overcome the vertical overlapping caused by the body:100% style.
+// body: 100% should be removed from the stylesheet as it causes vertical overlapping of content on the page and once that is removed the following fix should be no longer needed.
+#form-devices {
+  height: 100vh;
+  padding-top: 10px;
+}
+
+@media(min-width: 576px) {
+  .video-preview {
+    width: 100%;
+    max-height: 300px;
+    margin-left: 0;
+    margin-top: 0;
+  }
+  
+  #video-preview  {
+    max-height: 300px;
+  }
 }
 
 .markdown {

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -179,7 +179,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L716">src/devicecontroller/DefaultDeviceController.ts:716</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L730">src/devicecontroller/DefaultDeviceController.ts:730</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -197,7 +197,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L724">src/devicecontroller/DefaultDeviceController.ts:724</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L738">src/devicecontroller/DefaultDeviceController.ts:738</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L720">src/devicecontroller/DefaultDeviceController.ts:720</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L734">src/devicecontroller/DefaultDeviceController.ts:734</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -263,7 +263,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#bindtoaudiovideocontroller">bindToAudioVideoController</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L927">src/devicecontroller/DefaultDeviceController.ts:927</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L941">src/devicecontroller/DefaultDeviceController.ts:941</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -359,7 +359,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L696">src/devicecontroller/DefaultDeviceController.ts:696</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L710">src/devicecontroller/DefaultDeviceController.ts:710</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -445,7 +445,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L712">src/devicecontroller/DefaultDeviceController.ts:712</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L726">src/devicecontroller/DefaultDeviceController.ts:726</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1761">src/devicecontroller/DefaultDeviceController.ts:1761</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1775">src/devicecontroller/DefaultDeviceController.ts:1775</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -552,7 +552,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L683">src/devicecontroller/DefaultDeviceController.ts:683</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L697">src/devicecontroller/DefaultDeviceController.ts:697</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -575,7 +575,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L881">src/devicecontroller/DefaultDeviceController.ts:881</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L895">src/devicecontroller/DefaultDeviceController.ts:895</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -622,7 +622,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L668">src/devicecontroller/DefaultDeviceController.ts:668</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L682">src/devicecontroller/DefaultDeviceController.ts:682</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -682,7 +682,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L651">src/devicecontroller/DefaultDeviceController.ts:651</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L665">src/devicecontroller/DefaultDeviceController.ts:665</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1870">src/devicecontroller/DefaultDeviceController.ts:1870</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1884">src/devicecontroller/DefaultDeviceController.ts:1884</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -722,7 +722,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1010">src/devicecontroller/DefaultDeviceController.ts:1010</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1024">src/devicecontroller/DefaultDeviceController.ts:1024</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -739,7 +739,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1014">src/devicecontroller/DefaultDeviceController.ts:1014</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1028">src/devicecontroller/DefaultDeviceController.ts:1028</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -756,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1856">src/devicecontroller/DefaultDeviceController.ts:1856</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1870">src/devicecontroller/DefaultDeviceController.ts:1870</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -773,7 +773,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L968">src/devicecontroller/DefaultDeviceController.ts:968</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L982">src/devicecontroller/DefaultDeviceController.ts:982</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -796,7 +796,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1018">src/devicecontroller/DefaultDeviceController.ts:1018</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1032">src/devicecontroller/DefaultDeviceController.ts:1032</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -819,7 +819,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1064">src/devicecontroller/DefaultDeviceController.ts:1064</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1078">src/devicecontroller/DefaultDeviceController.ts:1078</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -1004,7 +1004,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1906">src/devicecontroller/DefaultDeviceController.ts:1906</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1920">src/devicecontroller/DefaultDeviceController.ts:1920</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -279,6 +279,11 @@ npm run test
 				<p>Tags are fetched in order to correctly generate versioning metadata.</p>
 				<p>To view code coverage results open <code>coverage/index.html</code> in your browser
 				after running <code>npm run test</code>.</p>
+				<p>If you run <code>npm run test</code> and the tests are running but the coverage report is not getting generated
+					then you might have a resource clean up issue. In Mocha v4.0.0 or newer the implementation was changed so
+					that the Mocha processes will not force exit when the test run is complete. <br /> For example, if you have a
+					<code>DefaultVideoTransformDevice</code> in your unit test then you must call <code>await device.stop();</code> to clean up the
+				resources and not run into this issue. You can also look into the usage of <code>done();</code> in the <a href="https://mochajs.org/#asynchronous-code">Mocha documentation</a>. </p>
 				<a href="#generating-the-documentation" id="generating-the-documentation" style="color: inherit; text-decoration: none;">
 					<h2>Generating the documentation</h2>
 				</a>

--- a/docs/modules/videoprocessor.html
+++ b/docs/modules/videoprocessor.html
@@ -126,8 +126,8 @@
 								<td>Not supported</td>
 							</tr>
 					</tbody></table>
-					<a href="#video-processing-apis-and-usage" id="video-processing-apis-and-usage" style="color: inherit; text-decoration: none;">
-						<h2>Video Processing APIs and Usage</h2>
+					<a href="#video-processing-apis" id="video-processing-apis" style="color: inherit; text-decoration: none;">
+						<h2>Video Processing APIs</h2>
 					</a>
 					<a href="#videotransformdevice" id="videotransformdevice" style="color: inherit; text-decoration: none;">
 						<h3>VideoTransformDevice</h3>
@@ -139,6 +139,7 @@
 						<h4>Construction and Starting Video Processing</h4>
 					</a>
 					<p>The construction of the <code>DefaultVideoTransformDevice</code> will not start the camera or start processing. The method <code>meetingSession.audioVideo.chooseVideoInputDevice</code> is needed to be called. The device controller will use the inner <code>Device</code> to acquire the source <code>MediaStream</code> and start the processing pipeline at the same frame rate.
+						&quot;Inner device&quot; in this context refers to the original video stream coming from the selected camera.
 						The parameters to <code>chooseVideoInputQuality</code> are used as constraints on the source <code>MediaStream</code>.
 					After the video input is chosen, <code>meetingSession.audioVideo.startLocalVideoTile</code> can be called to start streaming video.</p>
 					<a href="#switching-the-inner-device-on-videotransformdevice" id="switching-the-inner-device-on-videotransformdevice" style="color: inherit; text-decoration: none;">
@@ -229,7 +230,12 @@
   <span class="hljs-keyword">return</span> buffers;
 }
 </code></pre>
-					<p>Usage of the custom processor looks like the following:</p>
+					<a href="#video-processing-usage" id="video-processing-usage" style="color: inherit; text-decoration: none;">
+						<h2>Video Processing Usage</h2>
+					</a>
+					<a href="#custom-processor-usage-during-meeting" id="custom-processor-usage-during-meeting" style="color: inherit; text-decoration: none;">
+						<h3>Custom processor usage during meeting</h3>
+					</a>
 					<pre><code class="language-typescript"><span class="hljs-keyword">import</span> {
   DefaultVideoTransformDevice
 } <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;amazon-chime-sdk-js&#x27;</span>;
@@ -244,6 +250,24 @@
 
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseVideoInputDevice(transformDevice);
 meetingSession.audioVideo.startLocalVideo();
+</code></pre>
+					<a href="#custom-processor-usage-during-meeting-preview" id="custom-processor-usage-during-meeting-preview" style="color: inherit; text-decoration: none;">
+						<h3>Custom processor usage during meeting preview</h3>
+					</a>
+					<pre><code class="language-typescript"><span class="hljs-keyword">import</span> {
+  DefaultVideoTransformDevice
+} <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;amazon-chime-sdk-js&#x27;</span>;
+
+<span class="hljs-keyword">const</span> processor = <span class="hljs-keyword">new</span> VideoResizeProcessor(<span class="hljs-number">4</span>/<span class="hljs-number">3</span>);
+<span class="hljs-keyword">const</span> videoElement = <span class="hljs-built_in">document</span>.getElementById(<span class="hljs-string">&#x27;video-preview&#x27;</span>) <span class="hljs-keyword">as</span> HTMLVideoElement;
+<span class="hljs-keyword">const</span> transformDevice = <span class="hljs-keyword">new</span> DefaultVideoTransformDevice(
+  logger,
+  <span class="hljs-string">&#x27;foobar&#x27;</span>, <span class="hljs-comment">// device id string</span>
+  processor
+);
+
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseVideoInputDevice(transformDevice);
+meetingSession.audioVideo.startVideoPreviewForVideoInput(videoElement);
 </code></pre>
 					<p><a href="https://github.com/aws/amazon-chime-sdk-js/issues/new?assignees=&amp;labels=documentation&amp;template=documentation-request.md&amp;title=Video%20Processor%20feedback">Give feedback on this guide</a></p>
 				</div>

--- a/guides/10_Video_Processor.md
+++ b/guides/10_Video_Processor.md
@@ -31,7 +31,7 @@ WebRTC Unified Plan is also required. Unified Plan is by default enabled in [Mee
 |iOS Chrome                                                             |Not supported             
 |iOS Firefox                                                            |Not supported             
 
-## Video Processing APIs and Usage
+## Video Processing APIs
 
 ### VideoTransformDevice
 `VideoTransformDevice` allows `VideoFrameProcessor`s to be applied to to a `Device` and provide a new object which can be passed into `meetingSession.audioVideo.chooseVideoInputDevice`.
@@ -42,6 +42,7 @@ The `DefaultVideoTransformDevice` uses `VideoFrameProcessorPipeline` under the h
 #### Construction and Starting Video Processing
 
 The construction of the `DefaultVideoTransformDevice` will not start the camera or start processing. The method `meetingSession.audioVideo.chooseVideoInputDevice` is needed to be called. The device controller will use the inner `Device` to acquire the source `MediaStream` and start the processing pipeline at the same frame rate.
+"Inner device" in this context refers to the original video stream coming from the selected camera.
 The parameters to `chooseVideoInputQuality` are used as constraints on the source `MediaStream`. 
 After the video input is chosen, `meetingSession.audioVideo.startLocalVideoTile` can be called to start streaming video.
 
@@ -142,7 +143,8 @@ async process(buffers: VideoFrameBuffer[]): Promise<VideoFrameBuffer[]> {
 }
 ```
 
-Usage of the custom processor looks like the following:
+## Video Processing Usage
+### Custom processor usage during meeting
 
 ```typescript
 import {
@@ -160,4 +162,23 @@ const transformDevice = new DefaultVideoTransformDevice(
 await meetingSession.audioVideo.chooseVideoInputDevice(transformDevice);
 meetingSession.audioVideo.startLocalVideo();
 
+```
+
+### Custom processor usage during meeting preview
+
+```typescript
+import {
+  DefaultVideoTransformDevice
+} from 'amazon-chime-sdk-js';
+
+const processor = new VideoResizeProcessor(4/3);
+const videoElement = document.getElementById('video-preview') as HTMLVideoElement;
+const transformDevice = new DefaultVideoTransformDevice(
+  logger,
+  'foobar', // device id string
+  processor
+);
+
+await meetingSession.audioVideo.chooseVideoInputDevice(transformDevice);
+meetingSession.audioVideo.startVideoPreviewForVideoInput(videoElement);
 ```

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -636,14 +636,28 @@ export default class DefaultDeviceController
       return;
     }
 
+    const stream = element.srcObject as MediaStream;
     // TODO: implement MediaDestroyer to provide single release MediaStream function
-    this.releaseMediaStream(element.srcObject as MediaStream);
-    DefaultVideoTile.disconnectVideoStreamFromVideoElement(element, false);
-    DefaultVideoTile.connectVideoStreamToVideoElement(
-      this.activeDevices['video'].stream,
-      element,
-      true
-    );
+    // The video stream should be released only if the video stream in the HTML element is different from current stream.
+    // When a filter is applied the existing stream is reused and in that case the stream should not be released.
+    if (stream && this.activeDevices['video'].stream !== stream) {
+      this.releaseMediaStream(element.srcObject as MediaStream);
+      DefaultVideoTile.disconnectVideoStreamFromVideoElement(element, false);
+    }
+
+    if (this.chosenVideoTransformDevice) {
+      DefaultVideoTile.connectVideoStreamToVideoElement(
+        this.chosenVideoTransformDevice.outputMediaStream,
+        element,
+        true
+      );
+    } else {
+      DefaultVideoTile.connectVideoStreamToVideoElement(
+        this.activeDevices['video'].stream,
+        element,
+        true
+      );
+    }
 
     this.trace('startVideoPreviewForVideoInput', element.id);
   }


### PR DESCRIPTION
**Issue #1253:**

**Description of changes: Updated `startVideoPreviewForVideoInput` method to support filters in the preview window. Updated the browser demo to showcase the functionality and updated the UI.**

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Demo app and unit tests
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, use the application under demos/browser
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

