### PR TITLE
Specify to include CHANGELOG and NOTICE

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "types": "build/index.d.ts",
   "files": [
     "libs",
-    "build"
+    "build",
+    "CHANGELOG.md",
+    "NOTICE"
   ],
   "engines": {
     "node": "^12 || ^14 || ^15 || ^16",


### PR DESCRIPTION
**Issue #:**
NPM 7 and later no longer auto includes CHANGELOG.md and NOTICE files.
**Description of changes:**

Specify those files in package.json to include in the npm package.

**Testing:**
Run `npm run build && npm pack` and verify those files are included with the build, lib folders as well as README and LICENSE.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

