### PR TITLE
Fix release script to add missing captureOutputPrefix param for SDK demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video
   track.
+- Add missing captureOutputPrefix param for SDK demo app in release script.
   
 ## [2.18.0] - 2021-09-22
 

--- a/script/release
+++ b/script/release
@@ -87,4 +87,4 @@ else
 end
 
 Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../demos/serverless')))
-verbose("npm run deploy -- -b chime-sdk-demo-#{formatted_version} -s chime-sdk-demo-#{formatted_version}")
+verbose("npm run deploy -- -b chime-sdk-demo-#{formatted_version} -s chime-sdk-demo-#{formatted_version} -o chime-sdk-demo-#{formatted_version}")


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Fix release script to add missing captureOutputPrefix param for SDK demo app. This was causing the demo app deployed for the release testing to not have the `captureOutputPrefix` and resulted in not creating S3 buckets and hence media capture did not start.

**Testing**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. How did you test these changes?
This can be verified before the next release.

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?
No. This is just a change in the release script. 

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

