### PR TITLE
[Do Not Merge] Add a github action to block merge during release

### DIFF
--- a/.github/workflows/allow-merge.yml
+++ b/.github/workflows/allow-merge.yml
@@ -1,0 +1,32 @@
+# This workflow will just make sure that the PR cannot be merged during release by check if there is a release PR opened.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Allow Merge
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  can-merge:
+    name: Check If Can Merge
+    if: ${{ github.head_ref != 'release' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if there is a release PR
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const prs = await github.rest.pulls.list({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          head: 'aws:release'
+                        })
+            if (prs.data.length !== 0) {
+              throw "There is a release PR opened. This PR cannot be merged at this time."
+            }
+            return "This PR can be merged."
+
+


### PR DESCRIPTION
**Description of changes:**
Add a GitHub action to prevent merging when there is a release PR opened to avoid accidentally merge into master during release.

**Testing:**
Test that the Allow Merge failed when there was a release PR opened.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not JS SDK changes.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

