### PR TITLE
Bug/msg session reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     
 ### Added
 
-- `MessagingSession` reconnects with refreshed endpoint and credentials if needed.  EndpointUrl on `MessagingSessionConfiguration` is deprecated as it is resolved by calling `getMessagingSessionEndpoint` internally.
-    
 ### Removed
     
 ### Changed
     
 ### Fixed
+
+- `MessagingSession` reconnects with refreshed endpoint and credentials if needed.  EndpointUrl on `MessagingSessionConfiguration` is deprecated as it is resolved by calling `getMessagingSessionEndpoint` internally.
     
 ## [2.30.0] - 2022-03-08
     


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Fix issue with recent change to getMessagingSessionEndpoint resolve on connect where it would not reconnect if getMessagingSessionEndpoint failed.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Start the messaging demo app in browser.  Create app instance user.  Connect.  Disconnect wifi, reconnect, and see websocket get establish

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
yes

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
yes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

