### PR TITLE
Removed unneeded variable from Previous Major Version Browser Compatibility tests 

### DIFF
--- a/.github/workflows/browser-compatibility-test-previous-major-version.yml
+++ b/.github/workflows/browser-compatibility-test-previous-major-version.yml
@@ -278,7 +278,6 @@ jobs:
       - name: Checkout Package
         uses: actions/checkout@v2
         with:
-          ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
       - name: Setup Node.js - 16.x
         uses: actions/setup-node@v1
@@ -305,4 +304,4 @@ jobs:
       - name: Install Axios
         run: npm install axios
       - name: Send Slack Message
-        run: node .github/script/send-test-report.js ${{ secrets.SLACK_JS_SDK_DEV_CORE_PREV_VER_WEBHOOK }} ${{ env.WORKFLOW_URL}} ${{ env.WORKFLOW_JOBS_STATUS }} ${{ needs.get-previous-version.outputs.previous_version_number }}
+        run: node .github/script/send-test-report.js ${{ secrets.SLACK_JS_SDK_DEV_CORE_PREV_VER_WEBHOOK }} ${{ env.WORKFLOW_URL}} ${{ env.WORKFLOW_JOBS_STATUS }}


### PR DESCRIPTION
**Issue #:**
Previous Major Version Browser Compatibility tests was failing on the final step from invalid credentials.
**Description of changes:**
Updated webhook credentials which means we can remove the passed version number
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

