### PR TITLE
[Demo] Fix the demo to display thunderbolt when paused by policy

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -3149,14 +3149,12 @@ export class DemoMeetingApp
 
   tileWillBePausedByDownlinkPolicy(tileId: number): void {
     this.log(`Tile ${tileId} will be paused due to insufficient bandwidth`);
-    const attendeeId = this.audioVideo.getVideoTile(tileId)?.state().boundAttendeeId;
-    this.roster[attendeeId].bandwidthConstrained = true;
+    this.videoTileCollection.bandwidthConstrainedTiles.add(tileId);
   }
 
   tileWillBeUnpausedByDownlinkPolicy(tileId: number): void {
     this.log(`Tile ${tileId} will be resumed due to sufficient bandwidth`);
-    const attendeeId = this.audioVideo.getVideoTile(tileId)?.state().boundAttendeeId;
-    this.roster[attendeeId].bandwidthConstrained = false;
+    this.videoTileCollection.bandwidthConstrainedTiles.delete(tileId);
   }
 }
 

--- a/demos/browser/app/meetingV2/video/VideoTileCollection.ts
+++ b/demos/browser/app/meetingV2/video/VideoTileCollection.ts
@@ -103,6 +103,8 @@ export default class VideoTileCollection implements AudioVideoObserver {
   tileArea = document.getElementById('tile-area') as HTMLDivElement;
   tileIndexToDemoVideoTile = new Map<number, DemoVideoTile>();
 
+  bandwidthConstrainedTiles = new Set<number>();
+
   _activeSpeakerAttendeeId = "";
   public set activeSpeakerAttendeeId(id: string) {
     this.logger.info(`setting act spk to ${id}`)
@@ -110,7 +112,7 @@ export default class VideoTileCollection implements AudioVideoObserver {
     this.layoutFeaturedTile();
   }
 
-  constructor(private videoTileController: VideoTileControllerFacade, 
+  constructor(private videoTileController: VideoTileControllerFacade,
     private logger: Logger,
     private videoPreferenceManager?: VideoPreferenceManager) {
     this.setupVideoTiles();
@@ -159,6 +161,11 @@ export default class VideoTileCollection implements AudioVideoObserver {
     this.tileIdToAttendeeId[tileState.tileId] = tileState.boundAttendeeId;
     if (tileState.boundExternalUserId) {
       demoVideoTile.nameplate = tileState.boundExternalUserId.split('#').slice(-1)[0];
+    }
+    if (tileState.paused && this.bandwidthConstrainedTiles.has(tileState.tileId)) {
+      demoVideoTile.pauseState = '⚡';
+    } else {
+      demoVideoTile.pauseState = '';
     }
     demoVideoTile.attendeeId = tileState.boundAttendeeId;
     demoVideoTile.show(tileState.isContent);


### PR DESCRIPTION
**Description of changes:**
Fix the current demo to display thunderbolt sign when video tiles are paused by priority downlink policy.
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Join a meeting with priority-based downlink policy with several videos
- Use Network link conditioner to throttle the network
- Verify that you can see the thunderbolt sign

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

