### PR TITLE
Update integration test setup documentation

### DIFF
--- a/.integration-watchlist
+++ b/.integration-watchlist
@@ -7,6 +7,7 @@ integration/
 !.eslintignore
 !src/versioning/Versioning.ts
 !README.md
+!integration/js/README.md
 !demos/browser/README.md
 !demos/device/README.md
 !guides/

--- a/integration/js/README.md
+++ b/integration/js/README.md
@@ -9,6 +9,7 @@ To run integration tests you will need:
 - Node 10 or higher. Node 14 is supported.
 - npm 6.11 or higher. 6.14.8 is supported.
 - [KITE](https://github.com/webrtc/KITE).
+- Java runtime installed on the machine.
 
 ### Installing KITE on macOS
 
@@ -34,6 +35,10 @@ chmod +x configureMac.sh
 ```
 
 Choose 'y'.
+
+Note: If the `./configureMac.sh` script fails then make sure you are using Maven 3.6.3 or earlier. The KITE version in use does not work with the latest version of maven.
+For example, you can install maven 3.5 by calling `brew install maven@3.5`. If the issue persists, make sure the symlink is pointing to the right version of maven. Use `mvn -v` to check your maven version.
+If you have multiple installations of maven in homebrew then use `brew unlink maven` to unlink the latest version of maven and use `brew link maven@3.5` to use an older version.
 
 Now find the Terminal window that opened and complete interactive setup. A good configuration is:
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:** I was setting up the integration test locally and found some missing information in the README. With the KITE version latest version of maven is not compatible and this will cause issues in setup. Maven version 3.6.3 or below are compatible with KITE. Added documentation to help the user get around this issue.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes? NA
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? NA
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

