### PR TITLE
[Test] Fix stale element error in messaging integration test

### DIFF
--- a/integration/js/pages/MessagingSessionPage.js
+++ b/integration/js/pages/MessagingSessionPage.js
@@ -39,18 +39,22 @@ class MessagingSessionPage {
     let i = 0;
     let connecting = true;
     while (connecting && i < timeout) {
+      await TestUtils.waitAround(1000);
       connecting = await this.isConnecting();
       if (connecting === false) {
         return 'done'
       }
       i++;
-      await TestUtils.waitAround(1000);
     }
     return 'failed'
   }
 
   async isConnecting() {
-    return await this.driver.findElement(elements.connectFlow).isDisplayed();
+    try {
+      return await this.driver.findElement(elements.connectFlow).isDisplayed();
+    } catch (e) { //Catch StaleElementReferenceError
+      return false;
+    }
   }
 
   async disconnect() {
@@ -63,18 +67,22 @@ class MessagingSessionPage {
     let i = 0;
     let isDisconnecting = true;
     while (isDisconnecting && i < timeout) {
+      await TestUtils.waitAround(1000);
       isDisconnecting = await this.isDisconnecting();
       if (isDisconnecting === false) {
         return 'done'
       }
       i++;
-      await TestUtils.waitAround(1000);
     }
     return 'failed'
   }
 
   async isDisconnecting() {
-    return await this.driver.findElement(elements.disconnectFlow).isDisplayed();
+    try {
+      return await this.driver.findElement(elements.disconnectFlow).isDisplayed();
+    } catch (e) { //Catch StaleElementReferenceError
+      return false;
+    }
   }
 
   async checkMessageTypeExist(messageType) {


### PR DESCRIPTION
**Issue #:**
The messaging session integration test sometimes failed with stale element error in the last step when checking whether we no longer see the disconnect button because there can be a race condition when the page refreshes right after Selenium webdriver found the element reference causing it to be stale and `isDisplayed` will throw `StaleElementReferenceError`.

**Description of changes:**
- Moving the 1st wait time up first before the check to give some buffer between connect/disconnect step and the check.
- Add try/catch just to be safe.
- Refactor the test.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

