### PR TITLE
Add default value for DeletionPolicy and UpdateReplacePolicy explicitly

### DIFF
--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -399,10 +399,16 @@ Resources:
         - Ref: MeetingNotificationsQueue
   ChimeBrowserLogs:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
   ChimeBrowserMeetingEventLogs:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
   ChimeBrowserEventIngestionLogs:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
   ChimeSdkBrowserMeetingEventDashboard:
     Type: AWS::CloudWatch::Dashboard
     Properties:


### PR DESCRIPTION
**Issue #:**
- This is to fix non-compliant rules in AWS Config for the meetingV2 and
meetingReadinessChecker AWS Config rules in respective deployed accounts.

**Description of changes:**
- The AWS config rules have pointed to add the DeletionPolicy and UpdateReplacePolicy explicitly on the resources due to recent AWS failures.
- Since ours is just demo I am adding default values explicitly.
- I added: "Delete" as the value, other options are "Retain" and "Snapshot" where applicable.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Tested by deploying the meetingV2 demo app.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Not required.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

