### PR TITLE
Update migration document to callout beta installation

### DIFF
--- a/docs/modules/migrationto_3_0.html
+++ b/docs/modules/migrationto_3_0.html
@@ -77,7 +77,10 @@
 						<h2>Installation</h2>
 					</a>
 					<p>Installation involves adjusting your <code>package.json</code> to depend on version <code>3.0.0</code>.</p>
-					<pre><code class="language-shell">npm install --save amazon-chime-sdk-js@3
+					<pre><code class="language-shell">npm install amazon-chime-sdk-js@3
+</code></pre>
+					<p>Note that, currently only pre-release NPM versions of <code>3.0.0</code> are available until we do the final major version release. Do the following step to install the latest beta version for <code>amazon-chime-sdk-js</code>:</p>
+					<pre><code class="language-shell">npm install amazon-chime-sdk-js@beta
 </code></pre>
 					<p><strong>Version 3 of the Amazon Chime SDK for JavaScript makes a number of interface changes.</strong></p>
 					<p><strong>In many cases you should not need to adjust your application code at all. This will be the case if:</strong></p>

--- a/guides/17_Migration_to_3_0.md
+++ b/guides/17_Migration_to_3_0.md
@@ -5,7 +5,13 @@
 Installation involves adjusting your `package.json` to depend on version `3.0.0`.
 
 ```shell
-npm install --save amazon-chime-sdk-js@3
+npm install amazon-chime-sdk-js@3
+```
+
+Note that, currently only pre-release NPM versions of `3.0.0` are available until we do the final major version release. Do the following step to install the latest beta version for `amazon-chime-sdk-js`:
+
+```shell
+npm install amazon-chime-sdk-js@beta
 ```
 
 __Version 3 of the Amazon Chime SDK for JavaScript makes a number of interface changes.__


### PR DESCRIPTION
**Issue #:**
#2125 

**Description of changes:**
- Add a note that currently only pre-release versions are available on NPM for JS SDK.

**Testing:**
- Just doc change.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

