### PR TITLE
Remove optional chaining operation to support node version below 14

### DIFF
--- a/integration/js/utils/AppTestStep.js
+++ b/integration/js/utils/AppTestStep.js
@@ -18,7 +18,7 @@ class AppTestStep extends TestStep {
       this.driver = sessionInfo.driver;
     }
 
-    this.namespaceInfix = kiteBaseTest.payload?.namespaceInfix || '';
+    this.namespaceInfix = kiteBaseTest.payload.namespaceInfix || '';
   }
 
   async step() {

--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -35,8 +35,8 @@ class SdkBaseTest extends KiteBaseTest {
     this.testReady = false;
     this.testFinish = false;
     this.testName = testName;
-    this.useSimulcast = !!this.payload?.useSimulcast;
-    this.namespaceInfix = this.payload?.namespaceInfix || '';
+    this.useSimulcast = !!this.payload.useSimulcast;
+    this.namespaceInfix = this.payload.namespaceInfix || '';
 
     if (this.useSimulcast) {
       this.testName += 'Simulcast';


### PR DESCRIPTION
**Issue #1987 :**
In PR #1987, we use optional chaining operation for integration test which does not work with node 12 system.

**Description of changes:**
Replace the optional chaining with native JavaScript syntax.

**Testing:**
Test the replaced logic in JavaScript compiler and the result are exactly same as before.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

