### PR TITLE
Add messagingSession demo deployment to release script

### DIFF
--- a/script/release.js
+++ b/script/release.js
@@ -17,6 +17,9 @@ const deployDemo = (version) => {
   const readinessCheckerDemoName = `chime-sdk-meeting-readiness-checker-${formattedVersion}`;
   logger.log(`Deploying ${readinessCheckerDemoName} ...`);
   spawnOrFail('npm', [`run deploy -- -b ${readinessCheckerDemoName} -s ${readinessCheckerDemoName} -a meetingReadinessChecker -u false`], { printErr: true });
+  const messagingDemoName = `chime-sdk-demo-messaging-${formattedVersion}`;
+  logger.log(`Deploying ${messagingDemoName} ...`);
+  spawnOrFail('npm', [`run deploy -- -b ${messagingDemoName} -s ${messagingDemoName} -a messagingSession -u false`], { printErr: true });
 };
 
 const getCurrentRemoteBranch = () => {


### PR DESCRIPTION
**Issue #:**
- Currently we do not deploy messaging session demo as part of release script.

**Description of changes:**
- Update the release script to deploy messagingSession demo.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Tested using messagingSession demo by deploying it locally.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

