### PR TITLE
Update getIntrinsicDeviceId in DefaultDeviceController to be more explicit when handling null and undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Extend the `DeviceController` interface to include `Destroyable`.
 - Handle multiple start/stop audio/video input calls by calling them in order instead of throwing errors.
+- Update `getIntrinsicDeviceId` in `DefaultDeviceController` to be more explicit when handling `null` and `undefined`.
 
 ### Fixed
 - Fix a bug where joining without selecting any audio device failed when Web Audio is enabled.

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1499">src/devicecontroller/DefaultDeviceController.ts:1499</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -439,7 +439,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1379">src/devicecontroller/DefaultDeviceController.ts:1379</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1374">src/devicecontroller/DefaultDeviceController.ts:1374</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1503">src/devicecontroller/DefaultDeviceController.ts:1503</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1498">src/devicecontroller/DefaultDeviceController.ts:1498</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -803,7 +803,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1488">src/devicecontroller/DefaultDeviceController.ts:1488</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1483">src/devicecontroller/DefaultDeviceController.ts:1483</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -820,7 +820,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L754">src/devicecontroller/DefaultDeviceController.ts:754</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L746">src/devicecontroller/DefaultDeviceController.ts:746</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -837,7 +837,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1474">src/devicecontroller/DefaultDeviceController.ts:1474</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1469">src/devicecontroller/DefaultDeviceController.ts:1469</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -848,7 +848,7 @@
 					<a name="getintrinsicdeviceid" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> get<wbr>Intrinsic<wbr>Device<wbr>Id</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-static">
-						<li class="tsd-signature tsd-kind-icon">get<wbr>Intrinsic<wbr>Device<wbr>Id<span class="tsd-signature-symbol">(</span>device<span class="tsd-signature-symbol">: </span><a href="../globals.html#device" class="tsd-signature-type">Device</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></li>
+						<li class="tsd-signature tsd-kind-icon">get<wbr>Intrinsic<wbr>Device<wbr>Id<span class="tsd-signature-symbol">(</span>device<span class="tsd-signature-symbol">: </span><a href="../globals.html#device" class="tsd-signature-type">Device</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -860,10 +860,10 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>device: <a href="../globals.html#device" class="tsd-signature-type">Device</a></h5>
+									<h5>device: <a href="../globals.html#device" class="tsd-signature-type">Device</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h5>
 								</li>
 							</ul>
-							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></h4>
 						</li>
 					</ul>
 				</section>
@@ -877,7 +877,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L758">src/devicecontroller/DefaultDeviceController.ts:758</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L750">src/devicecontroller/DefaultDeviceController.ts:750</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -1033,7 +1033,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1558">src/devicecontroller/DefaultDeviceController.ts:1558</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1553">src/devicecontroller/DefaultDeviceController.ts:1553</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/migrationto_3_0.html
+++ b/docs/modules/migrationto_3_0.html
@@ -122,7 +122,8 @@ meetingSession.audioVideo.addObserver(observer);
 <span class="hljs-comment">// After</span>
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.startVideoInput(videoInputDeviceInfo.deviceId);
 </code></pre>
-					<p>In v3, you should call <code>stopVideoInput</code> to stop the video input stream.</p>
+					<p>In v3, you should call <code>stopVideoInput</code> to stop the video input stream. <code>null</code> is no longer a valid input for
+					<code>startVideoInput</code> (<code>null</code> is also removed from <code>Device</code> type).</p>
 					<pre><code class="language-js"><span class="hljs-comment">// Before</span>
 <span class="hljs-keyword">await</span> meetingSession.audioVideo.chooseVideoInputDevice(<span class="hljs-literal">null</span>);
 

--- a/guides/17_Migration_to_3_0.md
+++ b/guides/17_Migration_to_3_0.md
@@ -61,7 +61,8 @@ await meetingSession.audioVideo.chooseVideoInputDevice(videoInputDeviceInfo.devi
 await meetingSession.audioVideo.startVideoInput(videoInputDeviceInfo.deviceId);
 ```
 
-In v3, you should call `stopVideoInput` to stop the video input stream.
+In v3, you should call `stopVideoInput` to stop the video input stream. `null` is no longer a valid input for 
+`startVideoInput` (`null` is also removed from `Device` type).
 
 ```js
 // Before

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -709,13 +709,9 @@ export default class DefaultDeviceController
     }
   }
 
-  static getIntrinsicDeviceId(device: Device): string | string[] | null {
-    if (device === undefined) {
+  static getIntrinsicDeviceId(device: Device | null): string | string[] | undefined {
+    if (!device) {
       return undefined;
-    }
-
-    if (device === null) {
-      return null;
     }
 
     if (typeof device === 'string') {
@@ -728,12 +724,8 @@ export default class DefaultDeviceController
 
     const constraints: MediaTrackConstraints = device as MediaTrackConstraints;
     const deviceIdConstraints = constraints.deviceId;
-    if (deviceIdConstraints === undefined) {
+    if (!deviceIdConstraints) {
       return undefined;
-    }
-
-    if (deviceIdConstraints === null) {
-      return null;
     }
 
     if (typeof deviceIdConstraints === 'string' || Array.isArray(deviceIdConstraints)) {
@@ -1065,7 +1057,10 @@ export default class DefaultDeviceController
     return false;
   }
 
-  private async chooseInputIntrinsicDevice(kind: 'audio' | 'video', device: Device): Promise<void> {
+  private async chooseInputIntrinsicDevice(
+    kind: 'audio' | 'video',
+    device: Device | null
+  ): Promise<void> {
     // N.B.,: the input device might already have augmented constraints supplied
     // by an `AudioTransformDevice`. `getMediaStreamConstraints` will respect
     // settings supplied by the device.

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -2664,12 +2664,12 @@ describe('DefaultDeviceController', () => {
       expect(DefaultDeviceController.getIntrinsicDeviceId(undefined)).to.be.undefined;
     });
 
-    it('Return null if the input device is null', () => {
-      expect(DefaultDeviceController.getIntrinsicDeviceId(null)).to.be.null;
+    it('Return undefined if the input device is null', () => {
+      expect(DefaultDeviceController.getIntrinsicDeviceId(null)).to.be.undefined;
     });
 
-    it('Return empty string if the input device is an empty string', () => {
-      expect(DefaultDeviceController.getIntrinsicDeviceId('')).to.equal('');
+    it('Return undefined if the input device is an empty string', () => {
+      expect(DefaultDeviceController.getIntrinsicDeviceId('')).to.be.undefined;
     });
 
     it('Return default if the input device is default string', () => {
@@ -2691,9 +2691,9 @@ describe('DefaultDeviceController', () => {
       expect(DefaultDeviceController.getIntrinsicDeviceId(constraints)).to.be.undefined;
     });
 
-    it('Return null if the input constraint deviceId is null', () => {
+    it('Return undefined if the input constraint deviceId is null', () => {
       const constraints: MediaTrackConstraints = { deviceId: null };
-      expect(DefaultDeviceController.getIntrinsicDeviceId(constraints)).to.be.null;
+      expect(DefaultDeviceController.getIntrinsicDeviceId(constraints)).to.be.undefined;
     });
 
     it('Return string if the input constraint deviceId is of type string', () => {


### PR DESCRIPTION
**Description of changes:**
- Update `getIntrinsicDeviceId` in `DefaultDeviceController` to be more explicit when handling `null` and `undefined`.
- Clarify in the migration guide that `null` is no longer a valid input for `startVideoInput`.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No functional changes. Just regression testing with selecting audio/video devices.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

