### PR TITLE
Add delay and use meeting leave over end in event reporting test

### DIFF
--- a/integration/js/EventReportingTest.js
+++ b/integration/js/EventReportingTest.js
@@ -1,4 +1,4 @@
-const {OpenAppStep, JoinMeetingStep, AuthenticateUserStep, EndMeetingStep} = require('./steps');
+const {OpenAppStep, JoinMeetingStep, AuthenticateUserStep, LeaveMeetingStep} = require('./steps');
 const {UserJoinedMeetingCheck, UserAuthenticationCheck, RosterCheck} = require('./checks');
 const {TestUtils} = require('./node_modules/kite-common');
 const SdkBaseTest = require('./utils/SdkBaseTest');
@@ -8,7 +8,7 @@ const { v4: uuidv4 } = require('uuid');
 * 1. Starts a meeting with event reporting enabled.
 * 2. Adds participants to the meeting.
 * 3. Check if user joined correctly.
-* 4. End meeting.
+* 4. Leave meeting.
 * */
 class EventReportingTest extends SdkBaseTest {
   constructor(name, kiteConfig) {
@@ -24,7 +24,8 @@ class EventReportingTest extends SdkBaseTest {
     await JoinMeetingStep.executeStep(this, session);
     await UserJoinedMeetingCheck.executeStep(this, session, attendee_id);
     await RosterCheck.executeStep(this, session, 1);
-    await EndMeetingStep.executeStep(this, session);
+    await TestUtils.waitAround(5000);
+    await LeaveMeetingStep.executeStep(this, session);
     await this.waitAllSteps();
   }
 }


### PR DESCRIPTION
**Issue #:**
Some event ingestion integration test runs might result into 403s:
1. I am using EndMeetingStep instead of LeaveMeetingStep. When a meeting is ended the ingestion service invalidates the authorization token cache and hence any request reaching after this invalidation will result into a 403.
2. The join and the roster check often completes very quickly in max 3-4s seconds and soon the End meeting step is triggered. Now according to logic for event ingestion from client side, we send the collected events at an interval of 5s by default. Thus, this explains why the request may have not got triggered and the test ends soon with also ending the meeting.
3. The end meeting will move away from the meeting screen so this should also still send the POST request using sendBeacon but since the authorization token itself may have been invalidated those request might result in 403.

**Description of changes:**
To address this I am making below changes to the existing test:
1. Use LeaveMeeting over EndMeeting step.
2. Add a delay of 5s before leaving the meeting.

**Testing:**
- Tested few runs on SauceLabs from local and checked on the ingestion service backend logs if events are appeared fine. Received all events as expected.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA, integration test change.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

