### PR TITLE
Use optional chaining to prevent an error from undefined transceiverEncoding in FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the bug that the max bandwidth set by the chooseVideoInputQuality API is ignored when the Chime SDK retries the connection.
 - Added additional pausing of `MonitorTask` and `ReceiveVideoStreamIndexTask` to avoid modifying mutable state mid-subscribe
 - Fix the bug that the max bandwidth is ignored if the chooseVideoInputQuality API is called before starting a meeting.
+- Use optional chaining to prevent an error from undefined transceiverEncoding in FF.
 
 ## [2.25.0] - 2022-01-11
 ### Added

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -175,13 +175,14 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
   }
 
   private shouldUpdateEndcodingParameters(encoding: RTCRtpEncodingParameters): boolean {
-    /* istanbul ignore next: sender, getParameters, and encodings are optional */
     const transceiverEncoding = this.transceiverController
-      ?.localVideoTransceiver()
-      ?.sender?.getParameters()?.encodings?.[0];
+      .localVideoTransceiver()
+      .sender.getParameters()?.encodings?.[0];
+
+    /* istanbul ignore next: transceiverEncoding?.scaleResolutionDownBy cannot be covered */
     return (
-      encoding.maxBitrate !== transceiverEncoding.maxBitrate ||
-      encoding.scaleResolutionDownBy !== transceiverEncoding.scaleResolutionDownBy
+      encoding.maxBitrate !== transceiverEncoding?.maxBitrate ||
+      encoding.scaleResolutionDownBy !== transceiverEncoding?.scaleResolutionDownBy
     );
   }
 

--- a/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
+++ b/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
@@ -685,6 +685,57 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       spy.restore();
     });
 
+    it('calls setEncodingParameters if the transceiver controller has undefined encodings from transceiver controller', () => {
+      transceiverController.localVideoTransceiver().sender.setParameters({
+        transactionId: undefined,
+        codecs: [],
+        rtcp: undefined,
+        encodings: undefined,
+        headerExtensions: undefined,
+      });
+      policy.setTransceiverController(transceiverController);
+
+      const spy = sinon.spy(transceiverController, 'setEncodingParameters');
+      policy.updateTransceiverController();
+
+      expect(spy.calledOnce).to.be.true;
+      spy.restore();
+    });
+
+    it('calls setEncodingParameters if the transceiver controller has undefined parameters from transceiver controller', () => {
+      transceiverController.localVideoTransceiver().sender.setParameters(undefined);
+
+      const spy = sinon.spy(transceiverController, 'setEncodingParameters');
+
+      policy.setTransceiverController(transceiverController);
+      policy.updateTransceiverController();
+
+      expect(spy.calledOnce).to.be.true;
+      spy.restore();
+    });
+
+    it('should not call setEncodingParameters if the transceiver controller has an undefined sender', () => {
+      class InvalidTransceiverController extends TestTransceiverController {
+        localVideoTransceiver(): RTCRtpTransceiver {
+          // @ts-ignore
+          return {
+            sender: undefined,
+          };
+        }
+      }
+      const invalidTransceiverController = new InvalidTransceiverController(
+        new NoOpLogger(),
+        new DefaultBrowserBehavior()
+      );
+      const spy = sinon.spy(invalidTransceiverController, 'setEncodingParameters');
+      invalidTransceiverController.setPeer(new RTCPeerConnection());
+      invalidTransceiverController.setupLocalTransceivers();
+      policy.setTransceiverController(invalidTransceiverController);
+      policy.updateTransceiverController();
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+
     it('returns early if there is no transceiver controller', () => {
       const spy = sinon.spy(TestTransceiverController.prototype, 'setEncodingParameters');
       policy.updateTransceiverController();


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Use optional chaining (`transceiverEncoding?`) to prevent an error when `transceiverEncoding` is `undefined. In Firefox, the initial value of `transceiverEncoding` is `undefined`.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, ensure that you can enable a local video in Chrome, Firefox, and other supported browsers.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

