### PR TITLE
Fix RTCStatsReport of video kind being accidentally filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug that `remote-inbound-rtp` `RTCStatsReport` and `remote-outbound-rtp` `RTCStatsReport` of "video" `kind` are accidentally filtered.
+
 ## [3.0.0] - 2022-03-30
 
 Amazon Chime SDK for JavaScript v3 is here !! 🎉🎉🎉

--- a/docs/classes/statscollector.html
+++ b/docs/classes/statscollector.html
@@ -158,7 +158,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L448">src/statscollector/StatsCollector.ts:448</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L447">src/statscollector/StatsCollector.ts:447</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L441">src/statscollector/StatsCollector.ts:441</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L440">src/statscollector/StatsCollector.ts:440</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L426">src/statscollector/StatsCollector.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L425">src/statscollector/StatsCollector.ts:425</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L413">src/statscollector/StatsCollector.ts:413</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/statscollector/StatsCollector.ts#L412">src/statscollector/StatsCollector.ts:412</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -400,11 +400,10 @@ export default class StatsCollector {
    * Returns the Direction for a RawMetricReport.
    */
   private getDirectionType(rawMetricReport: RawMetricReport): Direction {
-    return rawMetricReport.id.toLowerCase().indexOf('send') !== -1 ||
-      rawMetricReport.id.toLowerCase().indexOf('outbound') !== -1 ||
-      rawMetricReport.type === 'outbound-rtp'
-      ? Direction.UPSTREAM
-      : Direction.DOWNSTREAM;
+    const { type } = rawMetricReport;
+    return type === 'inbound-rtp' || type === 'remote-outbound-rtp'
+      ? Direction.DOWNSTREAM
+      : Direction.UPSTREAM;
   }
 
   /**


### PR DESCRIPTION
**Issue #:**
* `remote-inbound-rtp` `RTCStatsReport` and `remote-outbound-rtp` `RTCStatsReport` of "video" `kind` are accidentally filtered. This is because `getDirectionType()` method returns wrong `Direction` for `remote-inbound-rtp` and `remote-outbound-rtp`.
* `logPPS()` in meeting demo will not run correctly after enabling camera. Because it accidentally use metrics from "video" kind.

**Description of changes:**
* Update `getDirectionType()` in StatsCollector` to return correct `Direction` for `remote-inbound-rtp` and `remote-outbound-rtp`.
* Update `logPPS()` in meeting demo to use correct metric.
* Fix the typo `defaultBrowserBehaviour` in meeting demo.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, meeting demo.
* Two attendees join a same meeting, open the console and add break point to verify the `remote-inbound-rtp` and `remote-outbound-rtp` of "video" `kind` exist after filtering the metrics (Chrome).

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

