### PR TITLE
Fix previous version integration test github workflow

### DIFF
--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -70,8 +70,10 @@ jobs:
         run: npm run test:integration-audio
       - name: Run Video Integ Test
         run: npm run test:integration-video
-      - name: Run Content Share Integration Test
-        run: npm run test:integration-content-share
+      - name: Run Content Share Integration Test Job One
+        run: npm run test:integration-content-share-test-suite-one
+      - name: Run Content Share Integration Test Job Two
+        run: npm run test:integration-content-share-test-suite-two
       - name: Run Data Message Integration Test
         run: npm run test:integration-data-message
       - name: Run Meeting Readiness Checker Integration Test


### PR DESCRIPTION
**Issue #:**
We separated the `integration-content-share` npm run script into
two `test:integration-content-share-test-suite-one` and `test:integration-content-share-test-suite-two`.

The previous version integration test has been failing due to this, hence update it
with new two script runs. Error is pasted below.
```
Run npm run test:integration-content-share
npm ERR! missing script: test:integration-content-share
npm ERR!
```

**Description of changes:**
- Just update the workflow job run flow.

**Testing:**
- Will be tested with next `prev-version-integration` run.
- Currently, been already tested when we fixed Backwards Compatibility Test.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA, integration test workflow fix.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Not required.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

