### PR TITLE
Upgrade AWS JS SDK to 2.1088.0

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-chime-sdk-messaging": "^3.47.0",
         "amazon-chime-sdk-js": "file:../..",
-        "aws-sdk": "^2.1034.0",
+        "aws-sdk": "^2.1088.0",
         "bootstrap": "^4.5.2",
         "compression": "^1.7.4",
         "jquery": "^3.5.1",
@@ -6098,13 +6098,14 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1034.0",
-      "license": "Apache-2.0",
+      "version": "2.1088.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
+      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -8901,7 +8902,9 @@
       }
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -16312,12 +16315,14 @@
       "version": "1.0.5"
     },
     "aws-sdk": {
-      "version": "2.1034.0",
+      "version": "2.1088.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
+      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -18110,7 +18115,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0"
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "jquery": {
       "version": "3.5.1"

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aws-sdk/client-chime-sdk-messaging": "^3.47.0",
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.1034.0",
+    "aws-sdk": "^2.1088.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/demos/serverless/src/package-lock.json
+++ b/demos/serverless/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "aws-embedded-metrics": "^2.0.4",
-        "aws-sdk": "^2.1034.0",
+        "aws-sdk": "^2.1088.0",
         "uuid": "^8.3.2"
       }
     },
@@ -23,14 +23,14 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1044.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1044.0.tgz",
-      "integrity": "sha512-n55uGUONQGXteGGG1QlZ1rKx447KSuV/x6jUGNf2nOl41qMI8ZgLUhNUt0uOtw3qJrCTanzCyR/JKBq2PMiqEQ==",
+      "version": "2.1088.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
+      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -98,9 +98,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -166,14 +166,14 @@
       "integrity": "sha512-b4+3BC8e3DE3HdZkmzlozvS8wU45w9M+4eAd2R4Z62N+ihiCuwndEh15Yj/scCKRq/FTO3rfKnzlvUMsuJtzLg=="
     },
     "aws-sdk": {
-      "version": "2.1044.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1044.0.tgz",
-      "integrity": "sha512-n55uGUONQGXteGGG1QlZ1rKx447KSuV/x6jUGNf2nOl41qMI8ZgLUhNUt0uOtw3qJrCTanzCyR/JKBq2PMiqEQ==",
+      "version": "2.1088.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
+      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -219,9 +219,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "punycode": {
       "version": "1.3.2",

--- a/demos/serverless/src/package.json
+++ b/demos/serverless/src/package.json
@@ -4,7 +4,7 @@
   "description": "Amazon Chime SDK JavaScript Serverless Demos Lambda Handler",
   "dependencies": {
     "aws-embedded-metrics": "^2.0.4",
-    "aws-sdk": "^2.1034.0",
+    "aws-sdk": "^2.1088.0",
     "uuid": "^8.3.2"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Upgrade AWS JS SDK to 2.1088.0 - https://github.com/aws/aws-sdk-js/releases/tag/v2.1088.0.

We added support for Transcribe language identification feature to the StartMeetingTranscription API in `v2.1088.0` - 
https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#210880

Upgrading the AWS SDK so demo server-less is able to call `StartMeetingTranscription` with additional parameters.

**Testing:**
Refer - https://github.com/aws/amazon-chime-sdk-js/pull/2087
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Refer - https://github.com/aws/amazon-chime-sdk-js/pull/2087

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

