### PR TITLE
Adding support for npm 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "engines": {
     "node": "^12 || ^14 || ^15 || ^16",
-    "npm": "^6 || ^7"
+    "npm": "^6 || ^7 || ^8"
   },
   "scripts": {
     "clean": "rimraf .nyc_output build node_modules",


### PR DESCRIPTION
**Issue #:**
No issue openned yet

**Description of changes:**
Adding support for npm cli version 8+

**Testing:**
Use latest stable npm version (8.0.0) and do `npm i`

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.