### PR TITLE
Fixed failure of backwards compatiblity test from missing content share test

### DIFF
--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -73,8 +73,10 @@ jobs:
         run: npm run test:integration-audio
       - name: Run Video Integ Test
         run: npm run test:integration-video
-      - name: Run Content Share Integration Test
-        run: npm run test:integration-content-share
+      - name: Run Content Share Integration Test Job One
+        run: npm run test:integration-content-share-test-suite-one
+      - name: Run Content Share Integration Test Job Two
+        run: npm run test:integration-content-share-test-suite-two
       - name: Run Data Message Integration Test
         run: npm run test:integration-data-message
       - name: Run Meeting Readiness Checker Integration Test


### PR DESCRIPTION
**Issue #:**
Backwards Compatibility test fails from missing the test:integration-content-share script
Failed Workflow: https://github.com/aws/amazon-chime-sdk-js/runs/3888566432?check_suite_focus=true
**Description of changes:**
Updated the workflow to make use of the test:integration-content-share-test-suite-one script and the test:integration-content-share-test-suite-two script that old script had been separated into.
**Testing:**
Ran the test by temporarily enabling it to run on any PRs
Successful Workflow: https://github.com/aws/amazon-chime-sdk-js/actions/runs/1339687162
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

