### PR TITLE
Prevent error thrown by nscale uplink bandwidth policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix disabling of send streams when local video was not enabled by integrating empty encoder params into `VideoStreamIndex` when sending is disabled.
 - Fix `visibilitychange` typo in `InMemoryJSONEventBuffer`.
-
-
+- Prevent error `'scaleResolutionDownBy' member of RTCRtpEncodingParameters is not a finite floating-point value` 
+  thrown by NScale video uplink bandwidth policy when there is no height information from the sending video stream.
+  
 ### Changed
 
 - Ignore `enableUnifiedPlanForChromiumBasedBrowsers` value (i.e. treat as always equaling the current default value of `true`) in `MeetingSesstionConfiguration`.  Chrome is [in the processing](https://groups.google.com/g/discuss-webrtc/c/UBtZfawdIAA/m/m-4wnVHXBgAJ) of deprecating and removing Plan-B which would cause breakage in applications still trying to use it.  This will have no effect on SDK behavior` and has been the default since 1.17.0.

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -190,7 +190,12 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
   private calculateEncodingParameters(setting: MediaTrackSettings): RTCRtpEncodingParameters {
     const maxBitrate = this.maxBandwidthKbps() * 1000;
     let scale = 1;
-    if (setting && this.scaleResolution && !this.hasBandwidthPriority && this.numParticipants > 2) {
+    if (
+      setting.height !== undefined &&
+      this.scaleResolution &&
+      !this.hasBandwidthPriority &&
+      this.numParticipants > 2
+    ) {
       const targetHeight =
         NScaleVideoUplinkBandwidthPolicy.targetHeightArray[
           Math.min(

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -43,7 +43,7 @@ export default class DOMMockBehavior {
   mediaStreamTrackSettings: {
     width?: number;
     height?: number;
-    deviceId: string;
+    deviceId?: string;
     facingMode?: string;
     groupId?: string;
   } = {

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -245,7 +245,7 @@ export default class DOMMockBuilder {
       listeners: { [type: string]: { once: boolean; listener: MockListener }[] } = {};
       readyState: MediaStreamTrackState = 'live';
 
-      streamDeviceID = mockBehavior.mediaStreamTrackSettings.deviceId || uuidv1();
+      streamDeviceID = mockBehavior.mediaStreamTrackSettings?.deviceId || uuidv1();
 
       readonly id: string;
       readonly kind: string = '';


### PR DESCRIPTION
**Issue #1723:**
In some cases such as enabling video filter in Firefox, the sending video stream may contain an empty setting object and cause the nscale video bandwidth uplink policy to use undefined height value when calculating scale down value leading to the `'scaleResolutionDownBy' member of RTCRtpEncodingParameters is not a finite floating-point value` error thrown.
**Description of changes:**
Prevent the error by checking for setting.height of the sending video stream to be defined. 
However, this does not fully fix the issue yet as Nscale would not attempt to downscale the resolution of the sending video stream anymore. We will follow up on this in another PR.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Join a meeting with one attendee joined from Firefox and turned on video
- The firefox attendee will enable video filter first before turning on video.
- Verify that there is no error thrown.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

