### PR TITLE
Fix readme - Use case4, exampleCode added quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ const observer = {
   },
 
   audioInputMuteStateChanged: (device, muted) => {
-    console.log('Device', device, muted ? 'is muted in hardware' : 'is not muted);
+    console.log('Device', device, muted ? 'is muted in hardware' : 'is not muted');
   },
 };
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
README.md case4 - exampleCode missing single quotes.
So Add it.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

