### PR TITLE
Update README Video -- perform startLocalVideoTile after audioVideoDidStart…

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ a video stream, etc. To view a video in your application, you must bind a tile t
 > - Make sure you bind a tile to the same video element until the tile is removed.
 > - A local video tile can be identified using `localTile` property.
 > - A tile is created with a new tile ID when the same remote attendee restarts the video.
-> - Media Capture Pipeline relies on the meeting session to get the attendee info. After calling `this.meetingSession.audioVideo.start();`, wait for `eventDidReceive` callback where the event name is `meetingStartSucceeded` before calling `startLocalVideoTile`.
+> - Media Capture Pipeline relies on the meeting session to get the attendee info. After calling `this.meetingSession.audioVideo.start();`, wait for `audioVideoDidStart` event to be received before calling `startLocalVideoTile`.
 
 **Use case 13.** Start sharing your video. The local video element is flipped horizontally (mirrored mode).
 

--- a/README.md
+++ b/README.md
@@ -566,6 +566,7 @@ a video stream, etc. To view a video in your application, you must bind a tile t
 > - Make sure you bind a tile to the same video element until the tile is removed.
 > - A local video tile can be identified using `localTile` property.
 > - A tile is created with a new tile ID when the same remote attendee restarts the video.
+> - Media Capture Pipeline relies on the meeting session to get the attendee info. After calling `this.meetingSession.audioVideo.start();`, wait for `eventDidReceive` callback where the event name is `meetingStartSucceeded` before calling `startLocalVideoTile`.
 
 **Use case 13.** Start sharing your video. The local video element is flipped horizontally (mirrored mode).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -600,7 +600,7 @@ meetingSession.audioVideo.subscribeToActiveSpeakerDetector(
 						<li>Make sure you bind a tile to the same video element until the tile is removed.</li>
 						<li>A local video tile can be identified using <code>localTile</code> property.</li>
 						<li>A tile is created with a new tile ID when the same remote attendee restarts the video.</li>
-						<li>Media Capture Pipeline relies on the meeting session to get the attendee info. After calling <code>this.meetingSession.audioVideo.start();</code>, wait for <code>eventDidReceive</code> callback where the event name is <code>meetingStartSucceeded</code> before calling <code>startLocalVideoTile</code>.</li>
+						<li>Media Capture Pipeline relies on the meeting session to get the attendee info. After calling <code>this.meetingSession.audioVideo.start();</code>, wait for <code>audioVideoDidStart</code> event to be received before calling <code>startLocalVideoTile</code>.</li>
 					</ul>
 				</blockquote>
 				<p><strong>Use case 13.</strong> Start sharing your video. The local video element is flipped horizontally (mirrored mode).</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -600,6 +600,7 @@ meetingSession.audioVideo.subscribeToActiveSpeakerDetector(
 						<li>Make sure you bind a tile to the same video element until the tile is removed.</li>
 						<li>A local video tile can be identified using <code>localTile</code> property.</li>
 						<li>A tile is created with a new tile ID when the same remote attendee restarts the video.</li>
+						<li>Media Capture Pipeline relies on the meeting session to get the attendee info. After calling <code>this.meetingSession.audioVideo.start();</code>, wait for <code>eventDidReceive</code> callback where the event name is <code>meetingStartSucceeded</code> before calling <code>startLocalVideoTile</code>.</li>
 					</ul>
 				</blockquote>
 				<p><strong>Use case 13.</strong> Start sharing your video. The local video element is flipped horizontally (mirrored mode).</p>


### PR DESCRIPTION
…Succeeded.

**Issue #:**
Media Capture Pipeline would fail to capture the selected video by external user id if the client startLocalVideoTile before receiving audioVideoDidStart.
**Description of changes:**
Add README that startLocalVideoTile should be performed after receiving audioVideoDidStart.
**Testing:**
N/A
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A README change.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

