### PR TITLE
Add documentation and update script for updating serverless demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for layers allocation negotiation in Chromium based browsers to avoid resubscribing to preemptively turn off simulcast streams or to switch layers.
 - Update browser compatibility doc for background blur
 - Add a doc to guide builders on managing video quality for different video layouts. See [guide](https://aws.github.io/amazon-chime-sdk-js/modules/videolayout.html).
+- Add documentation on how to update a deployment of the serverless demo.
 
 ### Removed
 
@@ -24,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ignore `enableUnifiedPlanForChromiumBasedBrowsers` value (i.e. treat as always equaling the current default value of `true`) in `MeetingSesstionConfiguration`.  Chrome is [in the processing](https://groups.google.com/g/discuss-webrtc/c/UBtZfawdIAA/m/m-4wnVHXBgAJ) of deprecating and removing Plan-B which would cause breakage in applications still trying to use it.  This will have no effect on SDK behavior` and has been the default since 1.17.0.
 - Change `appVersionName` and `appVersionCode` fields to `appName` and `appVersion` respectively.
-- Update similar log messages in `DefaultMessagingSession` and `DefaultSignalingClient`. 
+- Update similar log messages in `DefaultMessagingSession` and `DefaultSignalingClient`.
+- Change the serverless demo's `deploy.js` script to rebuild the demo on each run. This should remove a manual step of rebuilding the demo.
 
 ## [2.20.1] - 2021-10-27
 

--- a/demos/serverless/README.md
+++ b/demos/serverless/README.md
@@ -70,13 +70,17 @@ finishes, it will output a URL that can be opened in a browser.
 ### Updating deployed application
 Over time JS SDK will push new features, improvements, and bug fixes etc. It is important for the deployed application to maintain a recent version of the SDK. Updating the deployed application is easy to do with the help of the deploy script. 
 
-First you need to make sure you have the version of JS SDK that you want to deploy on your local machine. The deploy script will check whether there is a recent build of browser demo available. So, you want to delete the `dist` folder under browser demo. This will trigger the deploy script to rebuild the demo with the new version of JS SDK. Now that you have the build ready you need to deploy it again.
+First you need to make sure you have the version of JS SDK that you want to deploy on your local machine. The deploy script will check whether there is a recent build of browser demo available. So, you want to delete the `dist` folder under browser demo. This will trigger the deploy script to rebuild the demo with the new version of JS SDK. Another way to achieve a new build is to run `npm run build` under `demos/browser` as that will create a new `dist` folder.
 
 > NOTE: When you deploy the demo, make sure the params (for ex. my-bucket and my-stack-name) passed to the deploy script are the same as your original deployment. This is will cause the exisiting resources to be updated rather than creating new ones. If you change the name of resources you will end up with a new cloudformation stack and that might cause unintended billing charges.
 
 ```
 cd demos/browser
+# Option 1
 rm -rf dist
+
+# Option 2
+npm run build
 
 cd demos/serverless
 node ./deploy.js -r us-east-1 -b <my-bucket> -s <my-stack-name> -a meeting

--- a/demos/serverless/README.md
+++ b/demos/serverless/README.md
@@ -70,18 +70,9 @@ finishes, it will output a URL that can be opened in a browser.
 ### Updating deployed application
 Over time JS SDK will push new features, improvements, and bug fixes etc. It is important for the deployed application to maintain a recent version of the SDK. Updating the deployed application is easy to do with the help of the deploy script. 
 
-First you need to make sure you have the version of JS SDK that you want to deploy on your local machine. The deploy script will check whether there is a recent build of browser demo available. So, you want to delete the `dist` folder under browser demo. This will trigger the deploy script to rebuild the demo with the new version of JS SDK. Another way to achieve a new build is to run `npm run build` under `demos/browser` as that will create a new `dist` folder.
-
 > NOTE: When you deploy the demo, make sure the params (for ex. my-bucket and my-stack-name) passed to the deploy script are the same as your original deployment. This is will cause the exisiting resources to be updated rather than creating new ones. If you change the name of resources you will end up with a new cloudformation stack and that might cause unintended billing charges.
 
 ```
-cd demos/browser
-# Option 1
-rm -rf dist
-
-# Option 2
-npm run build
-
 cd demos/serverless
 node ./deploy.js -r us-east-1 -b <my-bucket> -s <my-stack-name> -a meeting
 ```

--- a/demos/serverless/README.md
+++ b/demos/serverless/README.md
@@ -67,6 +67,21 @@ These script will create an S3 bucket and CloudFormation stack
 with Lambda and API Gateway resources required to run the demo. After the script
 finishes, it will output a URL that can be opened in a browser.
 
+### Updating deployed application
+Over time JS SDK will push new features, improvements, and bug fixes etc. It is important for the deployed application to maintain a recent version of the SDK. Updating the deployed application is easy to do with the help of the deploy script. 
+
+First you need to make sure you have the version of JS SDK that you want to deploy on your local machine. The deploy script will check whether there is a recent build of browser demo available. So, you want to delete the `dist` folder under browser demo. This will trigger the deploy script to rebuild the demo with the new version of JS SDK. Now that you have the build ready you need to deploy it again.
+
+> NOTE: When you deploy the demo, make sure the params (for ex. my-bucket and my-stack-name) passed to the deploy script are the same as your original deployment. This is will cause the exisiting resources to be updated rather than creating new ones. If you change the name of resources you will end up with a new cloudformation stack and that might cause unintended billing charges.
+
+```
+cd demos/browser
+rm -rf dist
+
+cd demos/serverless
+node ./deploy.js -r us-east-1 -b <my-bucket> -s <my-stack-name> -a meeting
+```
+
 ### Cleaning up
 To avoid incurring any unintended charges as a result of deploying the serverless demo, it is important to delete the AWS CloudFormation stack after you are finished using it. You can delete the provisioned CloudFormation stack using the [AWS CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html) or the [AWS CLI](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-deleting-stack.html) as well as [delete the S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/delete-bucket.html) that were created.
 

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -165,10 +165,8 @@ function ensureApp(appName) {
     console.log(`Application ${appName} does not exist. Did you specify correct name?`);
     process.exit(1);
   }
-  if (!fs.existsSync(appHtml(appName))) {
-    console.log(`Application ${appHtml(appName)} does not exist. Rebuilding demo apps`);
-    spawnOrFail('npm', ['run', 'build', `--app=${appName}`], {cwd: path.join(__dirname, '..', 'browser')});
-  }
+  console.log(`Rebuilding demo app`);
+  spawnOrFail('npm', ['run', 'build', `--app=${appName}`], {cwd: path.join(__dirname, '..', 'browser')});
 }
 
 function ensureTools() {


### PR DESCRIPTION
**Issue #:**

**Description of changes:** Currently we do not have any documentation on how to update a deployed serverless demo. Adding this documentation will help builders maintain their deployments.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

