### PR TITLE
Updated SauceLabs Integration tests to the new mobile api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `startVideoPreviewForVideoInput` to support filters in the preview window.
 - Update browser demo to showcase preview filter capability.
 - Move `toLowerCasePropertyNames` inside `Utils.ts` and add test coverage.
+- Migrate SauceLabs mobile tests to new api. 
 
 ### Removed
 


### PR DESCRIPTION
**Issue #:**
TestObject the saucelabs api we're currently using has been deprecated 
**Description of changes:**
Migrated to the new api.
**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes
2. How did you test these changes?
Ran Data Message and Audio integration tests on MAC Chrome, Firefox, and Android Chrome.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
No
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

