### PR TITLE
Reset the package.json version from 2.24.0 to 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "2.24.0",
+  "version": "2.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-chime-sdk-js",
-      "version": "2.24.0",
+      "version": "2.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "2.24.0",
+  "version": "2.23.0",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- We accidentally updated the package.json version from 2.23.0 to 2.24.0 and added a 2.24.0 section in CHANGELOG in https://github.com/aws/amazon-chime-sdk-js/pull/1859. We already reverted CHANGELOG in https://github.com/aws/amazon-chime-sdk-js/pull/1879

**Testing:**
N/A

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

