### PR TITLE
Add safeguard for Nscale policy in case we increase to more than 25 videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Add safeguard for Nscale policy in case we increase to more than 25 videos.
 
 ### Changed
 - Move `toLowerCasePropertyNames` inside `Utils.ts` and add test coverage.

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -191,8 +191,13 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
     const maxBitrate = this.maxBandwidthKbps() * 1000;
     let scale = 1;
     if (setting && this.scaleResolution && !this.hasBandwidthPriority && this.numParticipants > 2) {
-      const targetHeight = NScaleVideoUplinkBandwidthPolicy.targetHeightArray[this.numParticipants];
-
+      const targetHeight =
+        NScaleVideoUplinkBandwidthPolicy.targetHeightArray[
+          Math.min(
+            this.numParticipants,
+            NScaleVideoUplinkBandwidthPolicy.targetHeightArray.length - 1
+          )
+        ];
       scale = Math.max(setting.height / targetHeight, 1);
     }
     return {

--- a/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
+++ b/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
@@ -86,6 +86,7 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       [23, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 108, false, 3)],
       [24, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 105, false, 3)],
       [25, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 103, false, 3)],
+      [26, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 101, false, 3)],
     ]);
 
     const expectedNumParticipantsToParametersWithNoResolutionScaling = new Map([
@@ -114,6 +115,7 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       [23, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 108, false, 1)],
       [24, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 105, false, 1)],
       [25, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 103, false, 1)],
+      [26, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 101, false, 1)],
     ]);
 
     const expectedNumParticipantsToParametersWithPriority = new Map([
@@ -142,6 +144,7 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       [23, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 600, false, 1)],
       [24, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 600, false, 1)],
       [25, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 600, false, 1)],
+      [26, new DefaultVideoCaptureAndEncodeParameter(320, 192, 15, 600, false, 1)],
     ]);
 
     it('returns the correct values when the self is present in the SdkIndexFrame', () => {


### PR DESCRIPTION
**Description of changes:**
Add safeguard for Nscale policy in case we increase to more than 25 videos to not run into exception when calculating target height.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? Add unit tests.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

