### PR TITLE
Remove screen signaling protocol generation as it is no longer is use

### DIFF
--- a/script/generate-signaling-protocol
+++ b/script/generate-signaling-protocol
@@ -7,22 +7,23 @@ def verbose command
   system(command) || fail("Failed: #{command}")
 end
 
-protocol = 'SignalingProtocol'
-dir = protocol.downcase
+['SignalingProtocol'].each do |protocol|
+  dir = protocol.downcase
 
-verbose "rm -rf src/#{dir}"
-verbose "mkdir -p src/#{dir}"
+  verbose "rm -rf src/#{dir}"
+  verbose "mkdir -p src/#{dir}"
 
-# workaround for https://github.com/hegemonic/requizzle/issues/5
-verbose "brew install node@10"
-node = "#{`brew --prefix node@10`.strip}/bin/node"
+  # workaround for https://github.com/hegemonic/requizzle/issues/5
+  verbose "brew install node@10"
+  node = "#{`brew --prefix node@10`.strip}/bin/node"
 
-# workaround for https://github.com/protobufjs/protobuf.js/issues/1217
-verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
-File.write('node_modules/protobufjs/package.json', File.read('node_modules/protobufjs/package.json').gsub('"jsdoc": "^3.5.5",', '"jsdoc": "~3.5.5",'))
+  # workaround for https://github.com/protobufjs/protobuf.js/issues/1217
+  verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
+  File.write('node_modules/protobufjs/package.json', File.read('node_modules/protobufjs/package.json').gsub('"jsdoc": "^3.5.5",', '"jsdoc": "~3.5.5",'))
 
-verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
-verbose "#{node} node_modules/.bin/pbts -o src/#{dir}/#{protocol}.d.ts src/#{dir}/#{protocol}.js"
+  verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
+  verbose "#{node} node_modules/.bin/pbts -o src/#{dir}/#{protocol}.d.ts src/#{dir}/#{protocol}.js"
 
-# workaround for the Long type import issue. Remove when https://github.com/protobufjs/protobuf.js/pull/1166/files is released.
-File.write("src/#{dir}/#{protocol}.d.ts", "import * as Long from \"long\";\n" + File.read("src/#{dir}/#{protocol}.d.ts"))
+  # workaround for the Long type import issue. Remove when https://github.com/protobufjs/protobuf.js/pull/1166/files is released.
+  File.write("src/#{dir}/#{protocol}.d.ts", "import * as Long from \"long\";\n" + File.read("src/#{dir}/#{protocol}.d.ts"))
+end

--- a/script/generate-signaling-protocol
+++ b/script/generate-signaling-protocol
@@ -7,23 +7,22 @@ def verbose command
   system(command) || fail("Failed: #{command}")
 end
 
-['SignalingProtocol', 'ScreenSignalingProtocol'].each do |protocol|
-  dir = protocol.downcase
+protocol = 'SignalingProtocol'
+dir = protocol.downcase
 
-  verbose "rm -rf src/#{dir}"
-  verbose "mkdir -p src/#{dir}"
+verbose "rm -rf src/#{dir}"
+verbose "mkdir -p src/#{dir}"
 
-  # workaround for https://github.com/hegemonic/requizzle/issues/5
-  verbose "brew install node@10"
-  node = "#{`brew --prefix node@10`.strip}/bin/node"
+# workaround for https://github.com/hegemonic/requizzle/issues/5
+verbose "brew install node@10"
+node = "#{`brew --prefix node@10`.strip}/bin/node"
 
-  # workaround for https://github.com/protobufjs/protobuf.js/issues/1217
-  verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
-  File.write('node_modules/protobufjs/package.json', File.read('node_modules/protobufjs/package.json').gsub('"jsdoc": "^3.5.5",', '"jsdoc": "~3.5.5",'))
+# workaround for https://github.com/protobufjs/protobuf.js/issues/1217
+verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
+File.write('node_modules/protobufjs/package.json', File.read('node_modules/protobufjs/package.json').gsub('"jsdoc": "^3.5.5",', '"jsdoc": "~3.5.5",'))
 
-  verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
-  verbose "#{node} node_modules/.bin/pbts -o src/#{dir}/#{protocol}.d.ts src/#{dir}/#{protocol}.js"
+verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
+verbose "#{node} node_modules/.bin/pbts -o src/#{dir}/#{protocol}.d.ts src/#{dir}/#{protocol}.js"
 
-  # workaround for the Long type import issue. Remove when https://github.com/protobufjs/protobuf.js/pull/1166/files is released.
-  File.write("src/#{dir}/#{protocol}.d.ts", "import * as Long from \"long\";\n" + File.read("src/#{dir}/#{protocol}.d.ts"))
-end
+# workaround for the Long type import issue. Remove when https://github.com/protobufjs/protobuf.js/pull/1166/files is released.
+File.write("src/#{dir}/#{protocol}.d.ts", "import * as Long from \"long\";\n" + File.read("src/#{dir}/#{protocol}.d.ts"))


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
The screen signaling protocol is no longer in use so it should be removed from the generate-signaling-protocol script to avoid auto generating it again whenever the script runs.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA
Tested by running the script generate-signaling-protocol locally.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

