### PR TITLE
Add opt-in region "eu-south-1" to meetings demo in deploy-canary-demo script to support media capture canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video track.
 - Add missing `captureOutputPrefix` param for SDK demo app in release script.
 - Amazon Voice Focus now works in Chrome 95 or later: WebAssembly policy changes required a change in how modules were loaded.
+- Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary
 
 
 ### Changed

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -9,17 +9,17 @@ cd $GITHUB_WORKSPACE/demos/serverless
 npm ci
 
 echo "Deploying to alpha stage for canary"
-npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -o chime-sdk-demo-canary -t -l
+npm run deploy -- -b chime-sdk-demo-canary -s chime-sdk-demo-canary -o chime-sdk-demo-canary -i eu-south-1 -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary -s chime-sdk-meeting-readiness-checker-dev-canary -a meetingReadinessChecker -t -l
 
 echo "Deploying to gamma stage for canary that talks to prod Chime endpoint"
 export AWS_ACCESS_KEY_ID=$GAMMA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$GAMMA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -o chime-sdk-demo-gamma-canary -t -l
+npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary -o chime-sdk-demo-gamma-canary -i eu-south-1 -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -t -l
 
 echo "Deploying to beta stage for canary that talks to gamma Chime endpoint"
 export AWS_ACCESS_KEY_ID=$BETA_AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$BETA_AWS_SECRET_ACCESS_KEY
-npm run deploy -- -b chime-sdk-demo-beta-canary -s chime-sdk-demo-beta-canary -o chime-sdk-demo-beta-canary -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT -t -l
+npm run deploy -- -b chime-sdk-demo-beta-canary -s chime-sdk-demo-beta-canary -o chime-sdk-demo-beta-canary -i eu-south-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT -t -l
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-beta-canary -s chime-sdk-meeting-readiness-checker-beta-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -t -l


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:** Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary

**Testing**

1. Have you successfully run `npm run build:release` locally? **YES**
2. How did you test these changes? **Deployed the app from my local environment**
3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? **Yes. Media capture should be working in `eu-south-1` from the demo apps deployed for canaries**
4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? **NA**
5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? **NA**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

