### PR TITLE
[TEST - DO NOT MERGE] Use correct NPM tag based on version to release

### DIFF
--- a/.github/script/get-npm-tag.js
+++ b/.github/script/get-npm-tag.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const { spawnOrFail } = require('../../script/cli-utils');
+const version = require('../../package.json').version;
+const release = version.split('-');
+if (release[1]) {
+  // For example, 3.0.0-beta.0
+  console.log(release[1].split('.')[0]);
+} else {
+  // For example, '3.1.0'
+  var npmLatestVersion = spawnOrFail('npm',['view', 'amazon-chime-sdk-js@latest', 'version']);
+  const npmLatestMajorVersion = npmLatestVersion.split('.')[0];
+  const majorVersionToRelease = version.split('.')[0];
+  if (majorVersionToRelease < npmLatestMajorVersion) {
+    console.log(`stable-v${majorVersionToRelease}`);
+  } else {
+    console.log('latest');
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,20 +21,13 @@ jobs:
         run: npm install
       - name: NPM run build
         run: npm run build
-      - name: Get npm tag name if needed
+      - name: Get npm tag name
         id: npm_tag
         run: |
-          pre_release_name=$(.github/script/get-pre-release-name.js)
-          echo "Pre release name:" $pre_release_name
-          echo ::set-output name=npm_tag::$pre_release_name
-      - name: Publish to NPM latest
-        if:  steps.npm_tag.outputs.npm_tag == ''
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          tag=$(.github/script/get-npm-tag.js)
+          echo "Release will be tagged with:" $tag
       - name: Publish to NPM with tag
-        if: steps.npm_tag.outputs.npm_tag != ''
-        run: npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
+        run: npm publish --tag ${tag}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
   deploy_chime_prod_demo:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish
 # When a new Github Release is created, publish to NPM
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish:
@@ -26,68 +27,69 @@ jobs:
         run: |
           tag=$(.github/script/get-npm-tag.js)
           echo "Release will be tagged with:" $tag
+          echo ::set-output name=npm_tag::$tag
       - name: Publish to NPM with tag
-        run: npm publish --tag ${tag}
+        run: echo "Tag to release to NPM:" ${{ steps.npm_tag.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-  deploy_chime_prod_demo:
-    needs: publish
-    name: Prod - Chime and ChimeSDKMeetings Client - Deploy the Serverless Meeting Demos
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        name: [ ChimeProd, ChimeSDKMeetingsProdIAD, ChimeSDKMeetingsProdPDX, ChimeSDKMeetingsProdFRA, ChimeSDKMeetingsProdSIN ]
-    env:
-      AWS_DEFAULT_REGION: us-east-1
-      AWS_DEFAULT_OUTPUT: text
-      NAME: ${{ matrix.name }}
-    steps:
-      - name: Verify the npm version is available
-        id: npm_version
-        run: |
-          tag_name=${{ github.event.release.tag_name }}
-          current_version=${tag_name:1}
-          max_wait_time=300
-          wait_time=0
-          sleep_time=60
-          while :
-          do
-            if [[ $wait_time -ge $max_wait_time ]]
-            then
-              echo "Version is not published to npm:" $current_version
-              exit 1
-            fi
-            echo $wait_time
-            npm_version=$(npm view amazon-chime-sdk-js@${current_version} version)
-            if [[ *$npm_version* = *$current_version* ]]
-            then
-              echo "Version is published to npm:" $current_version
-              echo ::set-output name=npm_version::$current_version
-              break
-            fi
+  # deploy_chime_prod_demo:
+  #   needs: publish
+  #   name: Prod - Chime and ChimeSDKMeetings Client - Deploy the Serverless Meeting Demos
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       name: [ ChimeProd, ChimeSDKMeetingsProdIAD, ChimeSDKMeetingsProdPDX, ChimeSDKMeetingsProdFRA, ChimeSDKMeetingsProdSIN ]
+  #   env:
+  #     AWS_DEFAULT_REGION: us-east-1
+  #     AWS_DEFAULT_OUTPUT: text
+  #     NAME: ${{ matrix.name }}
+  #   steps:
+  #     - name: Verify the npm version is available
+  #       id: npm_version
+  #       run: |
+  #         tag_name=${{ github.event.release.tag_name }}
+  #         current_version=${tag_name:1}
+  #         max_wait_time=300
+  #         wait_time=0
+  #         sleep_time=60
+  #         while :
+  #         do
+  #           if [[ $wait_time -ge $max_wait_time ]]
+  #           then
+  #             echo "Version is not published to npm:" $current_version
+  #             exit 1
+  #           fi
+  #           echo $wait_time
+  #           npm_version=$(npm view amazon-chime-sdk-js@${current_version} version)
+  #           if [[ *$npm_version* = *$current_version* ]]
+  #           then
+  #             echo "Version is published to npm:" $current_version
+  #             echo ::set-output name=npm_version::$current_version
+  #             break
+  #           fi
 
-            sleep $sleep_time
-            wait_time=$((wait_time+sleep_time))
-            done
-        shell: bash
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.PROD_CANARY_AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.PROD_CANARY_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Checkout Package
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.release.tag_name }}
-      - name: Install SDK
-        run: |
-          cd demos/browser
-          npm uninstall amazon-chime-sdk-js
-          npm install amazon-chime-sdk-js@${{ steps.npm_version.outputs.npm_version }}
-      - name: Verify demo browser npm version and run deployment script
-        run: |
-          demo_current_version=$(.github/script/get-demo-browser-current-version)
-          echo "Current demo version: " $demo_current_version
-          script/github-action-awscli-installation
-          node ./.github/script/call-canary-deploy-demo-prod $demo_current_version
+  #           sleep $sleep_time
+  #           wait_time=$((wait_time+sleep_time))
+  #           done
+  #       shell: bash
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.PROD_CANARY_AWS_ACCESS_KEY }}
+  #         aws-secret-access-key: ${{ secrets.PROD_CANARY_AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: us-east-1
+  #     - name: Checkout Package
+  #       uses: actions/checkout@v2
+  #       with:
+  #         ref: ${{ github.event.release.tag_name }}
+  #     - name: Install SDK
+  #       run: |
+  #         cd demos/browser
+  #         npm uninstall amazon-chime-sdk-js
+  #         npm install amazon-chime-sdk-js@${{ steps.npm_version.outputs.npm_version }}
+  #     - name: Verify demo browser npm version and run deployment script
+  #       run: |
+  #         demo_current_version=$(.github/script/get-demo-browser-current-version)
+  #         echo "Current demo version: " $demo_current_version
+  #         script/github-action-awscli-installation
+  #         node ./.github/script/call-canary-deploy-demo-prod $demo_current_version


### PR DESCRIPTION
**Issue #:**
- We are currently only tagging NPM pre-releases with `beta` tag. Any hotfix in 2.x is released with `latest` tag by default even if other 3.x versions exist in NPM.
- This can break builders whose release process or installation is dependent on `latest` tag and not a specific version.

**Description of changes:**
- Add a script to get the correct tag while publishing to NPM.

**Testing:**
Tested locally the tag being generated.
- For any pre-release on 3.x it will be `beta`.
- For any current major version for 3.x it will be `latest`.
- For any 2.x hotfix releases it will be `stable-v2`.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

