### PR TITLE
Remove auto-check functionality for Echo Reduction.

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -571,10 +571,6 @@ export class DemoMeetingApp
       this.enableWebAudio = (document.getElementById('webaudio') as HTMLInputElement).checked;
       this.usePriorityBasedDownlinkPolicy = (document.getElementById('priority-downlink-policy') as HTMLInputElement).checked;
       this.echoReductionCapability = (document.getElementById('echo-reduction-capability') as HTMLInputElement).checked;
-      if (this.echoReductionCapability) {
-        (document.getElementById('add-voice-focus') as HTMLInputElement).checked = true;
-        this.enableVoiceFocus = (document.getElementById('add-voice-focus') as HTMLInputElement).checked;
-      }
 
       const chosenLogLevel = (document.getElementById('logLevelSelect') as HTMLSelectElement).value;
       switch (chosenLogLevel) {

--- a/docs/modules/amazonvoice_focus.html
+++ b/docs/modules/amazonvoice_focus.html
@@ -84,6 +84,7 @@
 					</a>
 					<p>Echo reduction helps keep echoes—sounds from a user’s loudspeaker that get picked up by their microphone—from circulating back into meeting audio and bringing discussions to a standstill. The echo reduction feature is available in conjunction with the noise reduction provided by Amazon Voice Focus.</p>
 					<p>Echo reduction is enabled at the meeting level when you call the CreateMeeting or CreateMeetingWithAttendees APIs. Enabling the feature this way allows others who join the meeting to enable echo reduction as desired.</p>
+					<p>The feature is integrated into the <code>browser</code> demo application. To try it out, launch the demo with <code>npm run start</code>, choose “Web Audio” and “Use Echo Reduction (new meetings only)” on the first screen, then either check the “Voice Focus” box in the lobby view, or click “Voice Focus” in the device picker after joining the meeting.</p>
 					<p>Amazon Chime Echo Reduction is a premium feature, please refer to the <a href="https://aws.amazon.com/chime/pricing/#Chime_SDK_">Pricing</a> page for details.</p>
 					<a href="#amazon-voice-focus-on-the-web" id="amazon-voice-focus-on-the-web" style="color: inherit; text-decoration: none;">
 						<h2>Amazon Voice Focus on the web</h2>

--- a/guides/09_Amazon_Voice_Focus.md
+++ b/guides/09_Amazon_Voice_Focus.md
@@ -14,6 +14,8 @@ Echo reduction helps keep echoes—sounds from a user’s loudspeaker that get p
 
 Echo reduction is enabled at the meeting level when you call the CreateMeeting or CreateMeetingWithAttendees APIs. Enabling the feature this way allows others who join the meeting to enable echo reduction as desired.
 
+The feature is integrated into the `browser` demo application. To try it out, launch the demo with `npm run start`, choose “Web Audio” and “Use Echo Reduction (new meetings only)” on the first screen, then either check the “Voice Focus” box in the lobby view, or click “Voice Focus” in the device picker after joining the meeting.
+
 Amazon Chime Echo Reduction is a premium feature, please refer to the [Pricing](https://aws.amazon.com/chime/pricing/#Chime_SDK_) page for details.
 
 ## Amazon Voice Focus on the web


### PR DESCRIPTION
**Issue #:** 

**Description of changes:** 
Removes the auto-check functionality when creating meetings with Echo Reduction enabled by default.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Create a meeting in the demo app
2. Enable Echo Reduction
3. Enable Voice Focus
4. Join the meeting

Observe that the roster is working and audio is captured.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

