### PR TITLE
Remove extended debugging capability to reduce timeouts in saucelabs

### DIFF
--- a/integration/js/ContentShareOnlyAllowTwoTest.js
+++ b/integration/js/ContentShareOnlyAllowTwoTest.js
@@ -56,7 +56,7 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
+    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
 
     //Turn on Content Share for third participant
     await test_window_3.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,9 +104,10 @@ const getSauceLabsConfig = (capabilities) => {
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
     tunnelIdentifier: process.env.JOB_ID,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
-      extendedDebugging: true
-    })
+    ...(capabilities.platform.toUpperCase() !== 'LINUX' && 
+      (capabilities.name).includes('ContentShare') && {
+        extendedDebugging: true
+      }),
   }
 };
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
According to saucelabs, this capability could "generate a lot of additional assets, which could be the cause for this intermittent issue."

**Testing**

1. Have you successfully run `npm run build:release` locally? yes

2. How did you test these changes? this is an optional capability

3. Can these changes be tested using the demo application? If yes, which demo application can be used to test it? n/a

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n/a 

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n/a


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

