### PR TITLE
Do not pause sources that do not exist in priority downlink policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix handling pausing when using default preference for priority-based video bandwidth policy.
 - Bind tile controller for any downlink policy that implements `bindToTileController` such as 
   `VideoAdaptiveProbePolicy`.
+- Do not pause streams that do not exist in conference in `VideoPriorityBasedPolicy`.
 
 ### Changed
 

--- a/src/task/ReceiveVideoStreamIndexTask.ts
+++ b/src/task/ReceiveVideoStreamIndexTask.ts
@@ -84,6 +84,8 @@ export default class ReceiveVideoStreamIndexTask
     this.resubscribe(videoDownlinkBandwidthPolicy, videoUplinkBandwidthPolicy);
     this.updateVideoAvailability(indexFrame);
     this.handleIndexVideosPausedAtSource();
+    // `forEachObserver`is asynchronous anyways so it doesn't matter (for better or worse) whether we
+    // trigger it before or after the policy update + possible resubscribe kickoff
     const newVideoSources = videoStreamIndex.allVideoSendingSourcesExcludingSelf(selfAttendeeId);
     if (!this.areVideoSourcesEqual(oldVideoSources, newVideoSources)) {
       this.context.audioVideoController.forEachObserver((observer: AudioVideoObserver) => {

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -752,7 +752,13 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
         ) as DefaultVideoTile;
         const paused = videoTile?.state().paused || false;
         if (!chosenStreams.some(stream => stream.attendeeId === preference.attendeeId)) {
-          if (videoTile) {
+          // We cannot rely on the existance of video tile to indicate that the source exists in the call
+          // because tiles will not be added or removed until after a full renegotiation (i.e. it will
+          // be behind the state provided by the index)
+          const streamExists = remoteInfos.some(
+            stream => stream.attendeeId === preference.attendeeId
+          );
+          if (videoTile && streamExists) {
             const info = this.optimalReceiveStreams.find(
               stream => stream.attendeeId === preference.attendeeId
             );
@@ -769,7 +775,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
               chosenStreams.push(info);
             }
             this.pausedBwAttendeeIds.add(preference.attendeeId);
-          } else if (remoteInfos.some(stream => stream.attendeeId === preference.attendeeId)) {
+          } else if (streamExists) {
             // Create a tile for this participant if one doesn't already exist and mark it as paused
             // Don't include it in the chosen streams because we don't want to subscribe for it then have to pause it.
             const newTile = this.tileController.addVideoTile();


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** 
See title.  This would lead to a bug where native clients (e.g. mobile SDK in SDK world) enabling/disabling video would cause a pause to be signaled.  When re-enabling video the pause state would be stuck and the receiver would not receive any video.  This only effected native senders because (for better or worse) JS SDK clients change sending stream IDs every enable.

**Testing:**
Reproduced issue using SDK client with non-default preferences set + CLI clients that replicate native clients.  Post fix no longer sends out pause and hides video on re-enabling.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
They can at least be sanity checked.  I'm not sure if possible to reproduce using Mobile SDK demos.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

