### PR TITLE
Make tileWillBePausedByDownlinkPolicy synchronous and remove setTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix priority downlink policy bandwidth estimation metrics to work with Safari.
 - Add a workaround to switch to VP8 for iOS 15.1 due to [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=232416) that causes crash with H.264 encoding. 
+- Make `tileWillBePausedByDownlinkPolicy` observer update synchronous without `setTimeout`.
 
 ### Changed
 

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L426">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L422">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:422</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceivestreams">calculateOptimalReceiveStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L288">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L284">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setvideoprioritybasedpolicyconfigs">setVideoPriorityBasedPolicyConfigs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L258">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L254">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L426">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L422">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:422</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L288">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L284">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:284</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -458,7 +458,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L258">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:258</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/master/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L254">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:254</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -247,11 +247,7 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
 
   forEachObserver(observerFunc: (observer: VideoDownlinkObserver) => void): void {
     for (const observer of this.observerQueue) {
-      setTimeout(() => {
-        if (this.observerQueue.has(observer)) {
-          observerFunc(observer);
-        }
-      }, 0);
+      observerFunc(observer);
     }
   }
 


### PR DESCRIPTION
**Issue #:**
#1790 

**Description of changes:**
- Make `tileWillBePausedByDownlinkPolicy` observer update synchronous without `setTimeout`

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Yes using the meetingV2 demo.
1. Open the meeting in Chrome
2. Joined the same meeting with 6 attendees.
3. Added logs under `pause` and `unpause` APIs on the `DefaultVideoTileController` and observed the logs.
4. Started video for all attendees and on one of the local attendee observed the logs.
5. Checked the "will be paused/unpaused observers" are triggered synchronously and then the actual "pause/un-pause VideoTile" API is triggered.

Output from my test:
```
[DEMO] Tile 2 will be paused due to insufficient bandwidth
VM18:2 2021-11-18T16:55:40.078Z [INFO] SDK - bwe: unpausing attendee c2b19aaa-865f-5e10-a8af-a84ffeb883ec due to bandwidth
VM18:2 [DEMO] Tile 2 will be resumed due to sufficient bandwidth
VM18:2 due to 2 tile.unpause() called in DefaultVideoTileController
VM18:2 [DEMO] Tile 3 will be paused due to insufficient bandwidth
VM18:2 2021-11-18T16:55:43.858Z [INFO] SDK - bwe: unpausing attendee ad423fd4-c77f-6a2d-3e40-aeb1020a158b due to bandwidth
VM18:2 [DEMO] Tile 3 will be resumed due to sufficient bandwidth
VM18:2 due to 3 tile.unpause() called in DefaultVideoTileController
VM18:2 [DEMO] Tile 4 will be paused due to insufficient bandwidth
VM18:2 [DEMO] Tile 6 will be paused due to insufficient bandwidth
VM18:2 2021-11-18T16:55:48.232Z [INFO] SDK - bwe: unpausing attendee ef3560bb-1ee9-6254-55f6-1bed3ba985e8 due to bandwidth
VM18:2 [DEMO] Tile 6 will be resumed due to sufficient bandwidth
VM18:2 due to 6 tile.unpause() called in DefaultVideoTileController
VM18:2 2021-11-18T16:59:36.151Z [INFO] SDK - bwe: pausing streamId 13 attendee d1bfedd7-5a48-e56c-02b9-761cc752ef94 due to bandwidth
VM18:2 [DEMO] Tile 5 will be paused due to insufficient bandwidth
VM18:2 due to 5 tile.pause() called in DefaultVideoTileController
VM18:2 2021-11-18T16:59:36.152Z [INFO] SDK - bwe: pausing streamId 18 attendee ef3560bb-1ee9-6254-55f6-1bed3ba985e8 due to bandwidth
VM18:2 [DEMO] Tile 6 will be paused due to insufficient bandwidth
VM18:2 due to 6 tile.pause() called in DefaultVideoTileController
VM18:2 2021-11-18T16:59:43.163Z [INFO] SDK - bwe: unpausing attendee d1bfedd7-5a48-e56c-02b9-761cc752ef94 due to bandwidth
VM18:2 [DEMO] Tile 5 will be resumed due to sufficient bandwidth
VM18:2 due to 5 tile.unpause() called in DefaultVideoTileController
VM18:2 2021-11-18T16:59:43.165Z [INFO] SDK - bwe: unpausing attendee ef3560bb-1ee9-6254-55f6-1bed3ba985e8 due to bandwidth
VM18:2 [DEMO] Tile 6 will be resumed due to sufficient bandwidth
VM18:2 due to 6 tile.unpause() called in DefaultVideoTileController
```

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

