### PR TITLE
Format the CHANGELOG and improve the style of new section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,110 +6,127 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.0.0-beta.1] - 2022-02-23
-    
+
 ### Added
+
 - Add compression support when sending and receiving sdp messages.
-    
+
 ### Removed
-    
+
 ### Changed
-    
+
 ### Fixed
-- Clone the video preference input in `chooseRemoteVideoSources` API in `VideoPriorityBasedPolicy` to avoid mutation 
-  that can cause video preferences to not be sorted and lead to wrong video subscription determination by the policy. 
-    
+
+- Clone the video preference input in `chooseRemoteVideoSources` API in `VideoPriorityBasedPolicy` to avoid mutation that can cause video preferences to not be sorted and lead to wrong video subscription determination by the policy.
+
 ## [3.0.0-beta.0] - 2022-02-08
-    
+
 ### Added
-    
+
 ### Removed
+
 - Remove support for Plan B as well as Safari (and iOS) 12+. The minimum Safari and iOS supported version is now 13. Also clean up all plan-B code path.
 - Remove all deprecated meeting status code.  
-    
+
 ### Changed
+
 - Decoupled `EventController` from `AudioVideo` and `MeetingSession`.
 - Add support for pre-release in Versioning.
 - Removed upward BWE throttling logic in VideoPriorityBasedPolicyConfig, which was increasing recovery time more then intended, whereas its main focus was towards slowing downturns in BWE when the network is actually stable. We may come back to configuring the recovery delay another time.
 - Add support for aws-sdk js v3 for messaging session.
-    
+
 ### Fixed
+
 - Fix a worker resource leak with `BackgroundBlurProcessor` and `BackgroundReplacementProcessor`.
-    
+
 ## [2.27.0] - 2022-01-27
-    
+
 ### Added
-    
-### Removed
-    
-### Changed
-- Changed `VideoPriorityBasedPolicyConfig` to be dependent on bandwidth fluctuation so that `VideoPriorityBasedPolicy` will not drop/resume video instantly when network bandwidth changes. (#1921)
-- Adjust the recovery behavior of `VideoPriorityBasedPolicy` to not get stuck at low estimates, not overeact to spurious packet loss when probing, and not let the time between probes raise to 60 seconds (reduced to maximum of 30 seconds).
-    
-### Fixed
-- Fix the reconnecting issue (#1985) by skipping the "close" event if it does not arrive in two seconds.
-- Add a workaround to avoid 480p resolution scale down when there are 5-8 videos for the default video uplink policy
-  for Chromium browsers version 98 on Windows and use 360p instead.
-    
-## [2.26.0] - 2022-01-14
-    
-### Added
-    
+
 ### Removed
 
 ### Changed
+
+- Changed `VideoPriorityBasedPolicyConfig` to be dependent on bandwidth fluctuation so that `VideoPriorityBasedPolicy` will not drop/resume video instantly when network bandwidth changes. (#1921).
+- Adjust the recovery behavior of `VideoPriorityBasedPolicy` to not get stuck at low estimates, not overeact to spurious packet loss when probing, and not let the time between probes raise to 60 seconds (reduced to maximum of 30 seconds).
+
+### Fixed
+
+- Fix the reconnecting issue (#1985) by skipping the "close" event if it does not arrive in two seconds.
+- Add a workaround to avoid 480p resolution scale down when there are 5-8 videos for the default video uplink policy for Chromium browsers version 98 on Windows and use 360p instead.
+
+## [2.26.0] - 2022-01-14
+
+### Added
+
+### Removed
+
+### Changed
+
 - Made `SimulcastUplinkObserver.encodingSimulcastLayersDidChange` (*not* `AudioVideoObserver.encodingSimulcastLayersDidChange`) synchronous.
 
 ### Fixed
-- Fixed delays in advertising simulcast stream switches due to asynchronous and out of order checks
+
+- Fixed delays in advertising simulcast stream switches due to asynchronous and out of order checks.
 - Fixed Firefox video tiles containing stale frames from previous transceivers by not attempting to reuse inactive transceivers. This switches to using `RTCRtpTransceiver.stop` when possible and may fix other incorrect tile bugs.
 - Fix the bug that the max bandwidth set by the chooseVideoInputQuality API is ignored when the Chime SDK retries the connection.
-- Added additional pausing of `MonitorTask` and `ReceiveVideoStreamIndexTask` to avoid modifying mutable state mid-subscribe
+- Added additional pausing of `MonitorTask` and `ReceiveVideoStreamIndexTask` to avoid modifying mutable state mid-subscribe.
 - Fix the bug that the max bandwidth is ignored if the chooseVideoInputQuality API is called before starting a meeting.
 - Use optional chaining to prevent an error from undefined transceiverEncoding in FF.
 
 ## [2.25.0] - 2022-01-11
+
 ### Added
-- Ability to choose remote video sources in `AllHighestVideoBandwidthPolicy`. see [guide](https://aws.github.io/amazon-chime-sdk-js/modules/videolayout.html#downlink-policy)
+
+- Ability to choose remote video sources in `AllHighestVideoBandwidthPolicy`. see [guide](https://aws.github.io/amazon-chime-sdk-js/modules/videolayout.html#downlink-policy).
 - Add `BackgroundReplacementVideoFrameProcessor` that will create a `VideoFrameProcessor` to apply a background image to an outgoing video stream.
 
 ### Removed
 
 ### Fixed
+
 - Correct the minimum supported Firefox version to `75` to match the official [documentation](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-browsers).
 
 ### Changed
+
 - Enforced a video receive limit incase the number of videos shared in the meeting are greater than the limit. The current limit is 25, which can change in future.
 - Clarified a comment in `DefaultSimulcastUplinkPolicy`.
 
 ## [2.24.0] - 2021-12-17
+
 ### Added
-- Add `supportDownlinkBandwidthEstimation` API to check whether browsers support downlink bandwidth estimation 
-  which requires for priority based downlink policy to work.
+
+- Add `supportDownlinkBandwidthEstimation` API to check whether browsers support downlink bandwidth estimation which requires for priority based downlink policy to work.
 - Add `keepLastFrameWhenPaused` in `DefaultVideoTile` as an option to keep last frame when pausing a video tile.
 - Add error name for custom device controller error.
 - Added pagination option to meeting demo when priority downlink policy is used.
 - Add `ApplicationMetadata` to enable builders to send their application name or version to the Amazon Chime backend. This is an opt-in addition.
-- Add a new `AudioProfile` called `fullbandMusicStereo` which can be passed into `setAudioProfile` to support sending and recieving stereo audio through main audio input and output. This can also be passed into `setContentAudioProfile` to support sending stereo audio as content
-- [Demo] Add new checbox on join screen to select new `fullbandMusicStereo` audio profile
-- [Demo] Add new dropdown items in microphone dropdown menu to test sending stereo audio as main audio input
-- [Demo] Add new dropdown items in content share dropdown menu to test sending stereo audio as content
+- Add a new `AudioProfile` called `fullbandMusicStereo` which can be passed into `setAudioProfile` to support sending and receiving stereo audio through main audio input and output. This can also be passed into `setContentAudioProfile` to support sending stereo audio as content.
+- [Demo] Add new checkbox on join screen to select new `fullbandMusicStereo` audio profile.
+- [Demo] Add new dropdown items in microphone dropdown menu to test sending stereo audio as main audio input.
+- [Demo] Add new dropdown items in content share dropdown menu to test sending stereo audio as content.
 
 ### Removed
 
 ### Fixed
+
 - Fixed updates to mutable state during subscribe leading to non-existant/frozen video streams.
 - Fixed inconsistent default maxBitrate values in the NScaleVideoUplinkBandwithPolicy constructor leading to the default ideal max bitrate not being honored.
 
 ### Changed
+
 - Clarified comment in `DefaultSimulcastUplinkPolicy`.
 
 ## [2.23.1] - 2021-12-17
 
 ### Fixed
+
 - Temporararily removed munging of layers allocation extension to mitigate Chrome M97 change which led to `setLocalDescription` failures. This was not yet being negotiated by the remote end, so this will not have any impact on media quality.
 
 ## [2.23.0] - 2021-11-22
+
 ### Added
+
 - Add support for Echo Reduction when using Voice Focus.
 
 ### Removed
@@ -121,7 +138,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ## [2.22.0] - 2021-11-18
+
 ### Added
+
 - Add documentation in video processor on how to add a customized professor with new image loading.
 - Adds support to live transcription for new features including PII content identification and redaction, partial results stabilization, and custom language models for Amazon Transcribe and PHI content identification for Amazon Transcribe Medical.
 
@@ -131,8 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix priority downlink policy bandwidth estimation metrics to work with Safari.
 - Add a workaround to switch to VP8 for iOS 15.1 due to [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=232416) that causes crash with H.264 encoding.
-- Add a workaround to switch to VP8 for iOS 15.1 due to [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=232416) 
-  for iOS WebView that causes crash with H.264 encoding.  
+- Add a workaround to switch to VP8 for iOS 15.1 due to [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=232416) for iOS WebView that causes crash with H.264 encoding.
 - Make `tileWillBePausedByDownlinkPolicy` observer update synchronous without `setTimeout`.
 
 ### Changed
@@ -182,14 +200,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent error `'scaleResolutionDownBy' member of RTCRtpEncodingParameters is not a finite floating-point value` 
-  thrown by NScale video uplink bandwidth policy when there is no height information from the sending video stream.
+- Prevent error `'scaleResolutionDownBy' member of RTCRtpEncodingParameters is not a finite floating-point value` thrown by NScale video uplink bandwidth policy when there is no height information from the sending video stream.
 
 ## [2.20.0] - 2021-10-18
 
 ### Added
 
-- Add background blur video frame processor to enable background blur on streaming video. See [guide](https://aws.github.io/amazon-chime-sdk-js/modules/backgroundfilter_video_processor.html)
+- Add background blur video frame processor to enable background blur on streaming video. See [guide](https://aws.github.io/amazon-chime-sdk-js/modules/backgroundfilter_video_processor.html).
 
 ### Removed
 
@@ -217,10 +234,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add safeguard in `ReceivedVideoInputTask` to prevent crashing when video input stream does not contain any video track.
 - Add missing `captureOutputPrefix` param for SDK demo app in release script.
 - Add opt-in region `eu-south-1` to meetings demo in deploy-canary-demo script to support media capture canary.
-- Fix bug: DOMException: The play() request was interrupted by a new load request. https://goo.gl/LdLk22.
+- Fix bug: DOMException: The play() request was interrupted by a new load request. <https://goo.gl/LdLk22>.
 - Fix `removeObserver` function in `DefaultVideoTransformDevice`.
 - Fix handling pausing when using default preference for priority-based video bandwidth policy.
-- Bind tile controller for any downlink policy that implements `bindToTileController` such as 
+- Bind tile controller for any downlink policy that implements `bindToTileController` such as
   `VideoAdaptiveProbePolicy`.
 - Do not pause streams that do not exist in conference in `VideoPriorityBasedPolicy`.
 
@@ -239,7 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add events `meetingReconnected`, `signalingDropped` and `receivingAudioDropped` to `eventDidReceive` by publishing them as stand alone events. Currently, these events were only included in the meeting history attribute when a meeting event is published. 
+- Add events `meetingReconnected`, `signalingDropped` and `receivingAudioDropped` to `eventDidReceive` by publishing them as stand alone events. Currently, these events were only included in the meeting history attribute when a meeting event is published.
 - Added support for skipping full SDP renegotiations when switching simulcast streams.  This will result in less freezing when switching between layers in response to a network event as done in `VideoPriorityBasedPolicy`.  This will have no impact if not using simulcast.
 - Add link to SIP Media Application examples in README.
 
@@ -264,8 +281,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `audioInputMuteStateChanged` to the `DeviceChangeObserver` interface. This is called whenever the device is changed or is muted or unmuted, allowing applications to adapt to OS-level mute state for input devices.
 - Added Android WebView Sample UI test to workflow.
 - Add a new optional API `getVideoTileForAttendeeId` in `VideoTileController` and raise the `tileWillBePausedByDownlinkPolicy` event for empty video tiles.
-- Amazon Voice Focus will now trigger the `onCPUWarning` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
-- Amazon Voice Focus will now trigger the `voiceFocusInsufficientResources` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (_e.g._, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (_e.g._, thermal throttling) cause the worklet to take too long for each audio render quantum.
+- Amazon Voice Focus will now trigger the `onCPUWarning` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (*e.g.*, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (*e.g.*, thermal throttling) cause the worklet to take too long for each audio render quantum.
+- Amazon Voice Focus will now trigger the `voiceFocusInsufficientResources` method on the `VoiceFocusTransformDeviceDelegate` when using the default inline execution mode. This will be called when the browser fails to schedule the worklet in a timely fashion (*e.g.*, when the meeting code is running in an iframe /subframe) or when changes in the CPU environment (*e.g.*, thermal throttling) cause the worklet to take too long for each audio render quantum.
 - Add retry logic in FAQs.
 - The Amazon Voice Focus support check, `VoiceFocusDeviceTransformer.isSupported`, now warns to the logger when run in an iframe, and can be configured to fail in that case.
 - Add documentation in Video Processing APIs on how to add filters in the preview window.
@@ -275,25 +292,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarify why not use default downlink policy with simulcast.
 - Corrected argument `isUnifiedPlan` in `withBandwidthRestriction` to `isFirefox`. Also marked as deprecated since we no longer use it.
 - Update data message limit in the API Overview guide.
-- Do not trigger real time attendee presence event for local attendee if they are not appear in audio info frame 
-  during reconnection.
+- Do not trigger real time attendee presence event for local attendee if they are not appear in audio info frame during reconnection.
 - Update `startVideoPreviewForVideoInput` to support filters in the preview window.
 - Update browser demo to showcase preview filter capability.
 
 ### Removed
 
 ### Fixed
+
 - Fix priority-based downlink policy to not unpaused tiles that are not paused by the policy.
 - Fix empty video tiles when using priority-based downlink policy.
 - Fix simulcast guide that adaptive probe downlink policy is not enabled by default.
 - Fix a link format in simulcast guide.
 - No longer put useless 'pin' and 'pause' buttons on local tile in demo.
-- Choose a null device or media stream without a deviceId without first listing devices no longer logs `Device cache 
-  is not populated`.
+- Choose a null device or media stream without a deviceId without first listing devices no longer logs `Device cache is not populated`.
 
 ## [2.16.1] - 2021-08-23
 
 ### Fixed
+
 - Fix default priority downlink policy to update default preference correctly.
 
 ## [2.16.0] - 2021-08-17
@@ -305,18 +322,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a SignalClientEvent check in `SubscribeAndReceiveSubscribeAckTask` to immediately cancel the task when websocket connection is terminated.
 
 ### Changed
+
 - Update the default behavior of NScale video uplink bandwidth policy to scale down resolution based on the number
 of videos.
 
 ### Removed
 
 ### Fixed
-- Fix race condition in Safari when disconnect and connect stream from video element.
 
+- Fix race condition in Safari when disconnect and connect stream from video element.
 
 ## [2.15.0] - 2021-08-04
 
-### Added 
+### Added
 
 - Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
 - [Demo] Add live transcription functionality. You will need to have a serverless deployment to create new AWS Lambda endpoints for live transcription. Follow [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html) to create necessary service-linked role so that the demo app can call Amazon Transcribe and Amazon Transcribe Medical on your behalf.
@@ -328,11 +346,13 @@ of videos.
 - Add a warning log in `InMemoryJSONEventBuffer`'s `send` function when retrying starts.
 
 ### Changed
+
 - Update `InMemoryJSONEventBuffer` to retry with backoff.
 
 ### Removed
 
 ### Fixed
+
 - Stop `activeDevice` video track before selecting a new device to prevent `NotReadableError` when calling `getUserMedia` for a new video input device.
 - Fix priority-based downlink policy default behavior.
 - Fix client event ingestion guide rendering in typedoc.
@@ -340,6 +360,7 @@ of videos.
 ## [2.14.0] - 2021-07-23
 
 ### Added
+
 - Added `VideoPriorityBasedPolicyConfig` to control video downlink policy with network event response and recovery delays. Check [User Guide for Priority-based Downlink Policy](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html#user-guide-for-priority-based-downlink-policy) for more information.
 - Amazon Chime SDK Project Board Overview and Guide.
 - Added 25 video tile support for demo app.
@@ -368,6 +389,7 @@ of videos.
 ### Removed
 
 ### Fixed
+
 - Improve the meeting event guide
 
 ## [2.13.0] - 2021-06-29
@@ -411,14 +433,9 @@ of videos.
 ### Added
 
 - Bind tileController during the initialization of DefaultAudioVideoController for VideoPriorityBasedPolicy.
-- Add more debug logging for choose input device. 
+- Add more debug logging for choose input device.
 - Add the meeting and device error sections in the meeting-event guide.
-- Add a `forceUpdate` parameter to use when listing devices. In some cases, builders
-  need to delay the triggering of permission dialogs, _e.g._, when joining a
-  meeting in view-only mode, and then later be able to trigger a permission
-  prompt in order to show device labels. This parameter allows cached device
-  labels to be forcibly discarded and recomputed after the device label trigger
-  is run.
+- Add a `forceUpdate` parameter to use when listing devices. In some cases, builders need to delay the triggering of permission dialogs, *e.g.*, when joining a meeting in view-only mode, and then later be able to trigger a permission prompt in order to show device labels. This parameter allows cached device labels to be forcibly discarded and recomputed after the device label trigger is run.
 
 ### Changed
 
@@ -553,12 +570,14 @@ of videos.
 ## [2.6.2] - 2021-03-24
 
 ### Fixed
+
 - Calling `realtimeSetLocalAudioInput` as part of `AudioVideoController.restartLocalAudio()` to
   fix local mute/unmute issue while switching audio devices.
 
 ## [2.6.1] - 2021-03-17
 
 ### Fixed
+
 - Fix infinite loop when calling `chooseAudioInputDevice` with a
   `MediaDeviceInfo` instance.
 
@@ -592,10 +611,10 @@ of videos.
 - Don't automatically upgrade dev-dependencies to avoid a breaking typedoc upgrade.
 - Safely handle calling logger `debug` methods with `undefined`.
 
-
 ## [2.5.0] - 2021-02-16
 
 ### Added
+
 - Add GatheringICECandidate Finish Duration to Meeting Event and to demo app.
 - Add `attendeePresenceReceived`, `audioInputSelected`, `videoInputSelected`,
   `audioInputUnselected`, and `videoInputUnselected` meeting events.
@@ -605,11 +624,13 @@ of videos.
 - Add support for Chrome for iOS and Firefox for iOS.
 
 ### Changed
+
 - [Demo] Set `attendeePresenceTimeoutMs` to use value passed as parameter in the URL.
 
 ### Removed
 
 ### Fixed
+
 - `DefaultDeviceController` now attempts to resume a suspended `AudioContext`
   when choosing a transform device (#1062).
 - `DefaultVideoStreamIndex` now ignores old group IDs from a given attendee ID (#1029).
@@ -623,6 +644,7 @@ of videos.
 ### Removed
 
 ### Fixed
+
 - Disable reconnecting in AudioVideoControllerFacade's `stop` method.
   Add documentation for the `stop` method.
 - Fix dropped attendee presence during network reconnects.
@@ -631,6 +653,7 @@ of videos.
 ## [2.4.0] - 2021-01-08
 
 ### Added
+
 - Add support for Amazon Voice Focus support in Safari Technology Preview for macOS.
   Builders using an explicit revision or asset group must make sure to use a
   revision no earlier than this; an error will be thrown in Safari if older
@@ -1322,7 +1345,7 @@ of videos.
 - Add meeting demo parameter for recording user
 - Add a script demo to bundle Chime SDK into a single JS file
 - Add device demo
-- Add base infrastucture for demo app in react
+- Add base infrastructure for demo app in react
 - Add pricing link in README
 - Add an overview of API methods
 - Add IoT integration to device demo

--- a/script/version-utils.js
+++ b/script/version-utils.js
@@ -60,12 +60,14 @@ const updateChangelog = (newVersion) => {
   const filePath = path.resolve(__dirname, '../CHANGELOG.md');
   let changeLog = fs.readFileSync(filePath).toString();
   const latestEntryIndex = changeLog.indexOf('## [');
-  const newEntry = `## [${newVersion}] - ${new Date().toISOString().slice(0, 10)}
-    \n### Added
-    \n### Removed
-    \n### Changed
-    \n### Fixed
-    \n`;
+  const newEntry = [
+    [`## [${newVersion}] - ${new Date().toISOString().slice(0, 10)}`],
+    ['### Added'],
+    ['### Removed'],
+    ['### Changed'],
+    ['### Fixed'],
+    [''],
+  ].join('\n\n');
   changeLog = changeLog.substring(0, latestEntryIndex) + newEntry + changeLog.substring(latestEntryIndex);
   fs.writeFileSync(filePath, changeLog);
 };
@@ -76,7 +78,7 @@ const updateBaseBranch = (branchName) => {
   logger.log(`Updating the base branch in .base-branch to ${branchName}`);
   const filePath = path.resolve(__dirname, '../.base-branch');
   fs.writeFileSync(filePath, `origin/${branchName}`);
-}
+};
 
 const versionBump = async (option, branchName) => {
   process.chdir(path.join(__dirname, '..'));


### PR DESCRIPTION
**Issue #:**
* The format of CHANGELOG is not consistent.
* In the original script, it imports unnecessary tabs/spaces.
  https://github.com/aws/amazon-chime-sdk-js/blob/65aa2ccf431c873cb02730b9b62be25e985d8522/script/version-utils.js#L63-L68

**Description of changes:**
* Format the CHANGELOG to make the style consistent.
* Add blank line between `Heading`s and remove the unnecessary tabs/spaces in `version-utils.js` file.

**Testing:**

Confirm the updated logic works as expected.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

