### PR TITLE
Don't try to postMessage WebAssembly modules in Chrome 95 or later.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
+### Added
+
+### Removed
+
 ### Fixed
-- Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video
-  track.
-- Add missing captureOutputPrefix param for SDK demo app in release script.
+
+- Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video track.
+- Add missing `captureOutputPrefix` param for SDK demo app in release script.
+- Amazon Voice Focus now works in Chrome 95 or later: WebAssembly policy changes required a change in how modules were loaded.
+
+
+### Changed
+
   
 ## [2.18.0] - 2021-09-22
 
 ### Added
+
 - Add events `meetingReconnected`, `signalingDropped` and `receivingAudioDropped` to `eventDidReceive` by publishing them as stand alone events. Currently, these events were only included in the meeting history attribute when a meeting event is published. 
 - Added support for skipping full SDP renegotiations when switching simulcast streams.  This will result in less freezing when switching between layers in response to a network event as done in `VideoPriorityBasedPolicy`.  This will have no impact if not using simulcast.
 - Add link to SIP Media Application examples in README.
@@ -21,9 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
 - Add safeguard for Nscale policy in case we increase to more than 25 videos.
 
 ### Changed
+
 - Move `toLowerCasePropertyNames` inside `Utils.ts` and add test coverage.
 - Reduced uplink resubscription when only stream encoding is changed by adding bypassing path.
 - The browser demo now offers a configuration menu on each video tile. This menu replaces the 'Pin' button, which previously set the priority of the corresponding remote video to 1, and then rest to 2. The new configuration menu allows the user to specify the desired video quality and priority, which will be respected by simulcast and priority downlink policies. This is useful for testing or to demonstrate the behavior of those policies.


### PR DESCRIPTION
Chrome after 95 refuses to send WebAssembly modules between origins.

Instead, fall back to sending a buffer of data, which we can compile in
the destination origin.

I am following up with an additional layer of defense in the worker itself that can apply to older SDK releases.

https://www.chromestatus.com/feature/5650158039597056
https://developer.chrome.com/blog/wasm-module-sharing-restricted-to-same-origin/

---

**Testing**

> 1. Have you successfully run `npm run build:release` locally?

No. This is a libs-only change.

> 2. How did you test these changes?

Upstream. We will test this in the demo app at some point.

> 3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it?

Yes: make sure that Voice Focus works in the demo app in Chrome 95 or later.

> 4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

> 5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

Not really. This makes Chromium behave like Safari when messaging the Voice Focus worker.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

