### PR TITLE
Update publish script to publish the tag instead of master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,12 @@ jobs:
     steps:
       - name: Checkout Package
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - name: Setup Node environment
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - name: NPM Install
         run: npm install


### PR DESCRIPTION
**Description of changes:**
Change the publish workflow to checkout the tag that was created as part of the release.

**Testing:**

Just publish script tag.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

