### PR TITLE
Update Xcode UI Test workflow

### DIFF
--- a/.github/workflows/webview-ui-test.yml
+++ b/.github/workflows/webview-ui-test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run XCUITest Locally
         run: |
-          xcodebuild test -project apps/iOS-WKWebView-sample/WkWebView\ Demo.xcodeproj -scheme WkWebView\ Demo  -sdk iphonesimulator -destination "platform=iOS Simulator,OS=14.5,name=iPhone 11 Pro"
+          xcodebuild test -project apps/iOS-WKWebView-sample/WkWebView\ Demo.xcodeproj -scheme WkWebView\ Demo  -sdk iphonesimulator -destination "platform=iOS Simulator,OS=15.0,name=iPhone 11 Pro"
   androidtest:
     runs-on: macos-11
     defaults:


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Need to update to use xcode 13 and iOS 15 to fix the github action.

**Testing:**
Ran the command locally on my terminal.

```
xcodebuild test -project "apps/iOS-WKWebView-sample/WkWebView Demo.xcodeproj" -scheme "WkWebView Demo" -sdk iphonesimulator -destination "platform=iOS Simulator,OS=15.0,name=iPhone 11 Pro"
```

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
yes, by running the command locally above.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n/a

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

