### PR TITLE
Fix delay on simulcast uplink stream switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+### Removed
+
+### Fixed
+- Fixed delays in advertising simulcast stream switches due to asynchronous and out of order checks
+
+### Changed
+- Made `SimulcastUplinkObserver.encodingSimulcastLayersDidChange` (*not* `AudioVideoObserver.encodingSimulcastLayersDidChange`) synchronous.
+
 ## [2.25.0] - 2022-01-11
 ### Added
 - Ability to choose remote video sources in `AllHighestVideoBandwidthPolicy`. see [guide](https://aws.github.io/amazon-chime-sdk-js/modules/videolayout.html#downlink-policy)

--- a/docs/classes/defaultsimulcastuplinkpolicy.html
+++ b/docs/classes/defaultsimulcastuplinkpolicy.html
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L54">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L53">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Max<wbr>Frame<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">15</span><span class="tsd-signature-symbol"> = 15</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L32">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L31">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Uplink<wbr>Bandwidth<wbr>Kbps<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 1200</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L29">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L28">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">hold<wbr>Down<wbr>Duration<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 4000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L31">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L30">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>HiDisabled<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">700</span><span class="tsd-signature-symbol"> = 700</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L34">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L33">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Mid<wbr>Disabled<wbr>Rate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">240</span><span class="tsd-signature-symbol"> = 240</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L35">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L34">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">startup<wbr>Duration<wbr>Ms<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 6000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L30">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L29">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L401">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L400">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:400</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -259,7 +259,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#choosecaptureandencodeparameters">chooseCaptureAndEncodeParameters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L305">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:305</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L304">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:304</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">DefaultVideoAndEncodeParameter</span></h4>
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#chooseencodingparameters">chooseEncodingParameters</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L215">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L214">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:214</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">RTCRtpEncodingParameters</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#choosemediatrackconstraints">chooseMediaTrackConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L204">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:204</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L203">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:203</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaTrackConstraints</span></h4>
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L411">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:411</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L410">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:410</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -353,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L379">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:379</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L378">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:378</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -377,7 +377,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#maxbandwidthkbps">maxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L328">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L327">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L406">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L405">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:405</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -419,7 +419,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#sethasbandwidthpriority">setHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L337">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:337</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L336">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:336</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -443,7 +443,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#setidealmaxbandwidthkbps">setIdealMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L333">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:333</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L332">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:332</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -466,7 +466,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L64">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L63">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -495,7 +495,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L225">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L224">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:224</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -519,7 +519,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkpolicy.html">SimulcastUplinkPolicy</a>.<a href="../interfaces/simulcastuplinkpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L252">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L251">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/enums/activestreams.html
+++ b/docs/enums/activestreams.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Hi<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L18">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L17">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>HiAnd<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L19">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L18">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L21">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L20">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">k<wbr>Mid<wbr>And<wbr>Low<span class="tsd-signature-symbol">:</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L20">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts#L19">src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -898,25 +898,25 @@ export default class DefaultAudioVideoController
   }
 
   updateLocalVideoFromPolicy(): boolean {
-    if (
-      this.mayNeedRenegotiationForSimulcastLayerChange &&
-      !this.negotiatedBitrateLayersAllocationRtpHeaderExtension()
-    ) {
-      this.logger.info('Needs regenotiation for local video simulcast layer change');
-      this.mayNeedRenegotiationForSimulcastLayerChange = false;
-      return false;
+    // Try updating parameters without renegotiation
+    if (this.meetingSessionContext.enableSimulcast) {
+      // The following may result in `this.mayNeedRenegotiationForSimulcastLayerChange` being switched on
+      const encodingParam = this.meetingSessionContext.videoUplinkBandwidthPolicy.chooseEncodingParameters();
+      if (
+        this.mayNeedRenegotiationForSimulcastLayerChange &&
+        !this.negotiatedBitrateLayersAllocationRtpHeaderExtension()
+      ) {
+        this.logger.info('Needs regenotiation for local video simulcast layer change');
+        this.mayNeedRenegotiationForSimulcastLayerChange = false;
+        return false;
+      }
+      this.meetingSessionContext.transceiverController.setEncodingParameters(encodingParam);
+    } else {
+      this.meetingSessionContext.videoCaptureAndEncodeParameter = this.meetingSessionContext.videoUplinkBandwidthPolicy.chooseCaptureAndEncodeParameters();
+      // Bitrate will be set in `actionFinishUpdating`. This should never need a resubscribe.
     }
 
-    // Update bandwidth without renegotiation
-    this.logger.info('Updating local video from policy without renegotiation');
-    if (this.meetingSessionContext.enableSimulcast) {
-      // `AttachMediaInputTask` will update sender's simulcast streams encoding parameters of the local video transceiver
-      new AttachMediaInputTask(this.meetingSessionContext).run();
-    } else {
-      // `ReceiveVideoInputTask` will update `meetingSessionContext.videoCaptureAndEncodeParameter`
-      // from uplink policy on internal state
-      new ReceiveVideoInputTask(this.meetingSessionContext).run();
-    }
+    this.logger.info('Updated local video from policy without renegotiation');
     return true;
   }
 

--- a/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Logger from '../logger/Logger';
-import AsyncScheduler from '../scheduler/AsyncScheduler';
 import SimulcastLayers from '../simulcastlayers/SimulcastLayers';
 import SimulcastTransceiverController from '../transceivercontroller/SimulcastTransceiverController';
 import { Maybe } from '../utils/Types';
@@ -410,11 +409,7 @@ export default class DefaultSimulcastUplinkPolicy implements SimulcastUplinkPoli
 
   forEachObserver(observerFunc: (observer: SimulcastUplinkObserver) => void): void {
     for (const observer of this.observerQueue) {
-      AsyncScheduler.nextTick(() => {
-        if (this.observerQueue.has(observer)) {
-          observerFunc(observer);
-        }
-      });
+      observerFunc(observer);
     }
   }
 }

--- a/test/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.test.ts
+++ b/test/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy.test.ts
@@ -17,7 +17,6 @@ import {
 } from '../../src/signalingprotocol/SignalingProtocol.js';
 import SimulcastLayers from '../../src/simulcastlayers/SimulcastLayers';
 import SimulcastTransceiverController from '../../src/transceivercontroller/SimulcastTransceiverController';
-import { wait as delay } from '../../src/utils/Utils';
 import SimulcastVideoStreamIndex from '../../src/videostreamindex/SimulcastVideoStreamIndex';
 import DefaultSimulcastUplinkPolicy from '../../src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy';
 import SimulcastUplinkObserver from '../../src/videouplinkbandwidthpolicy/SimulcastUplinkObserver';
@@ -447,46 +446,30 @@ describe('DefaultSimulcastUplinkPolicy', () => {
       let called = 0;
       class TestObserver implements SimulcastUplinkObserver {
         encodingSimulcastLayersDidChange(_simulcastLayer: SimulcastLayers): void {
-          if (event !== 1 && event !== 3 && event !== 5) {
+          if (event !== 1 && event !== 3) {
             assert.fail();
           }
           called += 1;
         }
       }
       const observer = new TestObserver();
-      await delay(100);
       (policy as SimulcastUplinkPolicy).addObserver(observer);
       event += 1;
       (policy as SimulcastUplinkPolicy).forEachObserver((observer: SimulcastUplinkObserver) => {
         observer.encodingSimulcastLayersDidChange(SimulcastLayers.High);
       });
-      await delay(100);
       (policy as SimulcastUplinkPolicy).removeObserver(observer);
       event += 1;
       (policy as SimulcastUplinkPolicy).forEachObserver((observer: SimulcastUplinkObserver) => {
         observer.encodingSimulcastLayersDidChange(SimulcastLayers.High);
       });
-      await delay(100);
       (policy as SimulcastUplinkPolicy).addObserver(observer);
       event += 1;
       (policy as SimulcastUplinkPolicy).forEachObserver((observer: SimulcastUplinkObserver) => {
         observer.encodingSimulcastLayersDidChange(SimulcastLayers.High);
       });
-      await delay(100);
-      event += 1;
-      (policy as SimulcastUplinkPolicy).forEachObserver((observer: SimulcastUplinkObserver) => {
-        observer.encodingSimulcastLayersDidChange(SimulcastLayers.High);
-      });
-      (policy as SimulcastUplinkPolicy).removeObserver(observer);
-      await delay(100);
-      (policy as SimulcastUplinkPolicy).addObserver(observer);
-      event += 1;
-      (policy as SimulcastUplinkPolicy).forEachObserver((observer: SimulcastUplinkObserver) => {
-        observer.encodingSimulcastLayersDidChange(SimulcastLayers.High);
-      });
-      await delay(100);
-      expect(event).to.equal(5);
-      expect(called).to.equal(3);
+      expect(event).to.equal(3);
+      expect(called).to.equal(2);
     });
 
     it('observer should get called only when simulcast encoding layers change', async () => {
@@ -504,7 +487,6 @@ describe('DefaultSimulcastUplinkPolicy', () => {
       const index = new SimulcastVideoStreamIndex(logger);
       // Low and high simulcast streams by default
       let encodingParams = policy.chooseEncodingParameters();
-      await delay(100);
       index.integrateUplinkPolicyDecision(Array.from(encodingParams.values()));
       // Only high simulcast stream
       updateIndexFrame(index, 1);
@@ -525,7 +507,6 @@ describe('DefaultSimulcastUplinkPolicy', () => {
       updateIndexFrame(index, 8);
       policy.updateIndex(index);
       encodingParams = policy.chooseEncodingParameters();
-      await delay(100);
       expect(called).to.equal(4);
     });
   });


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** 

`updateLocalVideoFromPolicy` wasn't really working as expected for two reasons:
* `encodingSimulcastLayersDidChange` is not called until `chooseEncodingParameters` so it doesn't make sense to call before. Reversed the ordering here.
* `SimulcastUplinkObserver.encodingSimulcastLayersDidChange` is async so it would likely not be updated in time. Made this synchronous.
* `AttachMediaInputTask` and `ReceiveVideoInputTask` are run async (async on async!) so `chooseEncodingParameters` would also not be called in time.

**Testing:**
Smoke tested with three simulcast chrome senders with priority. Smoke tested with three non-simulcast chrome senders. Removed the third sender and there is no longer a long video freeze. There is a small one but that will not likely be fixable until we wire up the layers allocation extension again. This only occurs on participant number changes < 8 so its not very frequent.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
* 3 chrome senders using simulcast.
* One leaves conference
* No freezes on other applications

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
y

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
y

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

