### PR TITLE
Fix join with no audio when WebAudio is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix a bug where joining without selecting any audio device failed when Web Audio is enabled.
+- Fix a minor log info for video input ended event where we say resetting to null device when we just stop the video 
+  input.
 
 ## [3.0.0-beta.2] - 2022-03-09
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -110,6 +110,10 @@
               <label for="preconnect" class="custom-control-label">Open signaling connection early</label>
             </div>
             <div class="custom-control custom-checkbox" style="text-align: left;">
+              <input type="checkbox" id="join-view-only" class="custom-control-input">
+              <label for="join-view-only" class="custom-control-label">Join with view-only mode</label>
+            </div>
+            <div class="custom-control custom-checkbox" style="text-align: left;">
               <input type="checkbox" id="pause-last-frame" class="custom-control-input">
               <label for="pause-last-frame" class="custom-control-label">Keep Video Last Frame When Paused</label>
             </div>

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L576">src/devicecontroller/DefaultDeviceController.ts:576</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L591">src/devicecontroller/DefaultDeviceController.ts:591</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -249,7 +249,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L572">src/devicecontroller/DefaultDeviceController.ts:572</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L581">src/devicecontroller/DefaultDeviceController.ts:581</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1508">src/devicecontroller/DefaultDeviceController.ts:1508</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1501">src/devicecontroller/DefaultDeviceController.ts:1501</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -439,7 +439,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1388">src/devicecontroller/DefaultDeviceController.ts:1388</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1381">src/devicecontroller/DefaultDeviceController.ts:1381</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -553,7 +553,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mutelocalaudioinputstream">muteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L674">src/devicecontroller/DefaultDeviceController.ts:674</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L689">src/devicecontroller/DefaultDeviceController.ts:689</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1512">src/devicecontroller/DefaultDeviceController.ts:1512</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1505">src/devicecontroller/DefaultDeviceController.ts:1505</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -786,7 +786,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#unmutelocalaudioinputstream">unmuteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L678">src/devicecontroller/DefaultDeviceController.ts:678</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L693">src/devicecontroller/DefaultDeviceController.ts:693</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -803,7 +803,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1497">src/devicecontroller/DefaultDeviceController.ts:1497</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1490">src/devicecontroller/DefaultDeviceController.ts:1490</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -820,7 +820,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L741">src/devicecontroller/DefaultDeviceController.ts:741</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L756">src/devicecontroller/DefaultDeviceController.ts:756</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -837,7 +837,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1483">src/devicecontroller/DefaultDeviceController.ts:1483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1476">src/devicecontroller/DefaultDeviceController.ts:1476</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -854,7 +854,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L699">src/devicecontroller/DefaultDeviceController.ts:699</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L714">src/devicecontroller/DefaultDeviceController.ts:714</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -877,7 +877,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L745">src/devicecontroller/DefaultDeviceController.ts:745</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L760">src/devicecontroller/DefaultDeviceController.ts:760</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -1032,7 +1032,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1567">src/devicecontroller/DefaultDeviceController.ts:1567</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1560">src/devicecontroller/DefaultDeviceController.ts:1560</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/audiovideofacade.html
+++ b/docs/interfaces/audiovideofacade.html
@@ -2050,7 +2050,7 @@
 								<div class="lead">
 									<p>Selects an audio input device to use. The constraint may be a device id,
 										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing audio track), or <code>null</code> to
-										indicate no device. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
+										generate a dummy audio stream. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
 									constraints used or to apply Web Audio transforms.</p>
 								</div>
 								<p>The promise will resolve indicating success or it will throw an appropriate error
@@ -2162,9 +2162,9 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Selects a video input device to use. The constraint may be a device id,
-										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track), or <code>null</code> to
-										indicate no device. The promise will resolve indicating success or it will
-									throw an appropriate error indicating the failure.</p>
+										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track). It may also be an <a href="videotransformdevice.html">VideoTransformDevice</a>
+										to apply video transform.
+									The promise will resolve indicating success or it will throw an appropriate error indicating the failure.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2309,8 +2309,8 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Stop the current audio input. This needs to be called to clear out to stop the current video input resources
-									such as audio stream from camera.</p>
+									<p>Stop the current video input. This needs to be called to clear out to stop the current video input resources
+									such as video stream from camera.</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/interfaces/devicecontroller.html
+++ b/docs/interfaces/devicecontroller.html
@@ -100,8 +100,8 @@
 					<p>When you are done using a <code>DeviceController</code>, you should perform some
 					cleanup steps in order to avoid memory leaks:</p>
 					<ol>
-						<li>Deselect any audio input or output devices by calling
-						<a href="devicecontroller.html#startaudioinput">DeviceController.startAudioInput</a> and <a href="devicecontroller.html#chooseaudiooutput">DeviceController.chooseAudioOutput</a> with <code>null</code>.</li>
+						<li>Deselect any audio input or video input devices by calling
+						<a href="devicecontroller.html#stopaudioinput">DeviceController.stopAudioInput</a> and <a href="devicecontroller.html#stopvideoinput">DeviceController.stopVideoInput</a>.</li>
 						<li>Remove any device change observers that you registered by using
 						<a href="devicecontroller.html#removedevicechangeobserver">DeviceController.removeDeviceChangeObserver</a>.</li>
 						<li>Drop your reference to the controller to allow it to be garbage collected.</li>
@@ -523,7 +523,7 @@
 								<div class="lead">
 									<p>Selects an audio input device to use. The constraint may be a device id,
 										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing audio track), or <code>null</code> to
-										indicate no device. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
+										generate a dummy audio stream. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
 									constraints used or to apply Web Audio transforms.</p>
 								</div>
 								<p>The promise will resolve indicating success or it will throw an appropriate error
@@ -555,9 +555,9 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Selects a video input device to use. The constraint may be a device id,
-										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track), or <code>null</code> to
-										indicate no device. The promise will resolve indicating success or it will
-									throw an appropriate error indicating the failure.</p>
+										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track). It may also be an <a href="videotransformdevice.html">VideoTransformDevice</a>
+										to apply video transform.
+									The promise will resolve indicating success or it will throw an appropriate error indicating the failure.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -640,8 +640,8 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Stop the current audio input. This needs to be called to clear out to stop the current video input resources
-									such as audio stream from camera.</p>
+									<p>Stop the current video input. This needs to be called to clear out to stop the current video input resources
+									such as video stream from camera.</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/interfaces/devicecontrollerbasedmediastreambroker.html
+++ b/docs/interfaces/devicecontrollerbasedmediastreambroker.html
@@ -674,7 +674,7 @@
 								<div class="lead">
 									<p>Selects an audio input device to use. The constraint may be a device id,
 										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing audio track), or <code>null</code> to
-										indicate no device. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
+										generate a dummy audio stream. It may also be an <a href="audiotransformdevice.html">AudioTransformDevice</a> to customize the
 									constraints used or to apply Web Audio transforms.</p>
 								</div>
 								<p>The promise will resolve indicating success or it will throw an appropriate error
@@ -707,9 +707,9 @@
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Selects a video input device to use. The constraint may be a device id,
-										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track), or <code>null</code> to
-										indicate no device. The promise will resolve indicating success or it will
-									throw an appropriate error indicating the failure.</p>
+										<code>MediaTrackConstraint</code>, <code>MediaStream</code> (containing video track). It may also be an <a href="videotransformdevice.html">VideoTransformDevice</a>
+										to apply video transform.
+									The promise will resolve indicating success or it will throw an appropriate error indicating the failure.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -795,8 +795,8 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Stop the current audio input. This needs to be called to clear out to stop the current video input resources
-									such as audio stream from camera.</p>
+									<p>Stop the current video input. This needs to be called to clear out to stop the current video input resources
+									such as video stream from camera.</p>
 								</div>
 							</div>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/modules/migrationto_3_0.html
+++ b/docs/modules/migrationto_3_0.html
@@ -102,10 +102,10 @@
 					<pre><code class="language-js"><span class="hljs-keyword">const</span> observer = {
   <span class="hljs-attr">audioVideoDidStop</span>: <span class="hljs-keyword">async</span> sessionStatus =&gt; {
     <span class="hljs-comment">// v3</span>
-    <span class="hljs-keyword">await</span> meetingSession.audioVideo.stopVideoInput();
+    <span class="hljs-keyword">await</span> meetingSession.audioVideo.stopAudioInput();
 
     <span class="hljs-comment">// Or use the destroy API to call stopAudioInput and stopVideoInput.</span>
-    meetingSession.audioVideo.deviceController.destroy()
+    meetingSession.deviceController.destroy();
   },
 };
 meetingSession.audioVideo.addObserver(observer);
@@ -123,7 +123,10 @@ meetingSession.audioVideo.addObserver(observer);
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.startVideoInput(videoInputDeviceInfo.deviceId);
 </code></pre>
 					<p>In v3, you should call <code>stopVideoInput</code> to stop the video input stream.</p>
-					<pre><code class="language-js"><span class="hljs-comment">// v3</span>
+					<pre><code class="language-js"><span class="hljs-comment">// Before</span>
+<span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseVideoInputDevice(<span class="hljs-literal">null</span>);
+
+<span class="hljs-comment">// After</span>
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.stopVideoInput();
 </code></pre>
 					<a href="#updates-to-the-audio-output-api" id="updates-to-the-audio-output-api" style="color: inherit; text-decoration: none;">

--- a/guides/17_Migration_to_3_0.md
+++ b/guides/17_Migration_to_3_0.md
@@ -38,10 +38,10 @@ In v3, you should call `stopAudioInput` to stop sending an audio stream when you
 const observer = {
   audioVideoDidStop: async sessionStatus => {
     // v3
-    await meetingSession.audioVideo.stopVideoInput();
+    await meetingSession.audioVideo.stopAudioInput();
 
     // Or use the destroy API to call stopAudioInput and stopVideoInput.
-    meetingSession.audioVideo.deviceController.destroy()
+    meetingSession.deviceController.destroy();
   },
 };
 meetingSession.audioVideo.addObserver(observer);
@@ -64,7 +64,10 @@ await meetingSession.audioVideo.startVideoInput(videoInputDeviceInfo.deviceId);
 In v3, you should call `stopVideoInput` to stop the video input stream.
 
 ```js
-// v3
+// Before
+await meetingSession.audioVideo.chooseVideoInputDevice(null);
+
+// After
 await meetingSession.audioVideo.stopVideoInput();
 ```
 

--- a/src/devicecontroller/DeviceController.ts
+++ b/src/devicecontroller/DeviceController.ts
@@ -44,9 +44,9 @@ import VideoQualitySettings from './VideoQualitySettings';
  * When you are done using a `DeviceController`, you should perform some
  * cleanup steps in order to avoid memory leaks:
  *
- * 1. Deselect any audio input or output devices by calling
- *    {@link DeviceController.startAudioInput} and {@link
- *    DeviceController.chooseAudioOutput} with `null`.
+ * 1. Deselect any audio input or video input devices by calling
+ *    {@link DeviceController.stopAudioInput} and {@link
+ *    DeviceController.stopVideoInput}.
  * 2. Remove any device change observers that you registered by using
  *    {@link DeviceController.removeDeviceChangeObserver}.
  * 3. Drop your reference to the controller to allow it to be garbage collected.
@@ -70,7 +70,7 @@ export default interface DeviceController {
   /**
    * Selects an audio input device to use. The constraint may be a device id,
    * `MediaTrackConstraint`, `MediaStream` (containing audio track), or `null` to
-   * indicate no device. It may also be an {@link AudioTransformDevice} to customize the
+   * generate a dummy audio stream. It may also be an {@link AudioTransformDevice} to customize the
    * constraints used or to apply Web Audio transforms.
    *
    * The promise will resolve indicating success or it will throw an appropriate error
@@ -86,15 +86,15 @@ export default interface DeviceController {
 
   /**
    * Selects a video input device to use. The constraint may be a device id,
-   * `MediaTrackConstraint`, `MediaStream` (containing video track), or `null` to
-   * indicate no device. The promise will resolve indicating success or it will
-   * throw an appropriate error indicating the failure.
+   * `MediaTrackConstraint`, `MediaStream` (containing video track). It may also be an {@link VideoTransformDevice}
+   * to apply video transform.
+   * The promise will resolve indicating success or it will throw an appropriate error indicating the failure.
    */
   startVideoInput(device: VideoInputDevice): Promise<MediaStream | undefined>;
 
   /**
-   * Stop the current audio input. This needs to be called to clear out to stop the current video input resources
-   * such as audio stream from camera.
+   * Stop the current video input. This needs to be called to clear out to stop the current video input resources
+   * such as video stream from camera.
    */
   stopVideoInput(): Promise<void>;
 

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -431,7 +431,7 @@ export default class DefaultSignalingClient implements SignalingClient {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const GlobalAny = global as any;
     GlobalAny['window'] &&
-      GlobalAny['window']['addEventListener'] &&
+      GlobalAny['window']['removeEventListener'] &&
       window.removeEventListener('unload', this.unloadHandler);
     this.unloadHandler = null;
   }

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -2120,7 +2120,7 @@ describe('DefaultDeviceController', () => {
         await deviceController.acquireVideoInputStream();
         throw new Error('This line should not be reached.');
       } catch (e) {
-        expect(e.message).includes(`no video device chosen`);
+        expect(e.message).includes(`No video device chosen`);
       }
     });
 


### PR DESCRIPTION
**Description of changes:**
- Fix a bug where joining without selecting any audio device failed when Web Audio is on by making sure there is an inner device exists before returning.
- Fix a typo in `DefaultSignalingClient` that checks for the wrong method.
- Fix a minor log info for video input ended event, we say `resetting to null device` when we just stop the video input.
- Fix a minor demo bug where selecting a video input from the dropdown will auto start the video input stream even when the video button is not enabled yet. To enable it you will then have to click the video button which will then call `startVideoInput` again which will throw an error if the previous `startVideoInput` from selecting a video input is not completed yet.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- In Chrome, enable Web Audio and `Join with view-only mode`.
- Verify that you can join successfully and show up in roster and view other videos.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

