### PR TITLE
Deploy meeting readiness checker when running release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -88,3 +88,4 @@ end
 
 Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../demos/serverless')))
 verbose("npm run deploy -- -b chime-sdk-demo-#{formatted_version} -s chime-sdk-demo-#{formatted_version} -o chime-sdk-demo-#{formatted_version} -u false")
+verbose("npm run deploy -- -b chime-sdk-meeting-readiness-checker-#{formatted_version} -s chime-sdk-meeting-readiness-checker-#{formatted_version} -a meetingReadinessChecker -u false")


### PR DESCRIPTION
**Issue #:**
The release script does not deploy meeting readiness check so we have to manually do it for every release

**Description of changes:**
Add command to deploy meeting readiness checker after the meeting demo.

**Testing:**
Deploy the command to make sure it is correct.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

