### PR TITLE
Add additional logging for video check by attendee name

### DIFF
--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -572,6 +572,7 @@ class AppPage {
     const startTime = Date.now();
     let checked;
     let videos = await this.driver.findElements(By.css('video[id^="video-"]'));
+    console.log(`Looping through ${videos && videos.length}`);
     for (let i = 0; i < videos.length; i++) {
       const videoElementId = await videos[i].getAttribute('id');
       const seperatorIndex = videoElementId.lastIndexOf("-");
@@ -579,13 +580,15 @@ class AppPage {
         const tileIndex = parseInt(videoElementId.slice(seperatorIndex+1))
         if (tileIndex != NaN && tileIndex >= 0) {
           const nameplate = await this.driver.findElement(By.id(`nameplate-${tileIndex}`));
+          console.log(`nameplate: ${nameplate}`);
           const nameplateText = await nameplate.getText();
           if (nameplate && nameplateText === attendeeName) {
             let numRetries = 10;
             let retry = 0;
-            console.log('Start verifying video display by ID', attendeeName, tileIndex);
+            console.log(`Start verifying video display by video element ID:${videoElementId}, attendeeName=${attendeeName}, tileIndex=${tileIndex}`);
             let checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
             while ((checked.result !== expectedState) && retry < numRetries) {
+              console.log(`video check not yet complete, retrying again, retry count: ${retry}`);
               checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
               retry++;
               await TestUtils.waitAround(1000);

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -569,6 +569,7 @@ class AppPage {
   }
 
   async videoCheckByAttendeeName(stepInfo, attendeeName, expectedState = 'video') {
+    const startTime = Date.now();
     let checked;
     let videos = await this.driver.findElements(By.css('video[id^="video-"]'));
     for (let i = 0; i < videos.length; i++) {
@@ -582,17 +583,20 @@ class AppPage {
           if (nameplate && nameplateText === attendeeName) {
             let numRetries = 10;
             let retry = 0;
+            console.log('Start verifying video display by ID', attendeeName, tileIndex);
             let checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
             while ((checked.result !== expectedState) && retry < numRetries) {
               checked = await TestUtils.verifyVideoDisplayById(stepInfo.driver, `video-${tileIndex}`);
               retry++;
               await TestUtils.waitAround(1000);
             }
+            console.log(`videoCheckByAttendeeName completed in: ${Date.now()-startTime}ms`);
             return checked.result;
           }
         }
       }
     }
+    console.log(`videoCheckByAttendeeName completed in: ${Date.now()-startTime}ms`);
     return 'blank';
   }
 

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,6 +104,9 @@ const getSauceLabsConfig = (capabilities) => {
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
     tunnelIdentifier: process.env.JOB_ID,
+    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
+      extendedDebugging: true
+    })
   }
 };
 

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -83,7 +83,15 @@ const getChromeCapabilities = capabilities => {
   cap.setLoggingPrefs(prefs);
   cap.setBrowserVersion(capabilities.version);
   cap.set('goog:chromeOptions', {
-    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      'start-maximized',
+      'disable-infobars',
+      'ignore-gpu-blacklist',
+      'test-type',
+      'disable-gpu',
+    ],
   });
   cap.set('resolution', '1920x1080');
   cap.set('sauce:options', getSauceLabsConfig(capabilities));
@@ -96,9 +104,6 @@ const getSauceLabsConfig = (capabilities) => {
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
     tunnelIdentifier: process.env.JOB_ID,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
-      extendedDebugging: true
-    })
   }
 };
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Add more logs for `videoCheckByAttendeeName ` in the integration test which usually is taking more time than expected while running the integration test with a random re-pro.

**Testing**

1. Have you successfully run `npm run build:release` locally? Integration test logging change.
2. How did you test these changes? Got test when the integration tests including the `videoCheckByAttendeeName ` ran. Check GitHub action runs for this to see the logs.
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? NA. Integration test will check this.
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA.
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

