### PR TITLE
Add canarySuffix to Chime SDK Meetings deploy script and update deploy workflow

### DIFF
--- a/.github/script/call-canary-deploy-demo-prod
+++ b/.github/script/call-canary-deploy-demo-prod
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+const { spawnOrFail, logger } = require('../../script/cli-utils');
+
+const myArgs = process.argv.splice(2);
+// Browser demo to be deployed
+var demoDeployVersion = myArgs[0];
+
+var npmLatestVersion = spawnOrFail('npm',['view', 'amazon-chime-sdk-js@latest', 'version']);
+var npmBetaVersion = spawnOrFail('npm', ['view', 'amazon-chime-sdk-js@beta', 'version']);
+
+// Removing line breaks from the strings before comparison
+npmLatestVersion = npmLatestVersion.replace(/(\r\n|\n|\r)/gm, '');
+npmBetaVersion = npmBetaVersion.replace(/(\r\n|\n|\r)/gm, '');
+demoDeployVersion = demoDeployVersion.replace(/(\r\n|\n|\r)/gm, '');
+
+logger.log(`NPM latest version: ${npmLatestVersion}`);
+logger.log(`NPM beta version: ${npmBetaVersion}`);
+logger.log(`Demo deploy version: ${demoDeployVersion}`);
+
+// The npm beta version usually have the -beta.0 suffix. Removing this suffix to just leave the semver version number
+npmBetaVersion = npmBetaVersion.replace(/(-beta*)\w+/g, '');
+
+npmLatestVersion = npmLatestVersion.split('.');
+npmBetaVersion = npmBetaVersion.split('.');
+demoDeployVersion = demoDeployVersion.split('.');
+
+var npmHigherMajorVersion = Math.max(Number.parseInt(npmBetaVersion[0], 10), Number.parseInt(npmLatestVersion[0], 10));   // npm latest tag might not have the latest version of code so this comparison is added
+var demoDeployMajorVersion = demoDeployVersion[0];
+
+npmHigherMajorVersion = Number.parseInt(npmHigherMajorVersion, 10);
+demoDeployMajorVersion = Number.parseInt(demoDeployMajorVersion, 10);
+
+logger.log(`NPM higher major version: ${npmHigherMajorVersion}`);
+logger.log(`Demo deploy major version: ${demoDeployMajorVersion}`);
+
+if (demoDeployMajorVersion === npmHigherMajorVersion) {
+  logger.log('Deploying latest version canary demo');
+  spawnOrFail('script/deploy-canary-demo');
+} else if (demoDeployMajorVersion < npmHigherMajorVersion) {
+  logger.log('Deploying previous major version canary demo');
+  spawnOrFail('script/deploy-canary-demo', ['-prev']);
+} else {
+  logger.log('Current version deployment does not match a deployed npm version');
+  process.exit(1);
+}

--- a/.github/script/get-demo-browser-current-version
+++ b/.github/script/get-demo-browser-current-version
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 
-const pjson = require('../../demo/browser/package.json');
-console.log(pjson['dependencies']['amazon-chime-sdk-js']);
+const pjson = require('../../demos/browser/package.json');
+var currentVersion = pjson['dependencies']['amazon-chime-sdk-js'];
+// The package.json may contain special characters like ~, * or ^ etc and these special characters can cause issuess with the publih workflow. 
+// Hence, cleaning the version number. For example, ^2.27.0 to 2.27.0
+currentVersion = currentVersion.replace(/([~^*><=])/g, "");
+console.log(currentVersion);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Verify demo browser npm version and run deployment script
         run: |
           demo_current_version=$(.github/script/get-demo-browser-current-version)
-          echo "Current demo version:" $demo_current_version
+          echo "Current demo version: " $demo_current_version
+          echo "Current released npm version:" ${{ steps.npm_version.outputs.npm_version }}
           if [[ *$demo_current_version* != "^#${{ steps.npm_version.outputs.npm_version }}" ]];
           then
             echo "Demo npm version is not the same as the current released version"
@@ -103,5 +104,5 @@ jobs:
           else
             npm run build --app=meetingReadinessChecker
             script/github-action-awscli-installation
-            script/deploy-canary-demo
+            node ./.github/script/call-canary-deploy-demo-prod $demo_current_version
           fi

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -55,36 +55,36 @@ ChimeProd)
     echo "Deploying to prod stage for canary that talks to prod Chime client"
 
     # Uses Chime Client
-    npm run deploy -- -b chime-sdk-demo-prod-canary -o chime-sdk-demo-prod-canary -s chime-sdk-demo-prod-canary -u false -t -l
-    npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary -s chime-sdk-meeting-readiness-checker-prod-canary -a meetingReadinessChecker -u false -t -l
+    npm run deploy -- -b chime-sdk-demo-prod-canary$canarySuffix -o chime-sdk-demo-prod-canary$canarySuffix -s chime-sdk-demo-prod-canary$canarySuffix -u false -t -l
+    npm run deploy -- -b chime-sdk-meeting-readiness-checker-prod-canary$canarySuffix -s chime-sdk-meeting-readiness-checker-prod-canary$canarySuffix -a meetingReadinessChecker -u false -t -l
     ;;
 
 ChimeSDKMeetingsProdIAD)
     echo "Deploying to prod stage for canary that talks to prod IAD ChimeSDKMeetings client"
 
     # Uses ChimeSDKMeetings client
-    npm run deploy -- -r us-east-1 -b chime-sdk-meetings-demo-prod-canary-us-east-1 -o chime-sdk-meetings-iad-demo-prod-canary -s chime-sdk-meetings-demo-prod-canary-us-east-1 -t -l
+    npm run deploy -- -r us-east-1 -b chime-sdk-meetings-demo-prod-canary-us-east-1$canarySuffix -o chime-sdk-meetings-iad-demo-prod-canary$canarySuffix -s chime-sdk-meetings-demo-prod-canary-us-east-1$canarySuffix -t -l
     ;;
 
 ChimeSDKMeetingsProdPDX)
     echo "Deploying to prod stage for canary that talks to prod PDX ChimeSDKMeetings client"
 
     # Uses ChimeSDKMeetings client
-    npm run deploy -- -r us-west-2 -b chime-sdk-meetings-demo-prod-canary-us-west-2 -o chime-sdk-meetings-pdx-demo-prod-canary -s chime-sdk-meetings-demo-prod-canary-us-west-2 -t -l
+    npm run deploy -- -r us-west-2 -b chime-sdk-meetings-demo-prod-canary-us-west-2$canarySuffix -o chime-sdk-meetings-pdx-demo-prod-canary$canarySuffix -s chime-sdk-meetings-demo-prod-canary-us-west-2$canarySuffix -t -l
     ;;
 
 ChimeSDKMeetingsProdFRA)
     echo "Deploying to prod stage for canary that talks to prod FRA ChimeSDKMeetings client"
 
     # Uses ChimeSDKMeetings client
-    npm run deploy -- -r eu-central-1 -b chime-sdk-meetings-demo-prod-canary-eu-central-1 -o chime-sdk-meetings-fra-demo-prod-canary -s chime-sdk-meetings-demo-prod-canary-eu-central-1 -t -l
+    npm run deploy -- -r eu-central-1 -b chime-sdk-meetings-demo-prod-canary-eu-central-1$canarySuffix -o chime-sdk-meetings-fra-demo-prod-canary$canarySuffix -s chime-sdk-meetings-demo-prod-canary-eu-central-1$canarySuffix -t -l
     ;;
 
 ChimeSDKMeetingsProdSIN)
     echo "Deploying to prod stage for canary that talks to prod SIN ChimeSDKMeetings client"
 
     # Uses ChimeSDKMeetings client
-    npm run deploy -- -r ap-southeast-1 -b chime-sdk-meetings-demo-prod-canary-ap-southeast-1 -o chime-sdk-meetings-sin-demo-prod-canary -s chime-sdk-meetings-demo-prod-canary-ap-southeast-1 -t -l
+    npm run deploy -- -r ap-southeast-1 -b chime-sdk-meetings-demo-prod-canary-ap-southeast-1$canarySuffix -o chime-sdk-meetings-sin-demo-prod-canary$canarySuffix -s chime-sdk-meetings-demo-prod-canary-ap-southeast-1$canarySuffix -t -l
     ;;
 
 esac


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
In PR #1986, `canarySuffix` was added to environments except PROD. This PR adds the suffix to the PROD environment as well.

**Testing:**
NA

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No, it is a deployment change

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

