### PR TITLE
Adjust the recovery behavior of `VideoPriorityBasedPolicy` (#1999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
     
 ### Changed
-    
+- Adjust the recovery behavior of `VideoPriorityBasedPolicy` to not get stuck at low estimates, not overeact to spurious packet loss when probing, and not let the time between probes raise to 60 seconds (reduced to maximum of 30 seconds).
+
 ### Fixed
     
 ## [2.29.0] - 2022-03-10

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#defaultvideopreferences">defaultVideoPreferences</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L68">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L78">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#observerqueue">observerQueue</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L72">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L82">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#shouldpausetiles">shouldPauseTiles</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L69">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L79">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#tilecontroller">tileController</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L66">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L76">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#videoindex">videoIndex</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L70">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L80">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#videopreferences">videoPreferences</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L67">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L77">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#videopreferencesupdated">videoPreferencesUpdated</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L71">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L81">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L247">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:247</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -285,7 +285,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#bindtotilecontroller">bindToTileController</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L132">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L145">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L377">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L390">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:390</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceivestreams">calculateOptimalReceiveStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L252">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L265">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:265</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -377,7 +377,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L225">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L238">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -395,7 +395,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L242">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L255">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -438,7 +438,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L238">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L251">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setvideoprioritybasedpolicyconfigs">setVideoPriorityBasedPolicyConfigs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L248">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L261">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:261</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -530,7 +530,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L182">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L195">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:195</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -555,7 +555,7 @@
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L220">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L233">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:233</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L97">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L110">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:110</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Video<wbr>Preferences<span class="tsd-signature-symbol">:</span> <a href="videopreferences.html" class="tsd-signature-type">VideoPreferences</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L68">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L78">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="../interfaces/logger.html" class="tsd-signature-type">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L100">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L113">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:113</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">observer<wbr>Queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/videodownlinkobserver.html" class="tsd-signature-type">VideoDownlinkObserver</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = new Set&lt;VideoDownlinkObserver&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L72">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L82">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">should<wbr>Pause<wbr>Tiles<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L69">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L79">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">tile<wbr>Controller<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videotilecontroller.html" class="tsd-signature-type">VideoTileController</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L66">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L76">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:76</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Index<span class="tsd-signature-symbol">:</span> <a href="../interfaces/videostreamindex.html" class="tsd-signature-type">VideoStreamIndex</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L70">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L80">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:80</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Preferences<span class="tsd-signature-symbol">:</span> <a href="videopreferences.html" class="tsd-signature-type">VideoPreferences</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L67">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L77">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:77</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">video<wbr>Preferences<wbr>Updated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L71">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L81">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -254,7 +254,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L234">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:234</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L247">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:247</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L132">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L145">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:145</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L377">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L390">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:390</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L252">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L265">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:265</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L140">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L153">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:153</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L225">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L238">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:238</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/videostreamidset.html" class="tsd-signature-type">VideoStreamIdSet</a></h4>
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L242">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L255">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -417,7 +417,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L238">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:238</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L251">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:251</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -441,7 +441,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L106">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L119">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -458,7 +458,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L248">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L261">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:261</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -482,7 +482,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L152">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:152</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L165">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:165</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L182">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L195">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:195</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -529,7 +529,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L220">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:220</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L233">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:233</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -60,8 +60,18 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
   private static readonly LOW_BITRATE_THRESHOLD_KBPS = 300;
   private static readonly MIN_TIME_BETWEEN_PROBE_MS = 5000;
   private static readonly MIN_TIME_BETWEEN_SUBSCRIBE_MS = 2000;
-  private static readonly MAX_HOLD_BEFORE_PROBE_MS = 60000;
+  // We apply exponentional backoff to probe attempts if they do not
+  // succeed, so we need to set a reasonable maximum.
+  private static readonly MAX_HOLD_BEFORE_PROBE_MS = 30000;
   private static readonly MAX_ALLOWED_PROBE_TIME_MS = 60000;
+  // Occasionally we see that on unpause or upgrade we see a single packet lost
+  // or two, even in completely unconstrained scenarios. We should look into
+  // why this occurs on the backend, but for now we require a non-trivial
+  // amount of packets lost to fail the probe. These could also be from
+  // other senders given we don't yet use TWCC.
+  private static readonly SPURIOUS_PACKET_LOST_THRESHOLD = 2;
+  // See usage
+  private static readonly USED_BANDWIDTH_OVERRIDE_BUFFER_KBPS = 100;
 
   protected tileController: VideoTileController | undefined;
   protected videoPreferences: VideoPreferences | undefined;
@@ -87,6 +97,9 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
   private startupPeriod: boolean;
   private usingPrevTargetRate: boolean;
   private prevTargetRateKbps: number;
+  // A target rate baseline to use to avoid changing the subscriptions until we see
+  // a `TARGET_RATE_CHANGE_TRIGGER_PERCENT` change between this and the current target rate
+  private targetRateBaselineForDeltaCheckKbps: number;
   private lastUpgradeRateKbps: number;
   private firstEstimateTimestamp: number;
   private lastSubscribeTimestamp: number;
@@ -427,7 +440,24 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
       if (this.startupPeriod) {
         targetBitrate = VideoPriorityBasedPolicy.DEFAULT_BANDWIDTH_KBPS;
       } else {
-        targetBitrate = this.downlinkStats.bandwidthEstimateKbps;
+        // We rely on our target bitrate being above what we are receiving to mark a probe as complete,
+        // however in browsers, the estimate can heavily lag behind the actual receive rate, especially when low.
+        //
+        // To mitigate this we override with the actual estimate plus some buffer if we aren't seeing packet loss.
+        if (
+          this.rateProbeState === RateProbeState.Probing &&
+          this.downlinkStats.usedBandwidthKbps > this.downlinkStats.bandwidthEstimateKbps &&
+          this.downlinkStats.packetsLost < VideoPriorityBasedPolicy.SPURIOUS_PACKET_LOST_THRESHOLD
+        ) {
+          this.logger.info(
+            `bwe: In probe state, overriding estimate ${this.downlinkStats.bandwidthEstimateKbps} with actual receive bitrate ${this.downlinkStats.usedBandwidthKbps}`
+          );
+          targetBitrate =
+            this.downlinkStats.usedBandwidthKbps +
+            VideoPriorityBasedPolicy.USED_BANDWIDTH_OVERRIDE_BUFFER_KBPS;
+        } else {
+          targetBitrate = this.downlinkStats.bandwidthEstimateKbps;
+        }
       }
     } else {
       if (this.firstEstimateTimestamp === 0) {
@@ -552,31 +582,33 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     }
 
     if (this.downlinkStats.packetsLost > 0) {
-      this.setProbeState(RateProbeState.NotProbing);
-      this.logger.info(`bwe: Canceling probe due to network loss`);
-      this.probeFailed = true;
-      this.timeBeforeAllowSubscribeMs =
-        Math.max(
-          VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_SUBSCRIBE_MS,
-          this.timeBeforeAllowSubscribeMs
-        ) * 3;
-      // packet lost indicates bad network and thus slowing down subscribing by extend delay by 3 times
-      return UseReceiveSet.PreProbe;
+      this.logger.info(`bwe: Probe encountering packets lost:${this.downlinkStats.packetsLost}`);
+      // See comment above `VideoPriorityBasedPolicy.SPURIOUS_PACKET_LOST_THRESHOLD`
+      if (
+        this.downlinkStats.packetsLost > VideoPriorityBasedPolicy.SPURIOUS_PACKET_LOST_THRESHOLD
+      ) {
+        this.setProbeState(RateProbeState.NotProbing);
+        this.logger.info(
+          `bwe: Canceling probe due to packets lost:${this.downlinkStats.packetsLost}`
+        );
+        this.probeFailed = true;
+        this.timeBeforeAllowSubscribeMs =
+          Math.max(
+            VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_SUBSCRIBE_MS,
+            this.timeBeforeAllowSubscribeMs
+          ) * 3;
+        // packet lost indicates bad network and thus slowing down subscribing by extend delay by 3 times
+        return UseReceiveSet.PreProbe;
+      }
     }
     const subscribedRate = this.calculateSubscribeRate(this.optimalReceiveStreams);
     if (this.chosenStreamsSameAsLast(chosenStreams) || targetDownlinkBitrate > subscribedRate) {
-      let avgRate = 0;
-      for (const chosenStream of chosenStreams) {
-        avgRate += chosenStream.avgBitrateKbps;
-      }
-      if (targetDownlinkBitrate > avgRate) {
-        this.logger.info(`bwe: Probe successful`);
-        // If target bitrate can sustain probe rate, then probe was successful.
-        this.setProbeState(RateProbeState.NotProbing);
-        // Reset the time allowed between probes since this was successful
-        this.timeBeforeAllowProbeMs = VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_PROBE_MS;
-        return UseReceiveSet.NewOptimal;
-      }
+      this.logger.info(`bwe: Probe successful`);
+      // If target bitrate can sustain probe rate, then probe was successful.
+      this.setProbeState(RateProbeState.NotProbing);
+      // Reset the time allowed between probes since this was successful
+      this.timeBeforeAllowProbeMs = VideoPriorityBasedPolicy.MIN_TIME_BETWEEN_PROBE_MS;
+      return UseReceiveSet.NewOptimal;
     }
 
     return UseReceiveSet.PreviousOptimal;
@@ -598,9 +630,14 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
         ? VideoPriorityBasedPolicy.TARGET_RATE_CHANGE_TRIGGER_PERCENT
         : VideoPriorityBasedPolicy.TARGET_RATE_CHANGE_TRIGGER_PERCENT * 2;
     const minTargetBitrateDelta = (rates.targetDownlinkBitrate * triggerPercent) / 100;
+    this.targetRateBaselineForDeltaCheckKbps =
+      this.targetRateBaselineForDeltaCheckKbps !== undefined
+        ? this.targetRateBaselineForDeltaCheckKbps
+        : this.prevTargetRateKbps;
     if (
       !sameSubscriptions &&
-      Math.abs(rates.targetDownlinkBitrate - this.prevTargetRateKbps) < minTargetBitrateDelta
+      Math.abs(rates.targetDownlinkBitrate - this.targetRateBaselineForDeltaCheckKbps) <
+        minTargetBitrateDelta
     ) {
       this.logger.info(
         'bwe: MaybeOverrideOrProbe: Reuse last decision based on delta rate. {' +
@@ -608,6 +645,8 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
           `}`
       );
       useLastSubscriptions = UseReceiveSet.PreviousOptimal;
+    } else {
+      this.targetRateBaselineForDeltaCheckKbps = rates.targetDownlinkBitrate;
     }
 
     // If there has been packet loss, then reset to no probing state

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -134,7 +134,8 @@ describe('VideoPriorityBasedPolicy', () => {
     metricReport: DefaultClientMetricReport,
     nackCnt: number,
     packetsLost: number,
-    isGoogStat: boolean = true
+    isGoogStat: boolean = true,
+    usedBandwidthKbps: number = 10
   ): void {
     metricReport.currentTimestampMs = 2000;
     metricReport.previousTimestampMs = 1000;
@@ -151,7 +152,7 @@ describe('VideoPriorityBasedPolicy', () => {
     }
     streamReport1.previousMetrics['packetsLost'] = 0;
     streamReport1.currentMetrics['packetsLost'] = packetsLost;
-    streamReport1.currentMetrics['bytesReceived'] = 200;
+    streamReport1.currentMetrics['bytesReceived'] = usedBandwidthKbps * 1000;
 
     metricReport.streamMetricReports[1] = streamReport1;
   }
@@ -554,8 +555,9 @@ describe('VideoPriorityBasedPolicy', () => {
       expect(resub).to.equal(false);
 
       incrementTime(2000);
-      metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 1100 * 1000;
-      setPacketLoss(metricReport, 0, 0);
+      metricReport.globalMetricReport.currentMetrics['googAvailableReceiveBandwidth'] = 750 * 1000;
+      // Override with used kbps in this case and put packet loss below threshold
+      setPacketLoss(metricReport, 0, 1, true, 1100);
       policy.updateMetrics(metricReport);
       const bitrates = updateBitrateFrame(2, 200, 1100);
       videoStreamIndex.integrateBitratesFrame(bitrates);


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
Cherry picking https://github.com/aws/amazon-chime-sdk-js/pull/1999 . Unfortunate timing of the release branch being cut and the seperate 2.x and 3.x branches meant this didn't actually end up in 2.27.

**Testing:**

See https://github.com/aws/amazon-chime-sdk-js/pull/1999


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

