### PR TITLE
Potentially fixed race condition in videoPriorityBasedPolicy unit test

### DIFF
--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -756,6 +756,7 @@ describe('VideoPriorityBasedPolicy', () => {
       domMockBuilder.cleanup();
       spyPause.restore();
       spyUnpause.restore();
+      policy.removeObserver(observer);
     });
 
     it('Stream not added until enough bandwidth', () => {


### PR DESCRIPTION
**Issue #:**
Sometimes when running unit tests VideoPriorityBasedPolicy will fail from a null variable
**Description of changes:**
Added a remove observer in a test that did not remove its observer. 
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

