### PR TITLE
Version bump for amazon-chime-sdk-js@2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.27.0] - 2022-01-27
+    
+### Added
+    
+### Removed
+    
+### Changed
+    
+### Fixed
+    
 ## [2.26.0] - 2022-01-14
     
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-chime-sdk-js",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/dom-mediacapture-record": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
We will merge this PR after deploying new asset groups for 2.27 on Jan 28, 2022.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

