### PR TITLE
Update saucelabs pre-run script ID

### DIFF
--- a/.github/workflows/background-blur-integration.yml
+++ b/.github/workflows/background-blur-integration.yml
@@ -1,0 +1,79 @@
+  name: Background Blur Integration Workflow
+
+  on:
+    pull_request:
+      branches:
+        - master
+        - release-1.x
+
+  env:
+    SELENIUM_GRID_PROVIDER: saucelabs
+    CLOUD_WATCH_METRIC: false
+    TEST_TYPE: Github-Action
+    SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
+    SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+
+  jobs:
+    integ-background-blur:
+      name: Background Blur Integration Test
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout Package
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Pack the Chime SDK and install the tarball into the Demo
+          run: |
+            current_version=$(.github/script/get-current-version)
+            echo "Packing current version:" $current_version
+            npm run build
+            npm pack
+            cd demos/browser
+            npm uninstall amazon-chime-sdk-js
+            npm install ../../amazon-chime-sdk-js-$current_version.tgz
+        - name: Check if needed to run
+          id: test_needed
+          run: |
+            source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
+            check_if_integ_tests_required
+            echo ::set-output name=integ_test_required::$requires_integration_test
+        - name: Create a Job ID
+          id: create-job-id
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c
+        - name: Set JOB_ID Env Variable
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          run: echo "JOB_ID=${{ steps.create-job-id.outputs.uuid }}" >> $GITHUB_ENV
+        - name: Echo Job ID
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          run: echo "${{ steps.create-job-id.outputs.uuid }}"
+        - name: Configure AWS Credentials
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: us-east-1
+        - name: Setup Sauce Connect
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          uses: saucelabs/sauce-connect-action@v1
+          with:
+            username: ${{ secrets.SAUCE_USERNAME }}
+            accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+            noSSLBumpDomains: all
+            tunnelIdentifier: ${{ steps.create-job-id.outputs.uuid }}
+        - name: Setup Node.js - 14.x
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          uses: actions/setup-node@v1
+          with:
+            node-version: 14.x
+        - name: Install Kite
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          run: integration/js/script/install-kite
+        - name: Clean Install
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          run: npm ci
+        - name: Run Background Blur Integration Test
+          if:  steps.test_needed.outputs.integ_test_required == 'true'
+          run: npm run test:integration-background-blur

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -101,7 +101,7 @@ const fetchMediaPath = function(media, browserName) {
 }
 
 const getPrerunScript = (capabilities) =>{
-  return capabilities.name.includes("Background Blur Test") ? 'storage:cf5a00cc-2a0d-40bb-9f2e-f721f2eec1f4' : "";
+  return capabilities.name.includes("Background Blur Test") ? 'storage:b23b0bb6-8e47-4e90-80e8-fc2cb92408bf' : "";
 }
 const getChromeCapabilities = capabilities => {
   let cap = Capabilities.chrome();


### PR DESCRIPTION
**Issue #:**
The old saucelabs pre-run script used by background blur integration tests had expired. 

**Description of changes:**
Replace the old script ID with the ID of the newly uploaded script.
Add background blur github workflow.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes,

1. Deploy the application using the following [steps](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless).

2. Replace the url in the [config file](https://github.com/aws/amazon-chime-sdk-js/blob/master/integration/configs/background_blur_test.config.json#L13) with the url of the deployed demo application.

3. Follow these [steps](https://github.com/aws/amazon-chime-sdk-js/tree/master/integration/js#readme) to run the integration tests on saucelabs.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
