### PR TITLE
Fix the wrong code block style in Voice Focus guide

### DIFF
--- a/docs/modules/amazonvoice_focus.html
+++ b/docs/modules/amazonvoice_focus.html
@@ -230,9 +230,9 @@ because <span class="hljs-keyword">it</span> violates <span class="hljs-keyword"
 					</a>
 					<p>Some browsers support the Amazon Chime SDK but do not support Amazon Voice Focus. Additionally, some devices are not fast enough to keep up with real-time audio while suppressing noise.</p>
 					<p>The SDK provides a static method to allow you to cheaply check for the required browser features:</p>
-					<pre><code class="language-typescript"><span class="hljs-string">`import { VoiceFocusDeviceTransformer } from &#x27;amazon-chime-sdk-js&#x27;;`</span>
+					<pre><code class="language-typescript"><span class="hljs-keyword">import</span> { VoiceFocusDeviceTransformer } <span class="hljs-keyword">from</span> <span class="hljs-string">&#x27;amazon-chime-sdk-js&#x27;</span>;
 …
-<span class="hljs-string">`const isVoiceFocusSupported = await VoiceFocusDeviceTransformer.isSupported();`</span>
+<span class="hljs-keyword">const</span> isVoiceFocusSupported = <span class="hljs-keyword">await</span> VoiceFocusDeviceTransformer.isSupported();
 </code></pre>
 					<p>If <code>isSupported</code> returns <code>true</code>, you can instantiate a transformer. This will measure the runtime environment and perform some initialization, and so its <code>isSupported</code> method is more accurate.</p>
 					<pre><code class="language-typescript"><span class="hljs-keyword">let</span> transformer: VoiceFocusDeviceTransformer;

--- a/guides/09_Amazon_Voice_Focus.md
+++ b/guides/09_Amazon_Voice_Focus.md
@@ -144,9 +144,9 @@ Some browsers support the Amazon Chime SDK but do not support Amazon Voice Focus
 The SDK provides a static method to allow you to cheaply check for the required browser features:
 
 ```typescript
-`import { VoiceFocusDeviceTransformer } from 'amazon-chime-sdk-js';`
+import { VoiceFocusDeviceTransformer } from 'amazon-chime-sdk-js';
 …
-`const isVoiceFocusSupported = await VoiceFocusDeviceTransformer.isSupported();`
+const isVoiceFocusSupported = await VoiceFocusDeviceTransformer.isSupported();
 ```
 
 If `isSupported` returns `true`, you can instantiate a transformer. This will measure the runtime environment and perform some initialization, and so its `isSupported` method is more accurate.


### PR DESCRIPTION
**Issue #:**

The style of ene code bock in Voice Focus guide is wrong.

**Description of changes:**

Delete the inline code block inside the code block.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A, only doc updates

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

