### PR TITLE
Remove interface matching rule for all the components

### DIFF
--- a/script/check-code-style.js
+++ b/script/check-code-style.js
@@ -140,37 +140,6 @@ components().forEach(component => {
     return;
   }
 
-  if (component === 'voicefocus') {
-    // This rule does not make sense for Voice Focus.
-    return;
-  }
-
-  let hasMatchingInterface = false;
-  const componentDir = path.join('src', component);
-  walk(componentDir).forEach(file => {
-    if (
-      path.basename(file, '.ts').toLowerCase() === path.basename(componentDir) ||
-      path.basename(file, 'ComponentFactory.ts').toLowerCase() === path.basename(componentDir) ||
-      path.basename(file, '.d.ts').toLowerCase() === path.basename(componentDir)
-    ) {
-      hasMatchingInterface = true;
-    }
-  });
-
-  if (!hasMatchingInterface) {
-    failed(
-      componentDir,
-      'component does not have matching interface',
-      'Ensure that each component directory has an interface of the same name. \nFor example, src/foobar will have an interface src/foobar/FooBar.ts.'
-    );
-  }
-});
-
-components().forEach(component => {
-  if (isIgnored(component)) {
-    return;
-  }
-
   const componentDir = path.join('src', component);
   fs.readdirSync(componentDir).forEach(file => {
     let filePath = path.join(componentDir, file);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Remove interface matching rule for all the components. 

Each time we define an interface and then a class that implements it, that interface becomes part of our public, fixed API surface. We can't add to it because a customer might have used the interface! So because we have rules:

Each class should go in a separate file.
Each class has a matching interface.

By removing this rule, builders and developers can create components without a matching interface, which can give more freedom to developers to add or swap the default implementation.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

