### PR TITLE
Add error name for custom device controller error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add error name for custom device controller error.
+
+### Removed
+
+### Fixed
+
+### Changed
+
 ## [2.23.0] - 2021-11-22
 ### Added
 - Add support for Echo Reduction when using Voice Focus.

--- a/src/devicecontroller/GetUserMediaError.ts
+++ b/src/devicecontroller/GetUserMediaError.ts
@@ -4,5 +4,6 @@
 export default class GetUserMediaError extends Error {
   constructor(public cause?: Error, message?: string) {
     super(message || 'Error fetching device.');
+    this.name = 'GetUserMediaError';
   }
 }

--- a/src/devicecontroller/NotFoundError.ts
+++ b/src/devicecontroller/NotFoundError.ts
@@ -6,5 +6,6 @@ import GetUserMediaError from './GetUserMediaError';
 export default class NotFoundError extends GetUserMediaError {
   constructor(cause?: Error) {
     super(cause);
+    this.name = 'NotFoundError';
   }
 }

--- a/src/devicecontroller/NotReadableError.ts
+++ b/src/devicecontroller/NotReadableError.ts
@@ -6,5 +6,6 @@ import GetUserMediaError from './GetUserMediaError';
 export default class NotReadableError extends GetUserMediaError {
   constructor(cause?: Error) {
     super(cause);
+    this.name = 'NotReadableError';
   }
 }

--- a/src/devicecontroller/OverconstrainedError.ts
+++ b/src/devicecontroller/OverconstrainedError.ts
@@ -6,5 +6,6 @@ import GetUserMediaError from './GetUserMediaError';
 export default class OverconstrainedError extends GetUserMediaError {
   constructor(cause?: Error, public constraint?: string) {
     super(cause);
+    this.name = 'OverconstrainedError';
   }
 }

--- a/src/devicecontroller/PermissionDeniedError.ts
+++ b/src/devicecontroller/PermissionDeniedError.ts
@@ -6,5 +6,6 @@ import GetUserMediaError from './GetUserMediaError';
 export default class PermissionDeniedError extends GetUserMediaError {
   constructor(cause?: Error, message?: string) {
     super(cause, message);
+    this.name = 'PermissionDeniedError';
   }
 }

--- a/src/devicecontroller/TypeError.ts
+++ b/src/devicecontroller/TypeError.ts
@@ -6,5 +6,6 @@ import GetUserMediaError from './GetUserMediaError';
 export default class TypeError extends GetUserMediaError {
   constructor(cause?: Error) {
     super(cause);
+    this.name = 'TypeError';
   }
 }

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -1303,6 +1303,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(NotReadableError);
+        expect(e.name).to.be.equal('NotReadableError');
       }
     });
 
@@ -1315,6 +1316,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(NotReadableError);
+        expect(e.name).to.be.equal('NotReadableError');
       }
     });
 
@@ -1327,6 +1329,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(NotFoundError);
+        expect(e.name).to.be.equal('NotFoundError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1340,6 +1343,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(NotFoundError);
+        expect(e.name).to.be.equal('NotFoundError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1353,6 +1357,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(NotReadableError);
+        expect(e.name).to.be.equal('NotReadableError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1366,6 +1371,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(OverconstrainedError);
+        expect(e.name).to.be.equal('OverconstrainedError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1379,6 +1385,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(OverconstrainedError);
+        expect(e.name).to.be.equal('OverconstrainedError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1392,6 +1399,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(TypeError);
+        expect(e.name).to.be.equal('TypeError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1405,6 +1413,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(GetUserMediaError);
+        expect(e.name).to.be.equal('GetUserMediaError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1417,6 +1426,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(GetUserMediaError);
+        expect(e.name).to.be.equal('GetUserMediaError');
         expect(e.message).to.not.equal('This line should not be reached');
       }
     });
@@ -1429,6 +1439,7 @@ describe('DefaultDeviceController', () => {
         throw new Error('This line should not be reached');
       } catch (e) {
         expect(e).to.be.instanceof(GetUserMediaError);
+        expect(e.name).to.be.equal('GetUserMediaError');
         expect(e.message).to.include('Error fetching device.');
       }
     });


### PR DESCRIPTION
**Issue #1804:**

**Description of changes:**
We have several custom error for `GetUserMedia` but we did not set the name property so they all have the generic "Error" property.

**Testing:**
Unit test
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Open a meeting and deny the browser permission
- Click Continue and verify that the error name is `Type Error`

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

