### PR TITLE
[Test] Fix extended debugging for integ tests

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,8 +104,8 @@ const getSauceLabsConfig = (capabilities) => {
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
     tunnelIdentifier: process.env.JOB_ID,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && 
-      (capabilities.name).includes('ContentShare') && {
+    ...((capabilities.platform.toUpperCase() !== 'LINUX' &&
+      !((capabilities.name).includes('ContentShare'))) && {
         extendedDebugging: true
       }),
   }
@@ -115,7 +115,7 @@ const getSauceLabsDomain = (platform)  => {
   const platformUpperCase = platform.toUpperCase();
   if (platformUpperCase === 'LINUX') {
     return 'us-east-1.saucelabs.com';
-  } 
+  }
   return 'us-west-1.saucelabs.com';
 };
 


### PR DESCRIPTION
**Description of changes:**
Fix the logic to only disable extended debugging for content share integ tests.

**Testing:**
N/A


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

