### PR TITLE
Fix Background Blur integration test

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -39,8 +39,7 @@
       }
     },
     "../..": {
-      "name": "amazon-chime-sdk-js",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "integrity": "sha512-m05lG5lLMfRWOB6pnPFJITJcIn3yQHz9ygJBTlK/JBwdVdYDnB/Pr0yz60D/iyVaadI3lyvcjPM2uRliz9tVeg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -49,7 +48,7 @@
         "detect-browser": "^5.2.0",
         "protobufjs": "~6.8.8",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
       },
       "devDependencies": {
         "@fluffy-spoon/substitute": "^1.89.0",
@@ -12479,7 +12478,7 @@
         "ts-node": "^9.1.1",
         "typedoc": "0.19.2",
         "typescript": "^4.2.3",
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^1.0.1"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -15957,8 +15956,7 @@
           "dev": true
         },
         "ua-parser-js": {
-          "version": "0.7.24",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+          "version": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
           "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw=="
         },
         "uglify-js": {

--- a/integration/js/BackgroundBlurTest.js
+++ b/integration/js/BackgroundBlurTest.js
@@ -22,6 +22,7 @@ class BackgroundBlurTest extends SdkBaseTest {
     await test_window_2.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, remote_attendee_id, session));
     await test_window_1.runCommands(async () => await ClickVideoButton.executeStep(this, session));
     await test_window_1.runCommands(async () => await ClickBackgroundBlurButton.executeStep(this, session));
+    await test_window_1.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
     await test_window_1.runCommands(async () => await VideoBackgroundBlurCheck.executeStep(this, session, attendee_id));
     await test_window_2.runCommands(async () => await VideoBackgroundBlurCheck.executeStep(this, session, attendee_id));
     await test_window_2.runCommands(async () => await RemoteVideoCheck.executeStep(this, session, 'VIDEO_ON'));   

--- a/integration/js/checks/VideoBackgroundBlurCheck.js
+++ b/integration/js/checks/VideoBackgroundBlurCheck.js
@@ -1,5 +1,5 @@
 const AppTestStep = require('../utils/AppTestStep');
-const {KiteTestError, Status} = require('kite-common');
+const { KiteTestError, Status, TestUtils } = require('kite-common');
 
 class VideoBackgroundBlurCheck extends AppTestStep {
   constructor(kiteBaseTest, sessionInfo, attendeeId) {
@@ -16,11 +16,19 @@ class VideoBackgroundBlurCheck extends AppTestStep {
   }
 
   async run() {
-      const videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
-      if (!videoBackgroundBlurcheck) {
-        throw new KiteTestError(Status.FAILED, `Video blur failed`);
-      }
-      this.finished("Video blur success");
+    let videoBackgroundBlurcheck; // Result of the verification
+    let i = 0; // iteration indicator
+    let timeout = 10;
+    videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
+    while ((!videoBackgroundBlurcheck) && i < timeout) {
+      videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
+      i++;
+      await TestUtils.waitAround(1000);
+    }
+    if (!videoBackgroundBlurcheck) {
+      throw new KiteTestError(Status.FAILED, `Video blur failed`);
+    }
+    this.finished("Video blur success");
   }
 }
 


### PR DESCRIPTION
**Issue #:**
We're seeing intermittent failures for background blur integration tests on sauce labs.

For some of the failed tests, it looks like once the video is enabled, currently it checks if background blur is working even before the video could actually turn on, and due to this timing issue sometimes test fails too soon. 

**Description of changes:**

To avoid this issue, 
- After enabling video and background blur, I added a check to see if local video is turned on
- Once video is on, we'll then continuously check if background is blurred for a maximum of ten times(with 1s wait period).

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, 
1. Add a sample test video with name `test_video`under integration/js folder 
2. Modify directory value in [config file](https://github.com/aws/amazon-chime-sdk-js/blob/master/integration/configs/background_blur_test.config.json#L26) to `"directory":"",`
3. Follow the [steps](https://github.com/aws/amazon-chime-sdk-js/tree/master/integration/js#readme) to run integration test locally. 

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

