### PR TITLE
Add new release script

### DIFF
--- a/.github/script/get-pre-release-name.js
+++ b/.github/script/get-pre-release-name.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const version = require('../../package.json').version;
+const preRelease = version.split('-');
+if (preRelease[1]) {
+  console.log(preRelease[1].split('.')[0]);
+} else {
+  console.log('');
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,19 @@ jobs:
         run: npm install
       - name: NPM run build
         run: npm run build
-      - name: Publish to NPM
+      - name: Get npm tag name if needed
+        id: npm_tag
+        run: |
+          pre_release_name=$(.github/script/get-pre-release-name.js)
+          echo "Pre release name:" $pre_release_name
+          echo ::set-output name=npm_tag::$pre_release_name
+      - name: Publish to NPM latest
+        if:  steps.npm_tag.outputs.npm_tag == ''
         run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Publish to NPM with tag
+        if: steps.npm_tag.outputs.npm_tag != ''
+        run: npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/script/cli-utils.js
+++ b/script/cli-utils.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const exec = require('child_process').spawnSync;
+const process = require('process');
+const path = require('path');
+const input = require('process').stdin;
+const output = require('process').stdout;
+const util = require('util');
+const readline = require('readline');
+
+const YES = 'yes';
+
+const logger = {
+  error: (output, info = '') => console.error('\x1b[31m%s\x1b[0m', output, info), // Red
+  log: output => console.log('\x1b[36m%s\x1b[0m', output), // Teal
+  warn: output => console.warn('\x1b[33m%s\x1b[0m', output), // Yellow
+};
+
+const spawnOrFail = (command, args, options) => {
+  const cmd = exec(command, args, { shell: true });
+  if (cmd.error) {
+    logger.log(`Command ${command} failed with ${cmd.error.code}`);
+    quit(255);
+  }
+  const output = cmd.stdout.toString();
+  if (!options || !options.skipOutput) {
+    logger.log(output);
+  }
+  if (cmd.status !== 0) {
+    logger.error(`Command ${command} failed with exit code ${cmd.status} signal ${cmd.signal}`);
+    logger.error(cmd.stderr.toString());
+    quit(cmd.status);
+  } else if (options && options.printErr) { // Some commands like npm pack output to stderr
+    logger.log(cmd.stderr.toString());
+  }
+  return output;
+};
+
+const prompt = async (prompt) => {
+  return new Promise((resolve) => {
+    rl = readline.createInterface({ input , output });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer)
+    });
+  });
+};
+
+const shouldContinuePrompt = async () => {
+  const cont = await new Promise((resolve) => {
+    rl = readline.createInterface({ input , output });
+    rl.question(`Type '${util.format('\x1b[32m%s\x1b[0m', YES)}' to continue\n`, (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === YES);
+    });
+  });
+  if (!cont) {
+    quit(0);
+  }
+};
+
+const quit = (statusCode) => {
+  process.exit(statusCode);
+};
+
+module.exports = {
+  logger,
+  spawnOrFail,
+  prompt,
+  shouldContinuePrompt,
+  quit,
+  fs,
+  process,
+  path
+};

--- a/script/release.js
+++ b/script/release.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+const { versionBump, currentVersion, isPreRelease }  = require('./version-utils');
+const { logger, spawnOrFail, prompt, shouldContinuePrompt, quit, process, path } = require('./cli-utils');
+
+const deployDemo = (version) => {
+  const demoName = `chime-sdk-demo-${version.replace(/\./g, "-")}`;
+  logger.log(`Deploying ${demoName} ...`);
+  process.chdir(path.join(__dirname, '../demos/serverless'));
+  spawnOrFail('npm', [`run deploy -- -b ${demoName} -s ${demoName} -o ${demoName} -u false`], { printErr: true });
+};
+
+const getCurrentRemoteBranch = () => {
+  return (spawnOrFail('git', ['for-each-ref --format="%(upstream:short)" "$(git symbolic-ref -q HEAD)"'], { skipOutput: true })).trim();
+};
+
+const buildAndPack = () => {
+  logger.log('Building package...');
+  spawnOrFail('npm', ['run build:release']);
+  logger.log('Packaging ...');
+  spawnOrFail('npm', ['pack --dry-run'], { printErr: true });
+};
+
+const cleanUp = async (remoteBranch) => {
+  logger.warn(`Warning: Resetting HEAD${remoteBranch ? ` to ${remoteBranch}` : ''}.\nAll current staged and local changes will be lost.`);
+  await shouldContinuePrompt();
+  spawnOrFail('git', [`reset --hard ${remoteBranch ? remoteBranch : ''}`]);
+  spawnOrFail('git', [' clean -ffxd .']);
+};
+
+const release = async () => {
+  spawnOrFail('git', ['fetch origin'], { skipOutput: true });
+  const currentBranch = (spawnOrFail('git', [' branch --show-current'], { skipOutput: true })).trim();
+  const remoteBranch = getCurrentRemoteBranch();
+  if (!remoteBranch || (remoteBranch !== 'origin/main' && (/^origin\/release-[0-9]+\.x$/).test(remoteBranch))) {
+    logger.error(`The local branch ${currentBranch} does not track either main or release-<version>.x branch`);
+    quit(1);
+  }
+
+  await cleanUp(remoteBranch);
+
+  buildAndPack();
+
+  logger.log('Do you want to upload these files to release branch?\n');
+  await shouldContinuePrompt();
+  spawnOrFail('git', ['push origin HEAD:release -f']);
+
+  deployDemo(currentVersion);
+
+  //Bump next development version
+  await versionBump();
+};
+
+const hotfix = async () => {
+  if (isPreRelease(currentVersion)) {
+    logger.error(`We currently do not do hotfix for pre-release version.`);
+    quit(1);
+  }
+  await cleanUp();
+  buildAndPack();
+  await versionBump(1, 'hotfix');
+  deployDemo(currentVersion);
+};
+
+const main = async () => {
+  logger.log('Choose one of the following options:');
+  logger.log('  1. Release');
+  logger.log('  2. Hotfix');
+  logger.log('  3. Deploy demo');
+  const option = await prompt('');
+
+  switch (option) {
+    case '1':
+      await release();
+      break;
+    case '2':
+      await hotfix();
+      break;
+    case '3':
+      const remoteBranch = getCurrentRemoteBranch();
+      if (!remoteBranch || (remoteBranch !== 'origin/release' && (remoteBranch !== 'origin/hotfix'))) {
+        logger.error(`The local branch ${currentBranch} does not track either release or hotfix branch`);
+        quit(1);
+      }
+      await cleanUp(remoteBranch);
+      deployDemo(currentVersion);
+      break;
+    default:
+      if (option) {
+        logger.error('Invalid option');
+      }
+      quit(1);
+  }
+};
+
+main();

--- a/script/release.js
+++ b/script/release.js
@@ -4,10 +4,14 @@ const { versionBump, currentVersion, isPreRelease }  = require('./version-utils'
 const { logger, spawnOrFail, prompt, shouldContinuePrompt, quit, process, path } = require('./cli-utils');
 
 const deployDemo = (version) => {
-  const demoName = `chime-sdk-demo-${version.replace(/\./g, "-")}`;
-  logger.log(`Deploying ${demoName} ...`);
+  const formattedVersion = `${version.replace(/\./g, "-")}`;
   process.chdir(path.join(__dirname, '../demos/serverless'));
-  spawnOrFail('npm', [`run deploy -- -b ${demoName} -s ${demoName} -o ${demoName} -u false`], { printErr: true });
+  const meetingDemoName = `chime-sdk-demo-${formattedVersion}`;
+  logger.log(`Deploying ${meetingDemoName} ...`);
+  spawnOrFail('npm', [`run deploy -- -b ${meetingDemoName} -s ${meetingDemoName} -o ${meetingDemoName} -u false`], { printErr: true });
+  const readinessCheckerDemoName = `chime-sdk-meeting-readiness-checker-${formattedVersion}`;
+  logger.log(`Deploying ${readinessCheckerDemoName} ...`);
+  spawnOrFail('npm', [`run deploy -- -b ${readinessCheckerDemoName} -s ${readinessCheckerDemoName} -a meetingReadinessChecker -u false`], { printErr: true });
 };
 
 const getCurrentRemoteBranch = () => {

--- a/script/version-utils.js
+++ b/script/version-utils.js
@@ -29,12 +29,15 @@ const getNewVersion = (currentVersion, versionIncrement) => {
         return undefined;
       }
       verArr[1] = Number(verArr[1]) + 1;
+      verArr[2] = 0;
       return verArr.join('.');
     case 3: // Major
       if (isBeta) {
         return currentVersion.split('-')[0];
       }
       verArr[0] = Number(verArr[0]) + 1;
+      verArr[1] = 0;
+      verArr[2] = 0;
       return verArr.join('.');
     case 4: // Beta (e.g., 3.0.0-beta.0)
       if (isBeta) { // Already a beta version then just increase the build number at the end
@@ -42,6 +45,8 @@ const getNewVersion = (currentVersion, versionIncrement) => {
         return verArr.join('.');
       }
       verArr[0] = Number(verArr[0]) + 1;
+      verArr[1] = 0;
+      verArr[2] = 0;
       return verArr.join('.') + '-beta.0';
     default:
       logger.error(`ERROR: Invalid input: ${versionIncrement}`);

--- a/script/version-utils.js
+++ b/script/version-utils.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+const { logger, spawnOrFail, prompt, shouldContinuePrompt, quit, fs, path } = require('./cli-utils');
+const currentVersion = require('../package.json').version;
+
+const isPreRelease = (version) => {
+  //Check whether there is a build version at the end (e.g., 3.0.0-beta.0)
+  return version.split('.')[3] >= 0;
+};
+
+// Return the next version from the current version based on the inputs.
+// For pre-release candidate, the current option is Beta which will add beta after the patch version, separated by a
+// hyphen, following by the build number. (e.g, 3.0.0-beta.0).
+const getNewVersion = (currentVersion, versionIncrement) => {
+  const verArr = currentVersion.split('.');
+  const isBeta = isPreRelease(currentVersion);
+
+  switch (versionIncrement) {
+    case 1: // Patch
+      if (isBeta) {
+        logger.error(`ERROR: Cannot increase patch in pre-release version `);
+        return undefined;
+      }
+      verArr[2] = Number(verArr[2]) + 1;
+      return verArr.join('.');
+    case 2: // Minor
+      if (isBeta) {
+        logger.error(`ERROR: Cannot increase patch in pre-release version `);
+        return undefined;
+      }
+      verArr[1] = Number(verArr[1]) + 1;
+      return verArr.join('.');
+    case 3: // Major
+      if (isBeta) {
+        return currentVersion.split('-')[0];
+      }
+      verArr[0] = Number(verArr[0]) + 1;
+      return verArr.join('.');
+    case 4: // Beta (e.g., 3.0.0-beta.0)
+      if (isBeta) { // Already a beta version then just increase the build number at the end
+        verArr[3] = Number(verArr[3]) + 1;
+        return verArr.join('.');
+      }
+      verArr[0] = Number(verArr[0]) + 1;
+      return verArr.join('.') + '-beta.0';
+    default:
+      logger.error(`ERROR: Invalid input: ${versionIncrement}`);
+      return undefined;
+  }
+};
+
+// Add an entry for the new version in CHANGELOG.md
+const updateChangelog = (newVersion) => {
+  logger.log(`Updating CHANGELOG.md with a new release entry - ${newVersion}`);
+  const filePath = path.resolve(__dirname, '../CHANGELOG.md');
+  let changeLog = fs.readFileSync(filePath).toString();
+  const latestEntryIndex = changeLog.indexOf('## [');
+  const newEntry = `## [${newVersion}] - ${new Date().toISOString().slice(0, 10)}
+    \n### Added
+    \n### Removed
+    \n### Changed
+    \n### Fixed
+    \n`;
+  changeLog = changeLog.substring(0, latestEntryIndex) + newEntry + changeLog.substring(latestEntryIndex);
+  fs.writeFileSync(filePath, changeLog);
+};
+
+// Update the base branch to point to a new branch.
+// For example, base branch for release-2.x should be origin/release-2.x
+const updateBaseBranch = (branchName) => {
+  logger.log(`Updating the base branch in .base-branch to ${branchName}`);
+  const filePath = path.resolve(__dirname, '../.base-branch');
+  fs.writeFileSync(filePath, `origin/${branchName}`);
+}
+
+const versionBump = async (option, branchName) => {
+  if (!option) {
+    logger.log('Choose one of the following options to bump the next version:');
+    logger.log('  1. Patch');
+    logger.log('  2. Minor');
+    logger.log('  3. Major');
+    logger.log('  4. Beta');
+    option = Number(await prompt(''));
+  }
+  const newVersion = getNewVersion(currentVersion, option);
+  if (!newVersion) {
+    quit(1);
+  }
+
+  branchName = branchName ? branchName : 'version-bump';
+
+  const prevReleaseBranch = !isPreRelease(currentVersion) && (option === 3 || option === 4)
+    ? `release-${currentVersion.split('.')[0]}.x`
+    : '';
+
+  logger.warn('Warning: you are bumping the version\n');
+  logger.warn(`  From: ${currentVersion}\n`);
+  logger.warn(`  To: ${newVersion}\n`);
+  if (prevReleaseBranch) {
+    logger.warn(`  This will also create ${prevReleaseBranch} branch.`);
+  }
+  await shouldContinuePrompt();
+
+  if (prevReleaseBranch) {
+    const currentBranch = (spawnOrFail('git', [' branch --show-current'], { skipOutput: true })).trim();
+    spawnOrFail('git', [`checkout -b ${prevReleaseBranch}`]);
+    updateBaseBranch(prevReleaseBranch);
+    spawnOrFail('git', ['add -A']);
+    spawnOrFail('git', [`commit -m "Update base branch to ${prevReleaseBranch}"`]);
+    spawnOrFail('git', [`push origin HEAD:${prevReleaseBranch} -f`]);
+    logger.log(`Branch ${prevReleaseBranch} is created. Please make sure to set branch protection.`);
+
+    // Switch back to the local branch
+    spawnOrFail('git', [`checkout ${currentBranch}`]);
+  }
+
+  spawnOrFail('npm', [`version ${newVersion} --no-git-tag-version`]);
+  updateChangelog(newVersion);
+
+  logger.log('Committing version bump...');
+  spawnOrFail('git', ['add -A']);
+  spawnOrFail('git', [`commit -m "Version bump for amazon-chime-sdk-js@${newVersion}"`]);
+  logger.log(`Do you want to upload these files to ${branchName} branch?\n`);
+  await shouldContinuePrompt();
+  spawnOrFail('git', [`push origin HEAD:${branchName} -f`]);
+  logger.log('Please create a pull request to merge the version bump to main.');
+};
+
+module.exports = {
+  versionBump,
+  currentVersion,
+  isPreRelease
+};


### PR DESCRIPTION
**Description of changes:**
Replace our current release script:
- Switch to Node script and add some styling to text similar to the React library. One drawback of using Node child_process spawnSync is that we would not see the immediate output from the child process in console so long process such as `build:release` or demo deployment will take a while before we see anything.
- Include new options for handling major and pre-build versions (beta).
- Include new option for redeploy demo in release or hotfix branch so that we could do incorporate fix and redeploy test demo without rerun the entire script.
- Change release to bump version at the beginning of any new version.

Also update our publish script to tag pre-release (beta) version.

**Testing:**
- Test the release script using a private repo.
- Use verdaccio to test publish beta package to npm.
- Use dummy GitHub repo to test out publish action.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

