### PR TITLE
[Demo] Fix join view only does not hear audio

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -676,6 +676,7 @@ export class DemoMeetingApp
 
           if (this.isViewOnly) {
             this.updateUXForViewOnlyMode();
+            await this.openAudioOutputFromSelection();
             await this.join();
             this.switchToFlow('flow-meeting');
             this.hideProgress('progress-authenticate');


### PR DESCRIPTION
**Description of changes:**
Fix a bug where joining view-only does not bind audio output so can't hear audio in meeting
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Join meeting as view-only and make sure you can hear audio from others.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

