### PR TITLE
[release 2.x ] Get correct NPM tag when publishing to NPM

### DIFF
--- a/.github/script/get-npm-tag.js
+++ b/.github/script/get-npm-tag.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const { spawnOrFail } = require('../../script/cli-utils');
+const version = require('../../package.json').version;
+const release = version.split('-');
+if (release[1]) {
+  // For example, 3.0.0-beta.0
+  console.log(release[1].split('.')[0]);
+} else {
+  // For example, '3.1.0'
+  const npmLatestVersion = spawnOrFail('npm',['view', 'amazon-chime-sdk-js@latest', 'version'], { skipOutput: true }).trim();
+  const npmLatestMajorVersion = npmLatestVersion.split('.')[0];
+  const majorVersionToRelease = version.split('.')[0];
+  if (majorVersionToRelease < npmLatestMajorVersion) {
+    console.log(`stable-v${majorVersionToRelease}`);
+  } else {
+    console.log('latest');
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,19 +21,13 @@ jobs:
         run: npm install
       - name: NPM run build
         run: npm run build
-      - name: Get npm tag name if needed
+      - name: Get npm tag name
         id: npm_tag
         run: |
-          pre_release_name=$(.github/script/get-pre-release-name.js)
-          echo "Pre release name:" $pre_release_name
-          echo ::set-output name=npm_tag::$pre_release_name
-      - name: Publish to NPM latest
-        if:  steps.npm_tag.outputs.npm_tag == ''
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          npm_publish_tag=$(.github/script/get-npm-tag.js)
+          echo "Received NPM publish tag:" $npm_publish_tag
+          echo ::set-output name=npm_tag::$npm_publish_tag
       - name: Publish to NPM with tag
-        if: steps.npm_tag.outputs.npm_tag != ''
         run: npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
**Issue #:**
- We are currently only tagging NPM pre-releases with `beta` tag. Any hotfix in 2.x is released with `latest` tag by default even if other 3.x versions exist in NPM.
- This can break builders whose release process or installation is dependent on `latest` tag and not a specific version.

**Description of changes:**
- Add a script to get the correct tag while publishing to NPM.

**Testing:**
Tested locally the tag being generated.
- For any pre-release on 3.x it will be `beta`.
- For any current major version for 3.x it will be `latest`.
- For any 2.x hotfix releases it will be `stable-v2`.

Tested the commit by running the workflow on PR to main and release-2.x
branch. For 2.x it printed stable-v2 tag and for 3.x it printed latest
tag.

Successfull 2.x run testing:
https://github.com/aws/amazon-chime-sdk-js/runs/6298817583?check_suite_focus=true#step:6:9

Successfull 3.x run testing:
https://github.com/aws/amazon-chime-sdk-js/runs/6298838666?check_suite_focus=true#step:7:7

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

