### PR TITLE
Added support for non-audio and non-video IOS tests

### DIFF
--- a/integration/js/pages/TestAppPage.js
+++ b/integration/js/pages/TestAppPage.js
@@ -89,7 +89,7 @@ class TestAppPage {
     await joinMeetingButton.click();
   }
 
-  async waitForAuthentication() {
+  async waitForDeviceFlow() {
     await TestUtils.waitAround(5000);
   }
 

--- a/integration/js/steps/AuthenticateUserStep.js
+++ b/integration/js/steps/AuthenticateUserStep.js
@@ -69,7 +69,7 @@ class AuthenticateUserStep extends AppTestStep {
     }
     await this.page.authenticate();
     this.logger("waiting to authenticate");
-    let authenticationState = await this.page.waitForAuthentication();
+    let authenticationState = await this.page.waitForDeviceFlow();
     if (authenticationState === 'failed') {
       throw new KiteTestError(Status.FAILED, 'Authentication timeout');
     }

--- a/integration/js/steps/JoinVideoTestMeetingStep.js
+++ b/integration/js/steps/JoinVideoTestMeetingStep.js
@@ -36,7 +36,7 @@ class JoinVideoTestMeetingStep extends AppTestStep {
     await this.page.enterMeetingTitle(this.meeting_title);
     this.logger("waiting to authenticate");
     this.test.numRemoteJoined =  this.numberOfParticipant ;
-    let authenticationState = await this.page.waitForAuthentication();
+    let authenticationState = await this.page.waitForDeviceFlow();
     if (authenticationState === 'failed') {
       throw new KiteTestError(Status.FAILED, 'Authentication timeout');
     }

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -147,6 +147,7 @@ const getSafariIOSConfig = (capabilities) => {
     platformName: capabilities.platform,
     platformVersion: capabilities.version,
     deviceOrientation: 'portrait',
+    autoAcceptAlerts: "true",
     name: capabilities.name,
   };
 };


### PR DESCRIPTION
**Issue #:**
We have no IOS support with our integration tests.
**Description of changes:**
Added support for non-audio and non-video IOS tests. More changes are needed for other tests.
**Testing:**
Ran Data Message and Meeting End Tests on IOS 14.7/15, Android Chrome, FireFox Latest, and Chrome Latest
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.* No


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

