### PR TITLE
Update publish github workflow to remove useless if check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,13 +96,5 @@ jobs:
         run: |
           demo_current_version=$(.github/script/get-demo-browser-current-version)
           echo "Current demo version: " $demo_current_version
-          echo "Current released npm version:" ${{ steps.npm_version.outputs.npm_version }}
-          if [[ *$demo_current_version* != "^#${{ steps.npm_version.outputs.npm_version }}" ]];
-          then
-            echo "Demo npm version is not the same as the current released version"
-            exit 1
-          else
-            npm run build --app=meetingReadinessChecker
-            script/github-action-awscli-installation
-            node ./.github/script/call-canary-deploy-demo-prod $demo_current_version
-          fi
+          script/github-action-awscli-installation
+          node ./.github/script/call-canary-deploy-demo-prod $demo_current_version


### PR DESCRIPTION
**Issue #:**
Publish workflow failed due to buggy if check: https://github.com/aws/amazon-chime-sdk-js/actions/runs/1966093922
**Description of changes:**
Removing the if check as it is not needed.
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

