### PR TITLE
Reducing the threshold for transcript comparison to reduce alarm nois…

### DIFF
--- a/integration/js/TranscriptionTest.js
+++ b/integration/js/TranscriptionTest.js
@@ -51,8 +51,8 @@ class TranscriptionTest extends SdkBaseTest {
       }
 
       const hitPct = 100 * hits / total;
-      if (hitPct < 80) {
-        console.log(`Need at least 80% of expected tokens in transcript content, got ${hitPct}%. (isMedicalTranscribe == ${isMedicalTranscribe}, actual == "${actualContent}", expected == "${expectedContent}")`);
+      if (hitPct < 70) {
+        console.log(`Need at least 70% of expected tokens in transcript content, got ${hitPct}%. (isMedicalTranscribe == ${isMedicalTranscribe}, actual == "${actualContent}", expected == "${expectedContent}")`);
         return false;
       } else {
         console.log(`Success, ${hitPct}% of expected tokens present in transcripts`);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Choppy audio in saucelabs is resulting in transcription comparison failure for integration test. A majority of the comparison failure is having match % between 70-80. Reducing the transcription comparison threshold from 80 to 70%.
**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NAA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

