### PR TITLE
[Demo] Fix bandwidth selection in demo preview

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -859,9 +859,11 @@ export class DemoMeetingApp
           break;
         case '540p':
           this.audioVideo.chooseVideoInputQuality(960, 540, 15);
+          this.audioVideo.setVideoMaxBandwidthKbps(1400);
           break;
         case '720p':
           this.audioVideo.chooseVideoInputQuality(1280, 720, 15);
+          this.audioVideo.setVideoMaxBandwidthKbps(1400);
           break;
       }
       try {


### PR DESCRIPTION
**Description of changes:**
Make sure to reset the bandwidth for 540p and 720 in case the options are reselected after 360p.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Join a meeting
- In a preview page, switch to 360p then back to 540p.
- Proceed to meeting then turn on video.
- Join as another attendee and turn on video stat
- Verify that the bitrate of the video from the first attendee is around 1400 kbps.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

