### PR TITLE
Update NScale uplink initial encoder params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed updates to mutable state during subscribe leading to non-existant/frozen video streams.
+- Fixed inconsistent default maxBitrate values in the NScaleVideoUplinkBandwithPolicy constructor leading to the default ideal max bitrate not being honored.
 
 ### Changed
 - Clarified comment in `DefaultSimulcastUplinkPolicy`.

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -60,8 +60,7 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
     this.optimalParameters = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
     this.parametersInEffect = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
     this.encodingParamMap.set(NScaleVideoUplinkBandwidthPolicy.encodingMapKey, {
-      scaleResolutionDownBy: 1,
-      maxBitrate: this.idealMaxBandwidthKbps * 1000,
+      maxBitrate: 0,
     });
   }
 

--- a/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
+++ b/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
@@ -701,7 +701,30 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       expect(spy.calledOnce).to.be.true;
       spy.restore();
     });
-
+    it('Ensure setEncodingParameters is called to initially set the max bitrate', () => {
+      // use a new policy to ensure it's using the default values
+      policy = new NScaleVideoUplinkBandwidthPolicy(selfAttendeeId, true, new NoOpLogger());
+      policy.setTransceiverController(transceiverController);
+      const index = new DefaultVideoStreamIndex(logger);
+      const spy = sinon.spy(TestTransceiverController.prototype, 'setEncodingParameters');
+      index.integrateIndexFrame(
+        new SdkIndexFrame({
+          sources: [
+            new SdkStreamDescriptor({
+              streamId: 2,
+              groupId: 1,
+              maxBitrateKbps: 1400,
+              attendeeId: 'xy1',
+              mediaType: SdkStreamMediaType.VIDEO,
+            }),
+          ],
+        })
+      );
+      policy.updateIndex(index);
+      policy.updateTransceiverController();
+      expect(spy.calledOnce).to.be.true;
+      spy.restore();
+    });
     it('Return early if there is no transceiver controller', () => {
       const index = new DefaultVideoStreamIndex(logger);
       const spy = sinon.spy(TestTransceiverController.prototype, 'setEncodingParameters');


### PR DESCRIPTION
**Issue #:** No Issue

**Description of changes:**
While testing I found the default uplink bitrate was exceeding the default max bitrate for the stream when using the NScaleVideoUplinkBandwidthPolicy. While monitoring the calls to RTCRtpSender.setParameters I noticed they weren't being set initially.

A mismatch in the constructor seems to be the root cause. the optimalParameters value has a max bitrate of 0 but the encodingParamMap has a maxBitrate of 1400 (the default of idealMaxBandwidthKbps).

```
constructor(
    private selfAttendeeId: string,
    private scaleResolution: boolean = true,
    private logger: Logger | undefined = undefined
  ) {
    this.optimalParameters = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
    this.parametersInEffect = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
    this.encodingParamMap.set(NScaleVideoUplinkBandwidthPolicy.encodingMapKey, {
      scaleResolutionDownBy: 1,
      maxBitrate: this.idealMaxBandwidthKbps * 1000,
    });
  }
```

When the initial update for the stream was received, no call was made to WebRTC since the uplink policy believed it was no changes have been made.

```
NScaleVideoUplinkBandwidthPolicy.ts:172

  this.encodingParamMap.set(NScaleVideoUplinkBandwidthPolicy.encodingMapKey, {
    scaleResolutionDownBy: 1,
    maxBitrate: this.idealMaxBandwidthKbps * 1000,
  });
```

This update changes the constructor to bring the bitrate values in optimalParamsters and encodingParamMap into alignment.

**Testing:**

I verified the change brought the externally measured uplink bitrate to the expected 1400kbps. I then added a unit test to ensure setEncodingParameters is called on the first update when the default ideal bitrate is used.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

1. Create a client that never sets a new ideal bitrate using `NScaleVideoUplinkBandwidth.setIdealMaxBandwidthKbps'
2. Send only video from the client and monitor the output bitrate of the client (I used WireShark)
3. The bitrate was over the default ideal max bitrate of 1400kbps

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

