### PR TITLE
Removed upward logic in VideoPriorityBasedPolicyConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     
 ### Changed
 - Add support for pre-release in Versioning.
-- Removed upward logic in VideoPriorityBasedPolicyConfig.
+- Removed upward BWE throttling logic in VideoPriorityBasedPolicyConfig, which was increasing recovery time more then intended, whereas its main focus was towards slowing downturns in BWE when the network is actually stable. We may come back to configuring the recovery delay another time.
     
 ### Fixed
 - Add a workaround to avoid 480p resolution scale down when there are 5-8 videos for the default video uplink policy 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     
 ### Changed
 - Add support for pre-release in Versioning.
+- Removed upward logic in VideoPriorityBasedPolicyConfig.
     
 ### Fixed
 - Add a workaround to avoid 480p resolution scale down when there are 5-8 videos for the default video uplink policy 

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L390">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:390</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L391">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:391</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L390">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:390</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L391">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:391</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/videoprioritybasedpolicyconfig.html
+++ b/docs/classes/videoprioritybasedpolicyconfig.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L26">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L25">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<wbr>Issue<wbr>Recovery<wbr>Delay<wbr>Factor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L36">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L35">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<wbr>Issue<wbr>Response<wbr>Delay<wbr>Factor<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L35">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L34">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -231,7 +231,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L54">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L53">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -317,19 +317,20 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     const currentEstimated = this.downlinkStats.bandwidthEstimateKbps;
 
     // Use videoPriorityBasedPolicyConfig to add additional delays based on network conditions
-    if (
-      noMajorChange &&
-      this.probeFailed &&
-      !this.videoPriorityBasedPolicyConfig.allowSubscribe(numberOfParticipants, currentEstimated)
-    ) {
-      return;
-    }
+    const dontAllowSubscribe = !this.videoPriorityBasedPolicyConfig.allowSubscribe(
+      numberOfParticipants,
+      currentEstimated
+    );
 
-    // When probe failed, we set timeBeforeAllowSubscribeMs to 3x longer
-    // Since we have passed the subscribe interval now, we will try to probe again
-    this.probeFailed = false;
-    // For the same reason above, reset time before allow subscribe to default
-    this.timeBeforeAllowSubscribeMs = VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_SUBSCRIBE_MS;
+    if (this.probeFailed) {
+      // When probe failed, we set timeBeforeAllowSubscribeMs to 3x longer
+      // Since we have passed the subscribe interval now, we will try to probe again
+      this.probeFailed = false;
+      // For the same reason above, reset time before allow subscribe to default
+      this.timeBeforeAllowSubscribeMs = VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_SUBSCRIBE_MS;
+
+      if (noMajorChange && dontAllowSubscribe) return;
+    }
 
     const upgradeStream: VideoStreamDescription = this.priorityPolicy(
       rates,

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.test.ts
@@ -72,31 +72,9 @@ describe('VideoPriorityBasedPolicyConfig', () => {
   });
 
   describe('allowSubscribe', () => {
-    it('not allowed subscribe when bandwidth increases within recovery delay', () => {
-      const videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig();
-
-      incrementTime(1000);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
-      incrementTime(1000);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
-    });
-
-    it('allowed subscribe when bandwidth increases after recovery delay', () => {
-      const videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig();
-
-      incrementTime(1000);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
-      incrementTime(2100);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.true;
-      incrementTime(2100);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
-    });
-
     it('not allowed subscribe when bandwidth decreases within response delay', () => {
       const videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig();
 
-      incrementTime(1000);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
       incrementTime(2100);
       expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.true;
       incrementTime(1000);
@@ -105,17 +83,17 @@ describe('VideoPriorityBasedPolicyConfig', () => {
       expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 300)).to.be.false;
     });
 
-    it('not allowed subscribe when bandwidth increases within recovery delay', () => {
+    it('allowed subscribe when bandwidth decreases within response delay', () => {
       const videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig();
 
-      incrementTime(1000);
-      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.false;
       incrementTime(2100);
       expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 1000)).to.be.true;
       incrementTime(1000);
       expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 300)).to.be.false;
       incrementTime(2100);
       expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 300)).to.be.true;
+      incrementTime(2100);
+      expect(videoPriorityBasedPolicyConfig.allowSubscribe(1, 300)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
**Issue #:**

The content share may fail to resume after turning off network link conditioner. 

**Description of changes:**

Removed upward logic in `VideoPriorityBasedPolicyConfig`.

**Testing:**

Smoke tested locally. Used network link conditioner to control bandwidth to validate video tile will resume after bandwidth recovers.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

no

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

