### PR TITLE
Update the default priority-based video downlink policy to adjust target size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow passing in custom video simulcast uplink policy that implements the `SimulcastUplinkPolicy` interface.
 - Change the default video downlink policy to `VideoAdaptiveProbePolicy` to match with documentation.
 - Move configuration default from meeting session configuration to audio video controller.
+- Update the default priority-based video downlink policy to adjust target size based on number of videos in the 
+  meeting.
   
 ## [2.18.0] - 2021-09-22
 

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -261,7 +261,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L226">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L236">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L412">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L422">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:422</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceivestreams">calculateOptimalReceiveStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L274">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L284">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -377,7 +377,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L217">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L227">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +438,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L230">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L240">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:240</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setvideoprioritybasedpolicyconfigs">setVideoPriorityBasedPolicyConfigs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L254">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -530,7 +530,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L187">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:187</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -555,7 +555,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L212">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L222">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L226">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L236">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L412">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:412</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L422">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:422</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L274">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L284">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L217">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L227">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:227</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -417,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L230">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L240">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:240</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -458,7 +458,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L244">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L254">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L187">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:187</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -529,7 +529,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L212">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L222">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:222</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/modules/prioritybased_downlink_policy.html
+++ b/docs/modules/prioritybased_downlink_policy.html
@@ -101,10 +101,16 @@
 					<ul>
 						<li><em><em>attendeeId:</em></em>  The attendee ID this video tile belongs to. Note that screen share video will have a suffix of #content</li>
 						<li><em><em>priority:</em></em> Provides relative priority of this attendee from 1 to x, where 1 is the highest priority. Remote videos are allowed to have the same priority signifying equal priority between them.</li>
-						<li><em><em>targetSize:</em></em> Optional parameter to control maximum simulcast layer to receive. Default value is High.</li>
+						<li><em><em>targetSize:</em></em> Optional parameter to control maximum simulcast layer to receive.</li>
 					</ul>
-					<p><strong>Configuring the receipt and priority of remote video sources</strong>
-					The main API being used is:</p>
+					<p>The default preference set the same priority 1 for all attendees. The target size will be:</p>
+					<ul>
+						<li>High if there are 1-4 videos.</li>
+						<li>Medium if there are 5-8 videos.</li>
+						<li>Low otherwise.</li>
+					</ul>
+					<p><strong>Configuring the receipt and priority of remote video sources</strong></p>
+					<p>The main API being used is:</p>
 					<pre><code><span class="hljs-function"><span class="hljs-title">chooseRemoteVideoSources</span><span class="hljs-params">(sources: VideoPreference[])</span></span>: void
 </code></pre>
 					<p>An array of <code>VideoPreference</code> is passed in to specify preference for each remote video.

--- a/guides/11_Priority_Based_Downlink_Policy.md
+++ b/guides/11_Priority_Based_Downlink_Policy.md
@@ -35,9 +35,15 @@ Once you are connected to the meeting, builders will be notified of available re
 
 * _*attendeeId:*_  The attendee ID this video tile belongs to. Note that screen share video will have a suffix of #content
 * _*priority:*_ Provides relative priority of this attendee from 1 to x, where 1 is the highest priority. Remote videos are allowed to have the same priority signifying equal priority between them.
-* *_targetSize:_* Optional parameter to control maximum simulcast layer to receive. Default value is High.
+* *_targetSize:_* Optional parameter to control maximum simulcast layer to receive.
+
+The default preference set the same priority 1 for all attendees. The target size will be:
+- High if there are 1-4 videos.
+- Medium if there are 5-8 videos.
+- Low otherwise.
 
 **Configuring the receipt and priority of remote video sources** 
+
 The main API being used is:
 
 ```

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -168,8 +168,18 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     }
 
     const prefs = VideoPreferences.prepare();
+
+    const numAttendees = attendeeIds.size;
+    let targetDisplaySize = TargetDisplaySize.High;
+
+    if (numAttendees > 8) {
+      targetDisplaySize = TargetDisplaySize.Low;
+    } else if (numAttendees > 4) {
+      targetDisplaySize = TargetDisplaySize.Medium;
+    }
+
     for (const attendeeId of attendeeIds) {
-      prefs.add(new VideoPreference(attendeeId, 1, TargetDisplaySize.High));
+      prefs.add(new VideoPreference(attendeeId, 1, targetDisplaySize));
     }
     this.defaultVideoPreferences = prefs.build();
   }

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -205,20 +205,40 @@ describe('VideoPriorityBasedPolicy', () => {
   describe('default preference', () => {
     it('use default preference', () => {
       const policy = new VideoPriorityBasedPolicy(logger);
-      updateIndexFrame(videoStreamIndex, 1, 0, 600);
+      updateIndexFrame(videoStreamIndex, 1, 0, 1200);
       policy.updateIndex(videoStreamIndex);
       let resub = policy.wantsResubscribe();
       expect(resub).to.equal(true);
       let received = policy.chooseSubscriptions();
       expect(received.array()).to.deep.equal([2]);
 
+      // After startup period which is 6000 ms
       incrementTime(6100);
-      updateIndexFrame(videoStreamIndex, 2, 0, 600);
+      const metricReport = new DefaultClientMetricReport(logger);
+      metricReport.globalMetricReport = new GlobalMetricReport();
+      metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 3000 * 1000;
+      policy.updateMetrics(metricReport);
+
+      updateIndexFrame(videoStreamIndex, 2, 300, 1200);
       policy.updateIndex(videoStreamIndex);
       resub = policy.wantsResubscribe();
       expect(resub).to.equal(true);
       received = policy.chooseSubscriptions();
       expect(received.array()).to.deep.equal([2, 4]);
+
+      updateIndexFrame(videoStreamIndex, 6, 300, 1200);
+      policy.updateIndex(videoStreamIndex);
+      resub = policy.wantsResubscribe();
+      expect(resub).to.equal(true);
+      received = policy.chooseSubscriptions();
+      expect(received.array()).to.deep.equal([1, 3, 5, 7, 9, 11]);
+
+      updateIndexFrame(videoStreamIndex, 10, 300, 1200);
+      policy.updateIndex(videoStreamIndex);
+      resub = policy.wantsResubscribe();
+      expect(resub).to.equal(true);
+      received = policy.chooseSubscriptions();
+      expect(received.array()).to.deep.equal([1, 3, 5, 7, 9, 11, 13, 15, 17, 19]);
     });
   });
 


### PR DESCRIPTION
**Description of changes:**
Update the default priority-based video downlink policy to adjust target size based on number of videos in the meeting.

**Testing:**

Add unit tests to verify the changes.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No, would need a custom simulcast policy that does not downscale the high resolution stream.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

