### PR TITLE
Update documentation to include how to change background replacement image mid stream v2

### DIFF
--- a/docs/modules/backgroundfilter_video_processor.html
+++ b/docs/modules/backgroundfilter_video_processor.html
@@ -186,6 +186,16 @@ because <span class="hljs-keyword">it</span> violates <span class="hljs-keyword"
 }
 <span class="hljs-keyword">let</span> transformDevice = <span class="hljs-keyword">new</span> DefaultVideoTransformDevice(logger, device, processors);
 </code></pre>
+					<a href="#replacing-the-background-image-for-a-backgroundreplacementprocessor-mid-stream" id="replacing-the-background-image-for-a-backgroundreplacementprocessor-mid-stream" style="color: inherit; text-decoration: none;">
+						<h3>Replacing the background image for a BackgroundReplacementProcessor mid stream</h3>
+					</a>
+					<p>Store a reference to the background replacement processor object. Use BackgroundReplacementProcessor&#39;s <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/backgroundreplacementprocessor/BackgroundReplacementProcessor.ts#L28"><code>setImageBlob</code></a> to update the existing background image within the BackgroundReplacementProcessor anytime after initialization.</p>
+					<pre><code class="language-typescript"><span class="hljs-keyword">async</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">changeBackgroundImage</span>(<span class="hljs-params">backgroundReplacementProcessor: BackgroundReplacementProcessor</span>) </span>{
+    <span class="hljs-keyword">const</span> newImage = <span class="hljs-keyword">await</span> fetch(<span class="hljs-string">&#x27;https://pathtoimage.jpeg&#x27;</span>);
+    <span class="hljs-keyword">const</span> newImageBlob = <span class="hljs-keyword">await</span> newImage.blob();
+    <span class="hljs-keyword">await</span> backgroundReplacementProcessor.setImageBlob(newImageBlob);
+}
+</code></pre>
 					<a href="#configuration" id="configuration" style="color: inherit; text-decoration: none;">
 						<h2>Configuration</h2>
 					</a>

--- a/guides/15_Background_Filter_Video_Processor.md
+++ b/guides/15_Background_Filter_Video_Processor.md
@@ -141,6 +141,18 @@ if (await BackgroundReplacementVideoFrameProcessor.isSupported()) {
 let transformDevice = new DefaultVideoTransformDevice(logger, device, processors);
 ```
 
+### Replacing the background image for a BackgroundReplacementProcessor mid stream
+
+Store a reference to the background replacement processor object. Use BackgroundReplacementProcessor's [`setImageBlob`](https://github.com/aws/amazon-chime-sdk-js/blob/main/src/backgroundreplacementprocessor/BackgroundReplacementProcessor.ts#L28) to update the existing background image within the BackgroundReplacementProcessor anytime after initialization.
+
+```typescript
+async function changeBackgroundImage(backgroundReplacementProcessor: BackgroundReplacementProcessor) {
+    const newImage = await fetch('https://pathtoimage.jpeg'); 
+    const newImageBlob = await newImage.blob();
+    await backgroundReplacementProcessor.setImageBlob(newImageBlob);
+}
+```
+
 ## Configuration
 
 Both `isSupported` and `create` accept _specifications_ — `BackgroundFilterSpec` and `BackgroundBlurOptions` or `BackgroundReplacementOptions` structures — as input. The `BackgroundFilterSpec` allows you to describe the model attributes, CDN paths, and other configuration options that define how the feature should operate. The `BackgroundBlurOptions` and `BackgroundReplacementOptions` allow you to configure runtime options like observer reporting period, logging and the amount of blur strength to apply to the video.


### PR DESCRIPTION
**Issue #:**
The current documentation on background blur and replacement does not document how to change an image for a BackgroundReplacementProcessor after creation.

**Description of changes:**
Add a section to [15_Background_Filter_Video_Processor.md](https://github.com/aws/amazon-chime-sdk-js/blob/update_bg_replacement_docs/guides/15_Background_Filter_Video_Processor.md#changing-the-background-image-for-background-replacement) on how to use `setImageBlob()` API to change an image for a background replacement processor mid stream.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No code change


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes. It passed after couple of tries
=============================== Coverage summary ===============================
Statements   : 100% ( 10044/10044 )
Branches     : 100% ( 4541/4541 )
Functions    : 100% ( 1876/1876 )
Lines        : 100% ( 9926/9926 )
================================================================================

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

