### PR TITLE
Do not trigger leave event for self attendee during reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarify why not use default downlink policy with simulcast.
 - Corrected argument `isUnifiedPlan` in `withBandwidthRestriction` to `isFirefox`. Also marked as deprecated since we no longer use it.
 - Update data message limit in the API Overview guide.
+- Do not trigger real time attendee presence event for local attendee if they are not appear in audio info frame 
+  during reconnection.
 
 ### Removed
 

--- a/docs/classes/defaultvolumeindicatoradapter.html
+++ b/docs/classes/defaultvolumeindicatoradapter.html
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L144">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:144</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L147">src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts:147</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
+++ b/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts
@@ -123,6 +123,15 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
       delete this.warnedAboutMissingStreamIdMapping[streamId];
       delete this.attendeeIdToStreamId[deletedAttendeeId];
 
+      // During reconnection, the audio info frame might not include self attendee.
+      // However, if that happens, there would be another audio info frame with the self attendee after reconnection.
+      // So we should not send leave event here for self attendee.
+      if (deletedAttendeeId === this.selfAttendeeId) {
+        this.logger.warn(
+          `the volume indicator adapter cleans up the current attendee (presence = false) after reconnection`
+        );
+        continue;
+      }
       // The reconnect event does not have information whether the attendee is dropped/left.
       // Defaulting to attendee leaving the meeting
       this.realtimeController.realtimeSetAttendeeIdPresence(
@@ -132,12 +141,6 @@ export default class DefaultVolumeIndicatorAdapter implements VolumeIndicatorAda
         false,
         { attendeeIndex: index, attendeesInFrame: deletedAttendeeId.length }
       );
-
-      if (deletedAttendeeId === this.selfAttendeeId) {
-        this.logger.warn(
-          `the volume indicator adapter cleans up the current attendee (presence = false) after reconnection`
-        );
-      }
     }
   }
 


### PR DESCRIPTION
**Description of changes:**
Currently during reconnection, we can send out leaving attendee presence event for current attendee during reconnection https://github.com/aws/amazon-chime-sdk-js/blob/master/src/volumeindicatoradapter/DefaultVolumeIndicatorAdapter.ts#L128

However, there is always an audio info later after reconnection for the current attendee in that case so we should not send out the event during reconnection which does not make sense anyway since the fact we receive the audio info from backend means there is connection with the current client.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? 
   1. Launch meeting demo and join with 2 attendees 
   2. Mute all of them
   3. Use this code in dev console to trigger reconnection for one attendee:
   ```
    app.audioVideo.audioVideoController.handleMeetingSessionStatus({
      statusCode: () => 17,
      isFailure: () => true,
      isTerminal: () => false,
      isAudioConnectionFailure: () => false,
     }, null);
   ```
   4. Verify that we do not see any presence = false event in the console log
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, meeting demo
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

