### PR TITLE
Fix worker leak for background blur and replacement (#2017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.27.1] - 2022-02-17
+
+### Added
+
+### Removed
+
+### Fixed
+- Fix a worker resource leak with `BackgroundBlurProcessor` and `BackgroundReplacementProcessor`.
+
 ## [2.27.0] - 2022-01-27
     
 ### Added

--- a/src/backgroundfilter/BackgroundFilterProcessor.ts
+++ b/src/backgroundfilter/BackgroundFilterProcessor.ts
@@ -398,7 +398,7 @@ export default abstract class BackgroundFilterProcessor {
     this.delegate.removeObserver(this.cpuMonitor);
     this.canvasVideoFrameBuffer.destroy();
     this.worker?.postMessage({ msg: 'destroy' });
-    this.worker?.postMessage({ msg: 'close' });
+    this.worker?.postMessage({ msg: 'stop' });
     this.targetCanvas?.remove();
     this.targetCanvas = undefined;
     this.scaledCanvas?.remove();

--- a/test/backgroundprocessor/BackgroundBlurProcessor.test.ts
+++ b/test/backgroundprocessor/BackgroundBlurProcessor.test.ts
@@ -919,16 +919,33 @@ describe('BackgroundBlurProcessor', () => {
     });
 
     it('can destroy', async () => {
-      backgroundFilterCommon.stubInit({ initPayload: 2, loadModelPayload: 2 });
+      const worker = sandbox.spy(
+        backgroundFilterCommon.stubInit({ initPayload: 2, loadModelPayload: 2 }),
+        'postMessage'
+      );
       stubSupported(true, false);
 
       let bbprocessor = (await BackgroundBlurVideoFrameProcessor.create()) as BackgroundBlurProcessorBuiltIn;
       bbprocessor['blurCanvas'] = null;
       await bbprocessor.destroy();
 
+      // Verify `stop` is called for BackgroundBlurProcessorBuiltIn.
+      // Workers loaded for background blur must maintain API contract
+      // of `stop` command existing. Integration tests should exist on
+      // the worker code to ensure that it does not change. As a result,
+      // a unit test is fine here to ensure that `stop` contract is
+      // fulfilled on the client side.
+      expect(worker.callCount).to.be.equal(4);
+      expect(worker.calledWith({ msg: 'stop' })).to.be.true;
+      worker.resetHistory();
+
       bbprocessor = (await BackgroundBlurVideoFrameProcessor.create()) as BackgroundBlurProcessorBuiltIn;
       bbprocessor['blurCanvas'] = document.createElement('canvas');
       await bbprocessor.destroy();
+
+      // Verify `stop` is called for BackgroundBlurProcessorBuiltIn.
+      expect(worker.callCount).to.be.equal(4);
+      expect(worker.calledWith({ msg: 'stop' })).to.be.true;
     });
 
     it('initialize handles errors', async () => {


### PR DESCRIPTION
**Issue #:** #2017

**Description of changes:**
This is the same as #2022 except for the 2.x release branch.

This fixes a worker leak for background blur and replacement by changing the destroy message to stop. Previously, when the wrong message was sent, the worker would not be properly shut down and would still run, thereby consuming unnecessary resources.

**Testing:**
Added a unit test to BackgroundBlurProcessor.test.ts and verified the reproduction case as mentioned in the initial issue.

To verify the changes when using background blur in the SDK, toggling background blur on and off (e.g. calling `BackgroundBlurVideoFrameProcessor.create()` and then `processor.destroy()`) should not leak web workers anymore. This is verified by running the demo application (or the simple demo linked in the issue), switching between background blur 10% and 20%, and using the chrome task manager to see that the number of workers keeps increasing without getting deleted.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes. 
1. Launch the demo application.
2. Create a meeting
3. Enable your camera
4. Join the meeting
5. Select video on by clicking the video icon.
6. Select Background Blur 10% by clicking the circle half filled white and black.
7. Select Background Blur 20%.
8. Keep alternating between 10% and 20% and notice that the number of "Dedicated Worker:"s keep increasing in the Chrome task manager (sort by CPU).

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes.
