### PR TITLE
Fix issue when video reach capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `chooseAudioInputDevice` to explicit APIs `startAudioInput` and `stopAudioInput`. Application will need to
   call `stopVideoInput` at the end of the call to explicitly stop active audio stream.
 - Change `chooseVideoInputDevice` to explicit APIs `startVideoInput` and `stopVideoInput`. Application will need to 
-  call `stopVideoInput` now to explicitly stop active video stream. 
+  call `stopVideoInput` now to explicitly stop active video stream.
 - Minor name change to `chooseAudioOutputDevice` to `chooseAudioOutput`.
 - `startVideoPreviewForVideoInput` and `stopVideoPreviewForVideoInput` will no longer turn on and off video stream. 
   This allows applications to join meeting without reselecting video again.

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -3601,20 +3601,20 @@ export class DemoMeetingApp
     const didChange = this.canStartLocalVideo !== availability.canStartLocalVideo;
     this.canStartLocalVideo = availability.canStartLocalVideo;
     this.log(`video availability changed: canStartLocalVideo  ${availability.canStartLocalVideo}`);
-    if (didChange && !this.canStartLocalVideo) {
-      this.disableLocalVideo('Can no longer enable local video in conference');
-    } else if (didChange && this.buttonStates['button-camera'] === 'disabled') {
-      // Enable ability to press button again
-      this.toggleButton('button-camera', 'off');
+    if (didChange && !this.meetingSession.audioVideo.hasStartedLocalVideoTile()) {
+      if (!this.canStartLocalVideo) {
+        this.enableLocalVideoButton(false, 'Can no longer enable local video in conference.');
+      } else {
+        // Enable ability to press button again
+        this.enableLocalVideoButton(true, 'You can now enable local video in conference.');
+      }
     }
   }
 
-  private disableLocalVideo(warningMessage: string = null): void {
-    this.toggleButton('button-camera', 'disabled');
+  private enableLocalVideoButton(enabled: boolean, warningMessage: string = ''): void {
+    this.toggleButton('button-camera', enabled? 'off' : 'disabled');
 
-    this.audioVideo.stopLocalVideoTile();
-
-    if (warningMessage !== null) {
+    if (warningMessage) {
       const toastContainer = document.getElementById('toast-container');
       const toast = document.createElement('meeting-toast') as MeetingToast
       toastContainer.appendChild(toast);
@@ -3645,7 +3645,7 @@ export class DemoMeetingApp
 
   videoSendDidBecomeUnavailable(): void {
     this.log('sending video is not available');
-    this.disableLocalVideo('Cannot enable local video due to call being at capacity');
+    this.enableLocalVideoButton(false,'Cannot enable local video due to call being at capacity');
   }
 
   contentShareDidStart(): void {

--- a/docs/interfaces/audiovideocontroller.html
+++ b/docs/interfaces/audiovideocontroller.html
@@ -629,7 +629,7 @@
 								<li>
 									<h5>audioStream: <span class="tsd-signature-type">MediaStream</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p>The video stream to be replaced with</p>
+										<p>The audio stream to be replaced with</p>
 									</div>
 								</li>
 							</ul>

--- a/src/audiovideocontroller/AudioVideoController.ts
+++ b/src/audiovideocontroller/AudioVideoController.ts
@@ -46,7 +46,7 @@ export default interface AudioVideoController extends AudioVideoControllerFacade
   /**
    * Restarts the local audio. This function assumes the peer connection is established and an active
    * audio stream must be chosen in [[DeviceController]]
-   * @param audioStream - The video stream to be replaced with
+   * @param audioStream - The audio stream to be replaced with
    */
   replaceLocalAudio(audioStream: MediaStream): Promise<void>;
 


### PR DESCRIPTION
**Issue #:**
- This is a demo issue when video capacity is reached we try to stop local video tile when the user already shared video. Thus, causing all videos in the meeting to stop.

**Description of changes:**
- Change it to only show the toast message and disable video button if users have not share video yet.
- Fix a minor typo in documentation.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Turn on 25 videos
- Make sure you receive the toast notification that you can no longer share video if you have not shared video only.
- Verify all 25 videos appear.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

