### PR TITLE
Reset compression state during join request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a worker resource leak with `BackgroundBlurProcessor` and `BackgroundReplacementProcessor`.
 - Clone the video preference input in `chooseRemoteVideoSources` API in `VideoPriorityBasedPolicy` to avoid mutation
   that can cause video preferences to not be sorted and lead to wrong video subscription determination by the policy.
+- Fix a screen share issue by resetting the sdp compression state during join requests.
 
 ## [2.27.0] - 2022-01-27
     

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -39,7 +39,7 @@
       }
     },
     "../..": {
-      "version": "2.28.0",
+      "version": "2.29.0",
       "integrity": "sha512-80D5Q77ZQZrI2I6ndA6jMNprJydL4XuUcohXVb7c2V/pzLsUyLfwHKPF2/gaK3/gizUv0ZhXQa1Wa6iRIfS9BA==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/task/JoinAndReceiveIndexTask.ts
+++ b/src/task/JoinAndReceiveIndexTask.ts
@@ -106,6 +106,12 @@ export default class JoinAndReceiveIndexTask extends BaseTask {
       const interceptor = new IndexFrameInterceptor(this.context.signalingClient);
       this.context.signalingClient.registerObserver(interceptor);
       this.taskCanceler = interceptor;
+
+      // reset SDP compression state
+      this.context.previousSdpAnswerAsString = '';
+      this.context.previousSdpOffer = null;
+      this.context.serverSupportsCompression = false;
+
       this.context.signalingClient.join(
         new SignalingClientJoin(
           this.maxVideos,

--- a/test/task/JoinAndReceiveIndexTask.test.ts
+++ b/test/task/JoinAndReceiveIndexTask.test.ts
@@ -276,6 +276,9 @@ describe('JoinAndReceiveIndexTask', () => {
       expect(appName).to.eq('AmazonChimeJSSDKDemoApp');
       expect(appVersion).to.eq('1.0.0');
       expect(context.indexFrame).to.not.equal(null);
+      expect(context.previousSdpAnswerAsString).to.equal('');
+      expect(context.previousSdpOffer).to.equal(null);
+      expect(context.serverSupportsCompression).to.be.false;
       expect(context.turnCredentials.username).to.equal('fake-username');
       expect(context.turnCredentials.password).to.equal('fake-password');
       expect(context.turnCredentials.ttl).to.equal(300);


### PR DESCRIPTION
**Issue #:**
The content share feature establishes a new signaling connection (websocket connection), when we try to share a video. When we start a signaling connection, we record a previous SDP offer and previous SDP answer in the Application's [AudioVideoControllerState](https://github.com/aws/amazon-chime-sdk-js/blob/457dd7c1db9630817af92e9d170c994b8fa98b8f/src/audiovideocontroller/AudioVideoControllerState.ts#L34). As soon as we stop the video, we terminate the signaling connection but we do not clear the previous SDP offer and previous SDP Answer. Ideally, we should reset the previousSDPOffer and previousSDPAnswer during a Join request.

**Description of changes:**
This change resets the `previousSDPOffer`, `previousSDPAnswerAsString` and `serverSupportsCompression` states during the join negotiation.

**Testing:**
1. The change has been smoke tested against the production server.
2. Unit tests succeeded

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes.
1. Turn on the content share
2. Turn off the content share
3. Turn on the content share again

Expected
The content share should start again on the 3rd step.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Y

5. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N

6. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

