### PR TITLE
Added googleapis to CSP for Segmentation Filter

### DIFF
--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -40,11 +40,16 @@ for (const stage of ['a', 'b', 'g', '']) {
   csp['script-src-elem'] += host;
 }
 
-// 2. Access to jsdelivr for TensorFlow for background blur.
+// 2. Access to googleapis for the Segmentation filter 
+csp['connect-src'] += ' https://storage.googleapis.com';
+csp['script-src'] += ' https://storage.googleapis.com';
+csp['script-src-elem'] += ' https://storage.googleapis.com';
+
+// 3. Access to jsdelivr for TensorFlow for background blur.
 csp['script-src'] += ' https://cdn.jsdelivr.net';
 csp['script-src-elem'] += ' https://cdn.jsdelivr.net';
 
-// 3. Add 'unsafe-eval' because TensorFlow needs it.
+// 4. Add 'unsafe-eval' because TensorFlow needs it.
 if (!csp['script-src'].includes("'unsafe-eval'")) {
   csp['script-src'] += " 'unsafe-eval'";
 }


### PR DESCRIPTION
**Issue #:**
Segmentation Filter does not work because of a security violation 
**Description of changes:**
Added googleapis to CSP to fix
**Testing:**
Ran demo and confirmed that Segmentation filter works
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Built browser demo
- Ran locally
- Created a meeting
- In preview mode tried to use Segmentation filter
- Confirmed that the video stream looked correct

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

