### PR TITLE
Update CODEOWNERS with newly created dev team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # amazon-chime-sdk-js repo.
 # Check below link for more information:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @aws/amazon-chime-sdk
+* @aws/amazon-chime-sdk-js-dev


### PR DESCRIPTION
**Issue #:**
- Restrict the GitHub PR review notifications to just the JS SDK Dev team.

**Description of changes:**
- Update CODEOWNERS with newly created dev team: https://github.com/orgs/aws/teams/amazon-chime-sdk-js-dev/members

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

