### PR TITLE
Fix the bug that the max bandwidth is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix the bug that the max bandwidth set by the chooseVideoInputQuality API is ignored when the Chime SDK retries the connection.
 - Added additional pausing of `MonitorTask` and `ReceiveVideoStreamIndexTask` to avoid modifying mutable state mid-subscribe
 
 ### Changed

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -167,27 +167,21 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
     if (!settings) {
       return;
     }
-
     const encodingParams: RTCRtpEncodingParameters = this.calculateEncodingParameters(settings);
-    if (
-      !this.encodingParametersHaveSameBitrateAndScaling(
-        encodingParams,
-        this.encodingParamMap.get(NScaleVideoUplinkBandwidthPolicy.encodingMapKey)
-      )
-    ) {
+    if (this.shouldUpdateEndcodingParameters(encodingParams)) {
       this.encodingParamMap.set(NScaleVideoUplinkBandwidthPolicy.encodingMapKey, encodingParams);
       this.transceiverController.setEncodingParameters(this.encodingParamMap);
     }
   }
 
-  private encodingParametersHaveSameBitrateAndScaling(
-    encoding1: RTCRtpEncodingParameters,
-    encoding2: RTCRtpEncodingParameters
-  ): boolean {
+  private shouldUpdateEndcodingParameters(encoding: RTCRtpEncodingParameters): boolean {
+    /* istanbul ignore next: sender, getParameters, and encodings are optional */
+    const transceiverEncoding = this.transceiverController
+      ?.localVideoTransceiver()
+      ?.sender?.getParameters()?.encodings?.[0];
     return (
-      encoding1 === encoding2 ||
-      (encoding1.maxBitrate === encoding2.maxBitrate &&
-        encoding1.scaleResolutionDownBy === encoding2.scaleResolutionDownBy)
+      encoding.maxBitrate !== transceiverEncoding.maxBitrate ||
+      encoding.scaleResolutionDownBy !== transceiverEncoding.scaleResolutionDownBy
     );
   }
 


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/1946

**Description of changes:**

When retrying the connection, the SDK resets the transceiver controller, which is responsible for setting the max bandwidth on `RTCRtpTransceiver`.
https://github.com/aws/amazon-chime-sdk-js/blob/4d779e41136d927da7816e38c5c8cd6535f40897/src/task/CleanRestartedSessionTask.ts#L18

At the end of reconnection, the SDK calls `NScaleVideoUplinkBandwidthPolicy.updateTransceiverController` to update the max bandwidth on a new transceiver controller. However, `NScaleVideoUplinkBandwidthPolicy` sees that the max bandwidth remains the same, so it does not update the max bandwidth.
https://github.com/aws/amazon-chime-sdk-js/blob/4d779e41136d927da7816e38c5c8cd6535f40897/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L172-L180

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

1. Open the Chime SDK serverless demo, type any meeting info, and navigate to the **Select devices** page.
1. Open the browser console and run the following to set the maxBandwidth to 700 Kbps.
    ```
    app.audioVideo.chooseVideoInputQuality(640, 360, 15, 700)
    ```
1. Choose **Join** to join a meeting and enable the WebRTC stats button.
1. Turn on your video and hover your mouse over a video tile. You can see the **Bitrate (bps)** is around 700,000.
1. In the browser console, run the following to force reconnecting the session.
    ```
    app.audioVideo.audioVideoController.handleMeetingSessionStatus({ isFailure: () => true, isTerminal: () => false, statusCode: () => 17, isAudioConnectionFailure: () => false, toString: () => 'Error' });
    ```
1. **The **Bitrate (bps)** should not go higher.**



**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

