### PR TITLE
Fix removeObserver for DefaultVideoTransformDeviceObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video track.
 - Add missing `captureOutputPrefix` param for SDK demo app in release script.
 - Amazon Voice Focus now works in Chrome 95 or later: WebAssembly policy changes required a change in how modules were loaded.
-- Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary
-- Fix bug: DOMException: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
+- Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary.
+- Fix bug: DOMException: The play() request was interrupted by a new load request. https://goo.gl/LdLk22.
+- Fix `removeObserver` function in `DefaultVideoTransformDevice`.
 
 ### Changed
 - Allow passing in custom video simulcast uplink policy that implements the `SimulcastUplinkPolicy` interface.

--- a/src/videoframeprocessor/DefaultVideoTransformDevice.ts
+++ b/src/videoframeprocessor/DefaultVideoTransformDevice.ts
@@ -159,7 +159,7 @@ export default class DefaultVideoTransformDevice
    * Remove an existing observer. If the observer has not been previously. this method call has no effect.
    */
   removeObserver(observer: DefaultVideoTransformDeviceObserver): void {
-    this.observers.add(observer);
+    this.observers.delete(observer);
   }
 
   processingDidStart(): void {


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/1636

**Description of changes:**
Need to remove the observer from the observer set rather than add. 

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
yes, but this is the correct behaviour.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

