### PR TITLE
revert change for select region.

### DIFF
--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -106,7 +106,7 @@ class AppPage {
   }
 
   async selectRegion(region) {
-    await clickElement(this.driver, this.driver.findElement(By.css(`option[value=${region}]`)));
+    await this.driver.findElement(By.css(`option[value=${region}]`)).click();
   }
 
   async authenticate() {


### PR DESCRIPTION
**Issue #:**
Revert change for select region.
**Description of changes:**
https://github.com/aws/amazon-chime-sdk-js/pull/1693/files#diff-d8ed46a1c7dcbf904fa3537a5a7e9459604ca5508b035d3f1abc7365759e77ecR108 broke the media capture integration test. revert the change for selectRegion click.
**Testing:**
run media capture test in saucelab.
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

