### PR TITLE
Add ingestion gamma endpoint to CSP

### DIFF
--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -52,6 +52,9 @@ if (!csp['script-src'].includes("'unsafe-eval'")) {
   csp['script-src'] += " 'unsafe-eval'";
 }
 
+// 5. Access to event ingestion gamma endpoint for testing and canaries.
+csp['connect-src'] += ' https://*.ingest.gchime.aws';
+
 module.exports = env => {
   console.info('Env:', JSON.stringify(env, null, 2));
   console.info('App:', process.env.npm_config_app);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Add ingestion gamma endpoint to CSP so that beta canaries do not fail, prod and gamma are fine since the staged chime host does not apply to them and the existing basic CSP [connect-src](https://github.com/aws/amazon-chime-sdk-js/blob/master/demos/browser/webpack.config.js#L20) covers it.
- Below error appears in beta canaries:
```
Refused to connect to 'https://data.svc.ue1.ingest.gchime.aws/v1/client-events' because it violates the document's Content Security Policy.
....
2021-10-15T21:42:33.968Z [ERROR] SDK - Security Policy Violation
Blocked URI: https://data.svc.ue1.ingest.gchime.aws/v1/client-events
Violated Directive: connect-src
```

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
meetingV2
- I deployed a demo using Chime's gamma endpoint and test if events ingestion does not throw error in console and we receive 200s for fetch POSTs.
- This should also get tested as soon as merged and beta canaries are updated.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

