### PR TITLE
Fix metric name for RemoteAudioCheck

### DIFF
--- a/integration/js/checks/RemoteAudioCheck.js
+++ b/integration/js/checks/RemoteAudioCheck.js
@@ -14,11 +14,11 @@ class RemoteAudioCheck extends AppTestStep {
   }
 
   stepDescription() {
-    return 'Check the remote audio';
+    return `Check the remote audio for ${this.checkStereoTones ? 'stereo' : 'mono'} tone`;
   }
 
   metricName() {
-    return `Check the remote audio for ${this.checkStereoTones ? 'stereo' : 'mono'} tone`;
+    return `RemoteAudio${this.testType === 'AUDIO_ON' ? 'Enabled' : 'Disabled'}Check${this.checkStereoTones ? 'Stereo': ''}`
   }
 
   async run() {

--- a/integration/js/steps/PlayRandomToneStep.js
+++ b/integration/js/steps/PlayRandomToneStep.js
@@ -17,7 +17,7 @@ class PlayRandomToneStep extends AppTestStep {
   }
 
   metricName() {
-    return 'PlayRandomToneStep'
+    return `PlayRandomToneStep${this.playStereoTones ? 'Stereo': ''}`
   }
 
   async run() {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Fix metric name for `RemoteAudioCheck`. This was unintentionally changed in https://github.com/aws/amazon-chime-sdk-js/pull/1876

**Testing:**
* Did sanity test for audio integration test. Metric name fix will be verified by canary. 

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N. Integration test fix. 

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

