### PR TITLE
Update README Video -- perform startLocalVideoTile after meetingStart…

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ a video stream, etc. To view a video in your application, you must bind a tile t
 > - Make sure you bind a tile to the same video element until the tile is removed.
 > - A local video tile can be identified using `localTile` property.
 > - A tile is created with a new tile ID when the same remote attendee restarts the video.
+> - Media Capture Pipeline relies on the meeting session to get the attendee info. After calling `this.meetingSession.audioVideo.start();`, wait for `eventDidReceive` callback where the event name is `meetingStartSucceeded` before calling `startLocalVideoTile`.
 
 **Use case 13.** Start sharing your video. The local video element is flipped horizontally (mirrored mode).
 


### PR DESCRIPTION
…Succeeded.

**Issue #:**
Media Capture Pipeline would fail to capture the selected video by external user id if the client `startLocalVideoTile` before receiving `meetingStartSucceeded`

**Description of changes:**
Add README that `startLocalVideoTile` should be performed after receiving `meetingStartSucceeded`.
**Testing:**
N/A
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A readme change.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

