### PR TITLE
Fix Background Blur integration test

### DIFF
--- a/integration/js/BackgroundBlurTest.js
+++ b/integration/js/BackgroundBlurTest.js
@@ -22,6 +22,7 @@ class BackgroundBlurTest extends SdkBaseTest {
     await test_window_2.runCommands(async () => await SdkTestUtils.addUserToMeeting(this, remote_attendee_id, session));
     await test_window_1.runCommands(async () => await ClickVideoButton.executeStep(this, session));
     await test_window_1.runCommands(async () => await ClickBackgroundBlurButton.executeStep(this, session));
+    await test_window_1.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
     await test_window_1.runCommands(async () => await VideoBackgroundBlurCheck.executeStep(this, session, attendee_id));
     await test_window_2.runCommands(async () => await VideoBackgroundBlurCheck.executeStep(this, session, attendee_id));
     await test_window_2.runCommands(async () => await RemoteVideoCheck.executeStep(this, session, 'VIDEO_ON'));   

--- a/integration/js/checks/VideoBackgroundBlurCheck.js
+++ b/integration/js/checks/VideoBackgroundBlurCheck.js
@@ -1,5 +1,5 @@
 const AppTestStep = require('../utils/AppTestStep');
-const {KiteTestError, Status} = require('kite-common');
+const { KiteTestError, Status, TestUtils } = require('kite-common');
 
 class VideoBackgroundBlurCheck extends AppTestStep {
   constructor(kiteBaseTest, sessionInfo, attendeeId) {
@@ -16,11 +16,19 @@ class VideoBackgroundBlurCheck extends AppTestStep {
   }
 
   async run() {
-      const videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
-      if (!videoBackgroundBlurcheck) {
-        throw new KiteTestError(Status.FAILED, `Video blur failed`);
-      }
-      this.finished("Video blur success");
+    let videoBackgroundBlurcheck; // Result of the verification
+    let i = 0; // iteration indicator
+    let timeout = 10;
+    videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
+    while ((!videoBackgroundBlurcheck) && i < timeout) {
+      videoBackgroundBlurcheck = await this.page.backgroundBlurCheck(this.attendeeId);
+      i++;
+      await TestUtils.waitAround(1000);
+    }
+    if (!videoBackgroundBlurcheck) {
+      throw new KiteTestError(Status.FAILED, `Video blur failed`);
+    }
+    this.finished("Video blur success");
   }
 }
 

--- a/integration/js/package-lock.json
+++ b/integration/js/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "sdk-integration-tests",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -2612,6 +2612,14 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string.prototype.trimleft": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
@@ -2628,14 +2636,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "tmp": {
@@ -2722,7 +2722,8 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.22",


### PR DESCRIPTION
**Issue #:**
We're seeing intermittent failures for background blur integration tests on sauce labs.

For some of the failed tests, it looks like once the video is enabled, currently it checks if background blur is working even before the video could actually turn on, and due to this timing issue sometimes test fails too soon. 

**Description of changes:**

To avoid this issue, 
- After enabling video and background blur, I added a check to see if local video is turned on
- Once video is on, we'll then continuously check if background is blurred for a maximum of ten times(with 1s wait period).

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, 
1. Add a sample test video with name `test_video`under integration/js folder 
2. Modify directory value in [config file](https://github.com/aws/amazon-chime-sdk-js/blob/master/integration/configs/background_blur_test.config.json#L26) to `"directory":"",`
3. Follow the [steps](https://github.com/aws/amazon-chime-sdk-js/tree/master/integration/js#readme) to run integration test locally. 

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
