### PR TITLE
Cancel the bolding of the h5 label

### DIFF
--- a/docs/modules/videolayout.html
+++ b/docs/modules/videolayout.html
@@ -109,11 +109,11 @@
 					</a>
 					<p>The video encoding parameters are determined by the uplink policy, which takes into consideration the number of video publishers on the call. If necessary, it may suggest encoding multiple “simulcast” layers (with different bitrates and resolutions). The JavaScript SDK currently provides two uplink policies:</p>
 					<a href="#nscalevideouplinkbandwidthpolicy-default" id="nscalevideouplinkbandwidthpolicy-default" style="color: inherit; text-decoration: none;">
-						<h5><strong>NScaleVideoUplinkBandwidthPolicy (Default)</strong></h5>
+						<h5>NScaleVideoUplinkBandwidthPolicy (Default)</h5>
 					</a>
 					<p>In this policy, an attendee encodes and sends one video layer upstream and scales the resolution and bitrate based on the number of video publishers. This is to ensure the receiving attendees who are subscribed to these videos do not experience excessive network or compute load, which may degrade the meeting quality.</p>
 					<a href="#simulcastuplinkpolicy" id="simulcastuplinkpolicy" style="color: inherit; text-decoration: none;">
-						<h5><strong>SimulcastUplinkPolicy</strong></h5>
+						<h5>SimulcastUplinkPolicy</h5>
 					</a>
 					<p>Each attendee may encode and send up to two layers of video with different bitrates and resolutions under this policy. It enables the recipient to switch between the two video layers to adapt to changing network conditions or different layouts (e.g., a featured video may desire a higher resolution than a gallery view video).</p>
 					<ul>
@@ -124,11 +124,11 @@
 					</a>
 					<p>The downlink policy controls which remote video sources are received downstream based on the network condition, local resources (e.g., CPU), and other factors such as layout changes in the application. The JavaScript SDK currently provides two downlink policies:</p>
 					<a href="#allhighestvideobandwidthpolicy-default" id="allhighestvideobandwidthpolicy-default" style="color: inherit; text-decoration: none;">
-						<h5><strong>AllHighestVideoBandwidthPolicy (Default)</strong></h5>
+						<h5>AllHighestVideoBandwidthPolicy (Default)</h5>
 					</a>
 					<p>This policy subscribes to the highest quality video layer of all publishers. Under constrained network, some or all videos may freeze as packets are lost on the network, and they will recover automatically once network congestion is reduced.</p>
 					<a href="#videoprioritybasedpolicy" id="videoprioritybasedpolicy" style="color: inherit; text-decoration: none;">
-						<h5><strong>VideoPriorityBasedPolicy</strong></h5>
+						<h5>VideoPriorityBasedPolicy</h5>
 					</a>
 					<p>This policy allows builders to choose and configure which remote video sources to subscribe to, their relative priorities and preferences such as, <code>targetDisplaySize</code> . Under constrained network, the policy will automatically pause video tiles based on the priorities you set to these remote video sources until recovery. If used with the <code>SimulcastUplinkPolicy</code>, the policy may temporarily degrade to lower resolutions. For videos of the same priority, the policy first tries to allocate bandwidth to ensure as many videos can be displayed as possible before upgrading to higher quality if the bandwidth allows.</p>
 					<a href="#recommendations-for-common-layouts" id="recommendations-for-common-layouts" style="color: inherit; text-decoration: none;">

--- a/guides/16_Video_Layout.md
+++ b/guides/16_Video_Layout.md
@@ -32,11 +32,11 @@ Uplink and downlink policies help builders configure the video strategies for se
 
 The video encoding parameters are determined by the uplink policy, which takes into consideration the number of video publishers on the call. If necessary, it may suggest encoding multiple “simulcast” layers (with different bitrates and resolutions). The JavaScript SDK currently provides two uplink policies:
 
-##### **NScaleVideoUplinkBandwidthPolicy (Default)**
+##### NScaleVideoUplinkBandwidthPolicy (Default)
 
 In this policy, an attendee encodes and sends one video layer upstream and scales the resolution and bitrate based on the number of video publishers. This is to ensure the receiving attendees who are subscribed to these videos do not experience excessive network or compute load, which may degrade the meeting quality.
 
-##### **SimulcastUplinkPolicy**
+##### SimulcastUplinkPolicy
 
 Each attendee may encode and send up to two layers of video with different bitrates and resolutions under this policy. It enables the recipient to switch between the two video layers to adapt to changing network conditions or different layouts (e.g., a featured video may desire a higher resolution than a gallery view video).
 
@@ -46,11 +46,11 @@ Each attendee may encode and send up to two layers of video with different bitra
 
 The downlink policy controls which remote video sources are received downstream based on the network condition, local resources (e.g., CPU), and other factors such as layout changes in the application. The JavaScript SDK currently provides two downlink policies:
 
-##### **AllHighestVideoBandwidthPolicy (Default)**
+##### AllHighestVideoBandwidthPolicy (Default)
 
 This policy subscribes to the highest quality video layer of all publishers. Under constrained network, some or all videos may freeze as packets are lost on the network, and they will recover automatically once network congestion is reduced.
 
-##### **VideoPriorityBasedPolicy**
+##### VideoPriorityBasedPolicy
 
 This policy allows builders to choose and configure which remote video sources to subscribe to, their relative priorities and preferences such as, `targetDisplaySize` . Under constrained network, the policy will automatically pause video tiles based on the priorities you set to these remote video sources until recovery. If used with the `SimulcastUplinkPolicy`, the policy may temporarily degrade to lower resolutions. For videos of the same priority, the policy first tries to allocate bandwidth to ensure as many videos can be displayed as possible before upgrading to higher quality if the bandwidth allows.
 


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
Unbold the `h5` tag to distinguish the style of `h5` tag and `h4` tag.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A, just doc changes.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

