### PR TITLE
Optional chaining is not supported in Node < v14.

### DIFF
--- a/demos/browser/README.md
+++ b/demos/browser/README.md
@@ -6,7 +6,7 @@ This demo shows how to use the Amazon Chime SDK to build meeting applications fo
 
 To build, test, and run demos from source you will need:
 
-* Node 12 or higher
+* Node 14 or higher
 * npm 6.11 or higher
 
 Ensure you have AWS credentials configured in your `~/.aws` folder for a

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -49,9 +49,14 @@ if (captureS3Destination) {
 
 // return Chime Meetings SDK Client just for Echo Reduction for now.
 function getClientForMeeting(meeting) {
-  return (
-    (useChimeSDKMeetings === 'true') ||
-    (meeting && meeting.Meeting && meeting.Meeting.MeetingFeatures && meeting.Meeting.MeetingFeatures.Audio && meeting.Meeting.MeetingFeatures.Audio.EchoReduction === 'AVAILABLE')) ? chimeSDKMeetings : chime;
+  return useChimeSDKMeetings === "true" ||
+    (meeting &&
+      meeting.Meeting &&
+      meeting.Meeting.MeetingFeatures &&
+      meeting.Meeting.MeetingFeatures.Audio &&
+      meeting.Meeting.MeetingFeatures.Audio.EchoReduction === "AVAILABLE")
+    ? chimeSDKMeetings
+    : chime;
 }
 
 function serve(host = '127.0.0.1:8080') {

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -49,7 +49,9 @@ if (captureS3Destination) {
 
 // return Chime Meetings SDK Client just for Echo Reduction for now.
 function getClientForMeeting(meeting) {
-  return ((useChimeSDKMeetings === 'true') || (meeting?.Meeting?.MeetingFeatures?.Audio?.EchoReduction === 'AVAILABLE')) ? chimeSDKMeetings : chime;
+  return (
+    (useChimeSDKMeetings === 'true') ||
+    (meeting && meeting.Meeting && meeting.Meeting.MeetingFeatures && meeting.Meeting.MeetingFeatures.Audio && meeting.Meeting.MeetingFeatures.Audio.EchoReduction === 'AVAILABLE')) ? chimeSDKMeetings : chime;
 }
 
 function serve(host = '127.0.0.1:8080') {


### PR DESCRIPTION
Hence, fallback to older syntax.

We still support Node 12 in demo README and the JS SDK also has engine field with node12+
support. The GitHub actions test against node 16 hence all passed.

**Issue #:**
#1871 

**Description of changes:**
- Fallback to older syntax with `&&` chaining.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
meetingV2 server.js

1. Regular Github actions checks and integration testing with Echo reduction will test this change.

Steps I took:
1. Joined a meeting with a title "test".
1.1 Sanity check, leave the meeting.
2. Join the same meeting with meeting title "test" and check you are able to join the meeting.
3. Verified the outputs from `server.js` console to see whether the created meeting returns MeetingFeatures using the chimeSDKMeetings client.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Not required since this is a demo server.js local backend change.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

