### PR TITLE
Disable unstable transcript text accuracy validation in transcription…

### DIFF
--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -507,7 +507,6 @@ class AppPage {
       const speaker = actualSpeakers[i];
       if (!compareFn(actualTranscriptContentBySpeaker[speaker], expectedTranscriptContentBySpeaker[speaker], isMedicalTranscribe)) {
         console.log(`Transcript comparison failed, speaker: ${speaker} isMedicalTranscribe: ${isMedicalTranscribe} actual content: "${actualTranscriptContentBySpeaker[speaker]}" does not match with expected: "${expectedTranscriptContentBySpeaker[speaker]}"`);
-        return false;
       }
     }
 


### PR DESCRIPTION
… canary

**Issue #:**
Chime-50263

**Description of changes:**
Disable the text comparison check inside of the transcript integration test. This is unstable dependent on local environment conditions and has caused false positive failures when running in automated test infrastructure.

**Testing:**
Run integration test using a local selenium session.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.* 
No, the changes are limited to the integration test logic.


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes


4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? 
No


5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

