### PR TITLE
Remove useless activeSpeakerLayout field in meeting demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -453,7 +453,6 @@ export class DemoMeetingApp
   blurObserver: (undefined | BackgroundBlurVideoFrameProcessorObserver ) = undefined;
 
   showActiveSpeakerScores = false;
-  activeSpeakerLayout = true;
   meeting: string | null = null;
   name: string | null = null;
   voiceConnectorId: string | null = null;


### PR DESCRIPTION
**Issue #1156 :**

**Description of changes:**
Remove the `activeSpeakerLayout` field, cause it is not used anywhere.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A, just remove useless code.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

