### PR TITLE
Added IOS audio tests

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -203,6 +203,15 @@ class SaucelabsSession {
       .withCapabilities(cap)
       .forBrowser(capabilities.browserName)
       .build();
+
+    // Selenium is supposed to have a default timeout of 30 seconds, but on IOS Safari
+    // it is undefined. This will override the timeout in this case or any similar cases.
+    const defaultTimeout = 30000;
+    let timeouts = await driver.manage().getTimeouts()
+    if (timeouts.script == undefined || timeouts.script < defaultTimeout) {
+      await driver.manage().setTimeouts({script: defaultTimeout})
+    }
+    
     return new SaucelabsSession(driver, domain, appName);
   }
   constructor(inDriver, domain, appName) {


### PR DESCRIPTION
**Issue #:**
IOS audio tests fail from a selenium script timeout error. This is because currently for IOS Safari the script timeout is by default undefined which results in our asynchronous script being timeout instantly.
**Description of changes:**
Override the default script timeout for selenium which fixes IOS audio tests
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

