### PR TITLE
[Demo] Handle external camera unplugged in demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1613,6 +1613,10 @@ export class DemoMeetingApp
 
   videoInputStreamEnded(deviceId: string): void {
     this.log(`Current video input stream from device id ${deviceId} ended.`);
+    if (this.buttonStates['button-camera'] === 'on') { // Video input is ended, update button state
+      this.buttonStates['button-camera'] = 'off';
+      this.displayButtonStates();
+    }
   }
 
   estimatedDownlinkBandwidthLessThanRequired(
@@ -3028,7 +3032,7 @@ export class DemoMeetingApp
       }
     }
 
-    if (value === 'None') {
+    if (value === 'None' || value === '') {
       return null;
     }
 


### PR DESCRIPTION
**Description of changes:**
- Turn off the camera button if a video input ended (such as when an external camera is unplugged).
- Handle the case when there is no audio permission or no mic, change '' value to null audio device to be able to join meeting (otherwise, we will receive error from getUserMedia for '' deviceId).

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
First fix:
- Join a meeting and turn on an external camera
- Unplug the camera
- Verify that the camera button is off
- Turn on an internal camera
- Verify that video is on
Second fix
- Join a meeting with no mic (or close your laptop and just use external monitor).
- Verify that you can join a meeting and show up in the roster.


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

