### PR TITLE
Prevent crash in ReceiveVideoInputTask when there is no video track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
 
+### Fixed
+- Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video
+  track.
+  
 ## [2.18.0] - 2021-09-22
 
 ### Added

--- a/src/task/ReceiveVideoInputTask.ts
+++ b/src/task/ReceiveVideoInputTask.ts
@@ -56,6 +56,13 @@ export default class ReceiveVideoInputTask extends BaseTask {
     this.context.activeVideoInput = videoInput;
     if (videoInput) {
       const videoTracks = videoInput.getVideoTracks();
+      // There can be a race condition when there are several audioVideo.update calls (e.g., calling
+      // startLocalVideoTile and stopLocalVideoTile at the same time)
+      // that causes the video stream to not contain any video track.
+      // This should recovers in the next update call.
+      if (!videoTracks || videoTracks.length === 0) {
+        return;
+      }
       const attendeeId = this.context.meetingSessionConfiguration.credentials.attendeeId;
       const trackSettings = videoTracks[0].getSettings();
       if (this.context.enableSimulcast) {

--- a/test/task/ReceiveVideoInputTask.test.ts
+++ b/test/task/ReceiveVideoInputTask.test.ts
@@ -165,6 +165,19 @@ describe('ReceiveVideoInputTask', () => {
       await task.run();
       expect(context.activeVideoInput).to.be.null;
     });
+
+    it('will fail gracefully if a video input does not contain media stream track', async () => {
+      context.videoTileController.startLocalVideoTile();
+      class MockEmptyMediaStreamBroker extends NoOpMediaStreamBroker {
+        acquireVideoInputStream(): Promise<MediaStream> {
+          return Promise.resolve(new MediaStream());
+        }
+      }
+      context.mediaStreamBroker = new MockEmptyMediaStreamBroker();
+      const task = new ReceiveVideoInputTask(context);
+      await task.run();
+      expect(context.activeVideoInput.getVideoTracks()).to.be.empty;
+    });
   });
 
   describe('run with simulcast enabled', () => {


### PR DESCRIPTION
**Description of changes:**
Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video track.
For example, this can happen when there is a race condition between `StartLocalVideoTile` and `StopLocalVideoTile`.

**Testing**

1. Have you successfully run `npm run build:release` locally? Yes
2. How did you test these changes?
- In meeting demo, turn on and off video filter in rapid succession.
- Verify that there is no error
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? Yes, meeting demo.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

