### PR TITLE
Rework how group IDs are computed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `audioInputMuteStateChanged` to the `DeviceChangeObserver` interface. This is called whenever the device is changed or is muted or unmuted, allowing applications to adapt to OS-level mute state for input devices.
 - Added Android WebView Sample UI test to workflow.
 - Add a new optional API `getVideoTileForAttendeeId` in `VideoTileController` and raise the `tileWillBePausedByDownlinkPolicy` event for empty video tiles.
-- Amazon Voice Focus will now trigger the `onCPUWarning` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
+- Amazon Voice Focus will now trigger the `voiceFocusInsufficientResources` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
 - The Amazon Voice Focus support check, `VoiceFocusDeviceTransformer.isSupported`, now warns to the logger when run in an iframe, and can be configured to fail in that case.
 
 ### Changed
@@ -23,10 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 - Fix priority-based downlink policy to not unpaused tiles that are not paused by the policy.
 - Fix empty video tiles when using priority-based downlink policy.
 - Fix simulcast guide that adaptive probe downlink policy is not enabled by default.
 - Fix a link format in simulcast guide.
+- Selecting a device without first listing devices no longer logs `Device cache is not populated`.
 
 ## [2.16.1] - 2021-08-23
 

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -462,7 +462,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1758">src/devicecontroller/DefaultDeviceController.ts:1758</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1776">src/devicecontroller/DefaultDeviceController.ts:1776</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1867">src/devicecontroller/DefaultDeviceController.ts:1867</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1885">src/devicecontroller/DefaultDeviceController.ts:1885</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -756,7 +756,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1853">src/devicecontroller/DefaultDeviceController.ts:1853</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1871">src/devicecontroller/DefaultDeviceController.ts:1871</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -1004,7 +1004,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1903">src/devicecontroller/DefaultDeviceController.ts:1903</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/devicecontroller/DefaultDeviceController.ts#L1921">src/devicecontroller/DefaultDeviceController.ts:1921</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -997,6 +997,22 @@ describe('DefaultDeviceController', () => {
       }
     });
 
+    it('allows you to choose a null device without logging', () => {
+      const e = sinon.spy(logger, 'error');
+      const i = sinon.spy(logger, 'info');
+      const w = sinon.spy(logger, 'warn');
+
+      deviceController.chooseAudioInputDevice(null);
+
+      expect(e.notCalled).to.be.true;
+      expect(i.called).to.be.true;
+      expect(w.notCalled).to.be.true;
+
+      e.restore();
+      i.restore();
+      w.restore();
+    });
+
     it('releases audio media stream when requesting default device and default is already active in chromium based browser', async () => {
       enableWebAudio(true);
       domMockBehavior.browserName = 'chrome';


### PR DESCRIPTION
**Issue #:**

#1568 

**Description of changes:**

This change now extracts the group ID from the stream, rather than using the device ID to navigate into the device info cache.

This will avoid an error being logged when choosing a null device, and in some other cases, when devices have not yet been enumerated.

Comments in the code should be explanatory.


**Testing**

> 1. Have you successfully run `npm run build:release` locally?

In parts.

> 2. How did you test these changes?

Unit testing. I trust the integration tests to catch regressions.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

No: we always list devices first.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

