### PR TITLE
Add PrevMajorVersion infix to the test name

### DIFF
--- a/integration/js/utils/SdkBaseTest.js
+++ b/integration/js/utils/SdkBaseTest.js
@@ -50,7 +50,19 @@ class SdkBaseTest extends KiteBaseTest {
     if (this.useVideoProcessor) {
       this.testName += 'Processor';
     }
-    this.capabilities['name'] = process.env.STAGE !== undefined ? `${this.testName}-${process.env.TEST_TYPE}-${process.env.STAGE}` : `${this.testName}-${process.env.TEST_TYPE}`;
+    if(process.env.STAGE !== undefined) {
+      if(this.cwNamespaceInfix !== '')  {
+        this.capabilities['name'] = `${this.testName}-${this.cwNamespaceInfix}-${process.env.TEST_TYPE}-${process.env.STAGE}`;
+      } else  {
+        this.capabilities['name'] = `${this.testName}-${process.env.TEST_TYPE}-${process.env.STAGE}`;
+      }
+    } else  {
+      if(this.cwNamespaceInfix !== '')  {
+        this.capabilities['name'] = `${this.testName}-${this.cwNamespaceInfix}-${process.env.TEST_TYPE}`;
+      } else  {
+        this.capabilities['name'] = `${this.testName}-${process.env.TEST_TYPE}`;
+      }
+    }
     this.seleniumSessions = [];
     this.timeout = this.payload.testTimeout ? this.payload.testTimeout : 60;
     if (this.numberOfParticipant > 1) {


### PR DESCRIPTION
**Issue #:**
Latest and previous major version (PMV) tests are hard to distinguish in SauceLabs. Same as #2132 
**Description of changes:**
Adding `cwNamespaceInfix` to the test name if the test is PMV.
**Testing:**
Ran a test locally to verify the name in saucelabs
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

