### PR TITLE
Fix worker leak for background blur and replacement (#2017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.27.1] - 2022-02-XX
+
+### Added
+
+### Removed
+
+### Fixed
+- Fix a worker resource leak with `BackgroundBlurProcessor` and `BackgroundReplacementProcessor`.
+
 ## [2.27.0] - 2022-01-27
     
 ### Added

--- a/src/backgroundfilter/BackgroundFilterProcessor.ts
+++ b/src/backgroundfilter/BackgroundFilterProcessor.ts
@@ -398,7 +398,7 @@ export default abstract class BackgroundFilterProcessor {
     this.delegate.removeObserver(this.cpuMonitor);
     this.canvasVideoFrameBuffer.destroy();
     this.worker?.postMessage({ msg: 'destroy' });
-    this.worker?.postMessage({ msg: 'close' });
+    this.worker?.postMessage({ msg: 'stop' });
     this.targetCanvas?.remove();
     this.targetCanvas = undefined;
     this.scaledCanvas?.remove();


### PR DESCRIPTION
**Issue #:** #2017

**Description of changes:**
This is the same as #2020 except for the 2.x release branch.

This fixes a worker leak for background blur and replacement by changing the destroy message to stop. Previously, when the wrong message was sent, the worker would not be properly shut down and would still run, thereby consuming unnecessary resources.

**Testing:**
Added a unit test to BackgroundBlurProcessor.test.ts and verified the reproduction case as mentioned in the initial issue.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes.
