### PR TITLE
[release-2.x] Fix backward compatibility check (copy of #2077 merged in main)

### DIFF
--- a/.github/script/backward-compatibility-run-check.js
+++ b/.github/script/backward-compatibility-run-check.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/**
+ * This script simply checks whether the version we are releasing is either the first NPM version for any new major version or
+ * a beta version. For both, we do not want to run backward compatibility checks since both will have backward in-compatible breaking changes.
+ * 
+ * For e.g: 3.0.0, 3.0.0-beta.0, 4.0.0 and so on.
+ */
+ const { spawnOrFail } = require('../../script/cli-utils');
+
+ // eslint-disable-next-line @typescript-eslint/no-var-requires
+const versionToRelease = require('../../package.json').version;
+const preReleaseName = (spawnOrFail('node', ['.github/script/get-pre-release-name'], { skipOutput: true })).trim();
+
+// Check version to release if is a pre-release version or an first major version of a new major version.
+// This satisfies versions like: 3.0.0, 4.0.0, 3.0.0-beta.0, 3.0.0-beta.1
+if (versionToRelease.includes(preReleaseName)) {
+  console.log(`Skip backward compatibility checks for a pre release ${preReleaseName} version: ${versionToRelease}`);
+} else if ((/^[0-9]+\.0\.0$/g).test(versionToRelease)) {
+  console.log(`Skip backward compatibility checks for a new major version: ${versionToRelease}`);
+} else {
+  console.log(`Run backward compatibility checks to release ${versionToRelease}`);
+}

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -21,10 +21,25 @@ env:
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
 
 jobs:
+  check-backward-compatibility-run:
+    name: Check need for backward compatibility checks
+    runs-on: ubuntu-latest
+    outputs:
+      run-check: ${{ steps.version-check.outputs.run-check }}
+    steps:
+      - name: Checkout Package
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Version check for backward compatibility check
+        id: version-check
+        run: echo "::set-output name=run-check::$(node .github/script/backward-compatibility-run-check.js)"
+
   release-integ-test:
     name: Run Backwards Compatible Integration Tests with Release Tarball
     runs-on: ubuntu-latest
-
+    needs: check-backward-compatibility-run
+    if: contains(needs.check-backward-compatibility-run.outputs.run-check, 'Run backward compatibility checks')
     steps:
       - name: Setup Node.js - 16.x
         uses: actions/setup-node@v1
@@ -35,16 +50,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Pack the Chime SDK and install the tarball into the previous version Demo
-        run: |
-          current_version=$(.github/script/get-current-version)
-          echo "Packing current version:" $current_version
-          npm run build
-          npm pack
-          previousVersion=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1))
-          git checkout $previousVersion
-          cd ./demos/browser
-          npm uninstall amazon-chime-sdk-js
-          npm install ../../amazon-chime-sdk-js-$current_version.tgz
+        run: node script/backward-compatibility-demo-setup.js
       - name: Create a Job ID
         id: create-job-id
         uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c

--- a/script/backward-compatibility-demo-setup.js
+++ b/script/backward-compatibility-demo-setup.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/**
+ * This script sets up the amazon-chime-sdk-js new version release into the previous version release tagged demo so that we can run backward compatibility checks.
+ * Note that, this script will only be triggered if the new version release is not a beta version or not the first major version of a new major version.
+ * 
+ * For e.g: For 3.0.0, 3.0.0-beta.0, 4.0.0 and so on this script would not run and it will run when we release 2.29.0, 2.30.0, 3.1,0 and so on.
+ */
+ const { logger, spawnOrFail, path } = require('./cli-utils');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const versionToRelease = require('../package.json').version;
+logger.log(`We are releasing a new version: ${versionToRelease}`);
+
+logger.log('Building package...');
+spawnOrFail('npm', ['run build']);
+logger.log('Building done!');
+
+logger.log('Packaging...');
+spawnOrFail('npm', ['pack']);
+logger.log('Packaging done!');
+
+const previousRelease = (spawnOrFail('node', ['.github/script/get-prev-version'], { skipOutput: true })).trim();
+logger.log(`Previous release version: ${previousRelease}`);
+
+logger.log(`Checking out tags/v${previousRelease} for installing the new SDK version in previous release demo.`);
+spawnOrFail('git', [`fetch --all --tags`]);
+spawnOrFail('git', [`checkout tags/v${previousRelease}`]);
+
+logger.log(`Changing directory into demos/browser.`);
+process.chdir(path.join(__dirname, '../demos/browser'));
+
+logger.log(`Installing new ${versionToRelease} into ${previousRelease} browser demo.`);
+spawnOrFail('npm', ['uninstall amazon-chime-sdk-js']);
+spawnOrFail('npm', [`install ../../amazon-chime-sdk-js-${versionToRelease}.tgz`]);
+logger.log('Installing done.');


### PR DESCRIPTION
**Issue #:**
- Currently, for a `2.x` release the `release-backward-compatibility` workflow checks out the recent released tag (currently, `3.0.0-beta.0`) which is not intended as the major version release or beta releases intend to have breaking changes and hence do not make sense to run the backward compatibility changes in such cases.
- Copy of https://github.com/aws/amazon-chime-sdk-js/pull/2077 again `main` branch.

**Description of changes:**
- Fix backward compatibility checks to run only on valid minor and corresponding previous versions.
- For e.g: 2.28.0, then `release-backward-compatibility` workflow should run against a checked out `2.27.0` version.
- This check should be skipped we are releasing a beta version or the first major version of a new major version such as `3.0.0`, `4.0.0` and so on.
- We also do not run this checks for beta released like `3.0.0-beta.0` and so on.

**Testing:**
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Tested locally and changing the workflow to run on `pull_request`.
- Tested the added scripts locally as well as part of the above point testing multiple times.
- This is a Ops change and has not functional testing steps.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

