### PR TITLE
Update getMediaType() to check the property kind instead of mediaType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `getMediaType` method to check the property `kind` instead of `mediaType` of a `RawMetricReport`.
+
 ### Fixed
 
 ## [3.0.0] - 2022-03-30

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -393,7 +393,7 @@ export default class StatsCollector {
    * Returns the MediaType for a RawMetricReport.
    */
   private getMediaType(rawMetricReport: RawMetricReport): MediaType {
-    return rawMetricReport.mediaType === 'audio' ? MediaType.AUDIO : MediaType.VIDEO;
+    return rawMetricReport.kind === 'audio' ? MediaType.AUDIO : MediaType.VIDEO;
   }
 
   /**

--- a/test/statscollector/StatsCollector.test.ts
+++ b/test/statscollector/StatsCollector.test.ts
@@ -359,28 +359,28 @@ describe('StatsCollector', () => {
             statsCollector.isValidSsrc({
               type: 'inbound-rtp',
               id: 'id',
-              mediaType: 'video',
+              kind: 'video',
             })
           ).to.be.true;
           expect(
             statsCollector.isValidSsrc({
               type: 'outbound-rtp',
               id: 'id',
-              mediaType: 'video',
+              kind: 'video',
             })
           ).to.be.true;
           expect(
             statsCollector.isValidSsrc({
               type: 'inbound-rtp',
               id: 'id',
-              mediaType: 'audio',
+              kind: 'audio',
             })
           ).to.be.true;
           expect(
             statsCollector.isValidSsrc({
               type: 'outbound-rtp',
               id: 'outbound',
-              mediaType: 'video',
+              kind: 'video',
             })
           ).to.be.true;
           done();
@@ -401,7 +401,7 @@ describe('StatsCollector', () => {
             statsCollector.isValidSsrc({
               type: 'inbound-rtp',
               id: 'id',
-              mediaType: 'video',
+              kind: 'video',
             })
           ).to.be.false;
           done();


### PR DESCRIPTION
**Issue #:**
The `rawMetricReport` of type `remote-inbound-rtp` is not stored when using Chrome.

**Description of changes:**
Update `getMediaType()` to check the property `kind` instead of `mediaType`.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, meeting demo. Run an e2e test using Firefox and Chrome, and use Network Link Conditioner to simulate 30% `packetsLoss`. Confirm the metrics works well in both browser.


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

