### PR TITLE
Update prerun script ID used by integration tests

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,7 +104,7 @@ const getPrerunScript = (capabilities) =>{
   const name = capabilities.name;
   const blurName = "Background Blur Test";
   const repName = "Background Replacement Test";
-  return (name.includes(blurName) || name.includes(repName)) ?  'storage:b23b0bb6-8e47-4e90-80e8-fc2cb92408bf' : "";
+  return (name.includes(blurName) || name.includes(repName)) ?  'storage:8f86b53d-eeb3-4eb3-98c5-4c2b79544d23' : "";
 }
 const getChromeCapabilities = capabilities => {
   let cap = Capabilities.chrome();


### PR DESCRIPTION
**Issue #:**
Old prerun script used by Background Blur and Replacement integration tests might expire soon.

**Description of changes:**
Update the script ID to a newly updated one.

**Testing:**
Checking if Github workflow tests for background blur and replacement has passed with the new script.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes,
1947 passing (3m)


=============================== Coverage summary ===============================
Statements   : 100% ( 9908/9908 )
Branches     : 100% ( 4464/4464 )
Functions    : 100% ( 1865/1865 )
Lines        : 100% ( 9791/9791 )
================================================================================

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

