### PR TITLE
Fixing Deploy-Canary-Demo Script to deploy to non us-east-1 regions

### DIFF
--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -259,7 +259,7 @@ spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--sta
                     '--parameter-overrides', parameterOverrides,
                     '--capabilities', 'CAPABILITY_IAM', '--region', `${region}`, '--no-fail-on-empty-changeset'], null, !disablePrintingLogs);
 if (enableTerminationProtection) {
-  spawnOrFail('aws', ['cloudformation', 'update-termination-protection', '--enable-termination-protection', '--stack-name', `${stack}`], null, false);
+  spawnOrFail('aws', ['cloudformation', 'update-termination-protection', '--enable-termination-protection', '--stack-name', `${stack}`, '--region', `${region}`], null, false);
 }
 if (!disablePrintingLogs) {
   console.log('Amazon Chime SDK Meeting Demo URL: ');

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -22,10 +22,10 @@ npm run deploy -- -b chime-sdk-demo-gamma-canary -s chime-sdk-demo-gamma-canary 
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary -s chime-sdk-meeting-readiness-checker-gamma-canary -a meetingReadinessChecker -u false -t -l
 
 # Uses ChimeSDKMeetings client
-npm run deploy -- -r us-east-1 -b chime-sdk-demo-gamma-canary-us-east-1 -s chime-sdk-demo-gamma-canary-us-east-1 -o chime-sdk-demo-gamma-canary-us-east-1 -t -l
-npm run deploy -- -r us-west-2 -b chime-sdk-demo-gamma-canary-us-west-2 -s chime-sdk-demo-gamma-canary-us-west-2 -o chime-sdk-demo-gamma-canary-us-west-2 -t -l
-npm run deploy -- -r eu-central-1 -b chime-sdk-demo-gamma-canary-eu-central-1 -s chime-sdk-demo-gamma-canary-eu-central-1 -o chime-sdk-demo-gamma-canary-eu-central-1 -t -l
-npm run deploy -- -r ap-southeast-1 -b chime-sdk-demo-gamma-canary-ap-southeast-1 -s chime-sdk-demo-gamma-canary-ap-southeast-1 -o chime-sdk-demo-gamma-canary-ap-southeast-1 -t -l
+npm run deploy -- -r us-east-1 -b chime-sdk-meetings-demo-gamma-canary-us-east-1 -s chime-sdk-meetings-demo-gamma-canary-us-east-1 -t -l
+npm run deploy -- -r us-west-2 -b chime-sdk-meetings-demo-gamma-canary-us-west-2 -s chime-sdk-meetings-demo-gamma-canary-us-west-2 -t -l
+npm run deploy -- -r eu-central-1 -b chime-sdk-meetings-demo-gamma-canary-eu-central-1 -s chime-sdk-meetings-demo-gamma-canary-eu-central-1 -t -l
+npm run deploy -- -r ap-southeast-1 -b chime-sdk-meetings-demo-gamma-canary-ap-southeast-1 -s chime-sdk-meetings-demo-gamma-canary-ap-southeast-1 -t -l
 
 
 
@@ -38,7 +38,7 @@ npm run deploy -- -b chime-sdk-demo-beta-canary -s chime-sdk-demo-beta-canary -o
 npm run deploy -- -b chime-sdk-meeting-readiness-checker-beta-canary -s chime-sdk-meeting-readiness-checker-beta-canary -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -u false -t -l
 
 # Uses ChimeSDKMeetings client
-npm run deploy -- -r us-east-1 -b chime-sdk-demo-beta-canary-us-east-1 -s chime-sdk-demo-beta-canary-us-east-1 -o chime-sdk-demo-beta-canary-us-east-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_US_EAST_1 -t -l
-npm run deploy -- -r eu-central-1 -b chime-sdk-demo-beta-canary-eu-central-1 -s chime-sdk-demo-beta-canary-eu-central-1 -o chime-sdk-demo-beta-canary-eu-central-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1 -t -l
-npm run deploy -- -r ap-southeast-1 -b chime-sdk-demo-beta-canary-ap-southeast-1 -s chime-sdk-demo-beta-canary-ap-southeast-1 -o chime-sdk-demo-beta-canary-ap-southeast-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_AP_SOUTHEAST_1 -t -l
+npm run deploy -- -r us-east-1 -b chime-sdk-meetings-demo-beta-canary-us-east-1 -s chime-sdk-meetings-demo-beta-canary-us-east-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_US_EAST_1 -t -l
+npm run deploy -- -r eu-central-1 -b chime-sdk-meetings-demo-beta-canary-eu-central-1 -s chime-sdk-meetings-demo-beta-canary-eu-central-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1 -t -l
+npm run deploy -- -r ap-southeast-1 -b chime-sdk-meetings-demo-beta-canary-ap-southeast-1 -s chime-sdk-meetings-demo-beta-canary-ap-southeast-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT_AP_SOUTHEAST_1 -t -l
 


### PR DESCRIPTION
**Issue #:**
While Deploying JS SDK serverless demo to regions other than us-east-1 there are two Issues this PR is attempting to resolve:

1) AWS Cloud Formation for enableTerminationProtection was not using region command line parameter to check stack and thus was giving stack not found error. So included region while enableTerminationProtection.

2) While deploying demo using `-o` paramters used for Media Capture we create buckets for all the regions and this was causing the clash in bucket names as we deploying to multiple regions.  

**Description of changes:**
1) Add `--region` in deploy.js while Enabling Termination Protection.
2) Add `meetings` inside bucket names and remove `-o` parameter used for media capture while deploying demos that uses `ChimeSDKMeetings` client  

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Tested by Demploying demos from local 
Steps for Deployment
1) Get AWS Gamma Canary credentials
2) Deploy demo to non us-east-1 region `npm run deploy -- -r us-west-2 -b chime-sdk-meetings-demo-gamma-canary-us-west-2 -s chime-sdk-meetings-demo-gamma-canary-us-west-2 -t -l`

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

