### PR TITLE
Fix type comparison

### DIFF
--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -23,7 +23,7 @@ const indexPage = fs.readFileSync(indexPagePath);
 // Set the AWS SDK Chime endpoint. The Chime endpoint is https://service.chime.aws.amazon.com.
 const endpoint = process.env.ENDPOINT || 'https://service.chime.aws.amazon.com';
 const currentRegion = process.env.REGION || 'us-east-1';
-const useChimeSDKMeetings = process.env.USE_CHIME_SDK_MEETINGS || true;
+const useChimeSDKMeetings = process.env.USE_CHIME_SDK_MEETINGS || 'true';
 
 // Create ans AWS SDK Chime object. Region 'us-east-1' is globally available..
 // Use the MediaRegion property below in CreateMeeting to select the region
@@ -49,7 +49,7 @@ if (captureS3Destination) {
 
 // return Chime Meetings SDK Client just for Echo Reduction for now.
 function getClientForMeeting(meeting) {
-  return (useChimeSDKMeetings || (meeting?.Meeting?.MeetingFeatures?.Audio?.EchoReduction === 'AVAILABLE')) ? chimeSDKMeetings : chime;
+  return ((useChimeSDKMeetings === 'true') || (meeting?.Meeting?.MeetingFeatures?.Audio?.EchoReduction === 'AVAILABLE')) ? chimeSDKMeetings : chime;
 }
 
 function serve(host = '127.0.0.1:8080') {

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -30,7 +30,7 @@ if(endpoint != 'https://service.chime.aws.amazon.com'){
 
 // return chime meetings SDK client just for Echo Reduction for now.
 function getClientForMeeting(meeting) {
-  if(useChimeSDKMeetings){
+  if(useChimeSDKMeetings === 'true'){
     return chimeSDKMeetings;
   }
   if (meeting?.Meeting?.MeetingFeatures?.Audio?.EchoReduction === 'AVAILABLE') {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
`useChimeSDKMeetings` is getting from environment, so it is going to be string
We should compare against string `'true'`.
**Testing:**
Deployed my own instance and confirm that false will not use chime sdk meeting.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

