### PR TITLE
Separate mobile metrics from browser metrics

### DIFF
--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -34,7 +34,12 @@ class SdkBaseTest extends KiteBaseTest {
     this.originalURL = this.url;
     this.testReady = false;
     this.testFinish = false;
-    this.testName = testName;
+    if(kiteConfig.capabilities.platform == 'IOS' || kiteConfig.capabilities.platform == 'ANDROID') {
+      this.testName = 'Mobile_'+testName;
+    }
+    else {
+      this.testName = testName;
+    }
     this.useSimulcast = !!this.payload.useSimulcast;
     this.cwNamespaceInfix = this.payload.cwNamespaceInfix || '';
 


### PR DESCRIPTION
**Issue #:**
Mobile metrics are being mixed with our normal metrics
**Description of changes:**
Separated metrics
**Testing:**
Tested locally to test if affixes to test name properly.
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

