### PR TITLE
Fixing mobile sdk canary failure

### DIFF
--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -145,7 +145,10 @@ function serve(host = '127.0.0.1:8080') {
         const languageCode = requestUrl.query.language;
         const region = requestUrl.query.region;
         let transcriptionConfiguration = {};
-        const transcriptionStreamParams = JSON.parse(requestUrl.query.transcriptionStreamParams);
+        let transcriptionStreamParams = {};
+        if (requestUrl.query.transcriptionStreamParams){
+          transcriptionStreamParams = JSON.parse(requestUrl.query.transcriptionStreamParams);
+        } 
         const contentIdentification = requestUrl.query.contentIdentification;
         const piiEntityTypes = requestUrl.query.piiEntityTypes;
         if (requestUrl.query.engine === 'transcribe') {

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -111,7 +111,10 @@ exports.start_transcription = async (event, context) => {
   const languageCode = event.queryStringParameters.language;
   const region = event.queryStringParameters.region;
   let transcriptionConfiguration = {};
-  const transcriptionStreamParams = JSON.parse(event.queryStringParameters.transcriptionStreamParams);
+  let transcriptionStreamParams = {};
+  if (event.queryStringParameters.transcriptionStreamParams) {
+    transcriptionStreamParams = JSON.parse(event.queryStringParameters.transcriptionStreamParams);
+  }
   if (event.queryStringParameters.engine === 'transcribe') {
     transcriptionConfiguration = {
       EngineTranscribeSettings: {


### PR DESCRIPTION
**Issue #:**
Mobile-SDK and JS-SDK demo apps share same chime endpoint to start Live Transcription. The introduction of new parameters on js sdk demo app serverless deployment is changing the endpoint defintions which is making mobile-sdk canaries to fail. This fail is due to the additional parameters being mandatory instead of optional in handle.js file of demo app. 

So when JS-SDK is starting Live Transcription, it is running fine because the JS-SDK demo app passes the parameters that the endpoint needs. But the mobile-sdk fails since they don't know about the new parameters. 

This change makes the new parameters introduced to be optional, so that mobile-sdk canaries can call them without explicitly adding new parameters to their code.

**Description of changes:**
Handled the scenario when mobile-sdk/js-sdk demo app is not sending the new parameters.
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

