### PR TITLE
Fix handling pausing when using default preference for priority-based video bandwidth policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary.
 - Fix bug: DOMException: The play() request was interrupted by a new load request. https://goo.gl/LdLk22.
 - Fix `removeObserver` function in `DefaultVideoTransformDevice`.
+- Fix handling pausing when using default preference for priority-based video bandwidth policy.
 
 ### Changed
 - Allow passing in custom video simulcast uplink policy that implements the `SimulcastUplinkPolicy` interface.

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -185,7 +185,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
   }
 
   updateMetrics(clientMetricReport: ClientMetricReport): void {
-    if (this.videoIndex.allStreams().empty()) {
+    if (!this.videoIndex || this.videoIndex.allStreams().empty()) {
       return;
     }
     this.prevDownlinkStats = this.downlinkStats;
@@ -742,9 +742,10 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
       this.logger.warn('tileController not found!');
       return;
     }
-    if (this.videoPreferences && this.shouldPauseTiles) {
+    const preferences = this.getCurrentVideoPreferences();
+    if (preferences && this.shouldPauseTiles) {
       const videoTiles = this.tileController.getAllVideoTiles();
-      for (const preference of this.videoPreferences) {
+      for (const preference of preferences) {
         const videoTile = this.getVideoTileForAttendeeId(
           preference.attendeeId,
           videoTiles
@@ -802,6 +803,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
       return;
     }
     const tiles = this.tileController.getAllRemoteVideoTiles();
+    const preferences = this.getCurrentVideoPreferences();
     for (const tile of tiles) {
       const state = tile.state();
       if (!state.boundVideoStream) {
@@ -811,8 +813,8 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
             `bwe: Removed video tile ${state.tileId} for bw paused attendee ${state.boundAttendeeId}`
           );
         } else if (
-          this.videoPreferences !== undefined &&
-          !this.videoPreferences.some(pref => pref.attendeeId === state.boundAttendeeId)
+          preferences !== undefined &&
+          !preferences.some(pref => pref.attendeeId === state.boundAttendeeId)
         ) {
           this.tileController.removeVideoTile(state.tileId);
         }
@@ -826,8 +828,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     chosenStreams: VideoStreamDescription[]
   ): VideoStreamDescription {
     let upgradeStream: VideoStreamDescription;
-    const videoPreferences: VideoPreferences =
-      this.videoPreferences || this.defaultVideoPreferences;
+    const videoPreferences: VideoPreferences = this.getCurrentVideoPreferences();
 
     const highestPriority = videoPreferences.highestPriority();
     let nextPriority;
@@ -1027,7 +1028,13 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
 
     if (this.videoPreferences) {
       logString += `bwe:   preferences: ${JSON.stringify(this.videoPreferences)}`;
+    } else {
+      logString += `bwe:   default preferences: ${JSON.stringify(this.defaultVideoPreferences)}`;
     }
     return logString;
+  }
+
+  private getCurrentVideoPreferences(): VideoPreferences {
+    return this.videoPreferences || this.defaultVideoPreferences;
   }
 }


### PR DESCRIPTION
**Issue #:**
Previously, if using default preference (i.e., do not call `chooseRemoteVideoSource` manually to set preference), the policy will not try to pause streams and instead just dropping them.

**Description of changes:**
If videoPreferences is not set, then use defaultVideoPreferences when considering pausing streams.

**Testing:**
- Add a unit tests.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Join a meeting with at least 2 remotes videos.
- Verify that you can see 2 videos.
- Throttle network to 3G or some low value
- Verify that both videos are paused and not dropping


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

