### PR TITLE
Do not lose resolution when toggle transform video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fix issue where video resolution and framerate changes when toggle video transform.
 
 ## [3.1.0] - 2022-04-07
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -693,6 +693,7 @@ export class DemoMeetingApp
             ) as HTMLSelectElement;
             videoInputQuality.value = '720p';
             this.audioVideo.chooseVideoInputQuality(1280, 720, 15);
+            videoInputQuality.disabled = true;
           }
 
           // `this.primaryExternalMeetingId` may by the join request

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "../..": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -207,7 +207,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L566">src/devicecontroller/DefaultDeviceController.ts:566</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L556">src/devicecontroller/DefaultDeviceController.ts:556</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -225,7 +225,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L589">src/devicecontroller/DefaultDeviceController.ts:589</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L579">src/devicecontroller/DefaultDeviceController.ts:579</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -249,7 +249,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L579">src/devicecontroller/DefaultDeviceController.ts:579</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L569">src/devicecontroller/DefaultDeviceController.ts:569</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">MediaStream</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -267,7 +267,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L437">src/devicecontroller/DefaultDeviceController.ts:437</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L427">src/devicecontroller/DefaultDeviceController.ts:427</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1484">src/devicecontroller/DefaultDeviceController.ts:1484</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -315,7 +315,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudiooutput">chooseAudioOutput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L428">src/devicecontroller/DefaultDeviceController.ts:428</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L418">src/devicecontroller/DefaultDeviceController.ts:418</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -339,7 +339,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L553">src/devicecontroller/DefaultDeviceController.ts:553</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L543">src/devicecontroller/DefaultDeviceController.ts:543</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L451">src/devicecontroller/DefaultDeviceController.ts:451</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L441">src/devicecontroller/DefaultDeviceController.ts:441</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/removableanalysernode.html" class="tsd-signature-type">RemovableAnalyserNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L479">src/devicecontroller/DefaultDeviceController.ts:479</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L469">src/devicecontroller/DefaultDeviceController.ts:469</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/removableanalysernode.html" class="tsd-signature-type">RemovableAnalyserNode</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -422,7 +422,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L562">src/devicecontroller/DefaultDeviceController.ts:562</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L552">src/devicecontroller/DefaultDeviceController.ts:552</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videoqualitysettings.html" class="tsd-signature-type">VideoQualitySettings</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></h4>
@@ -439,7 +439,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1374">src/devicecontroller/DefaultDeviceController.ts:1374</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1364">src/devicecontroller/DefaultDeviceController.ts:1364</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -529,7 +529,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L540">src/devicecontroller/DefaultDeviceController.ts:540</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L530">src/devicecontroller/DefaultDeviceController.ts:530</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -553,7 +553,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mutelocalaudioinputstream">muteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L687">src/devicecontroller/DefaultDeviceController.ts:687</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L677">src/devicecontroller/DefaultDeviceController.ts:677</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -571,7 +571,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L444">src/devicecontroller/DefaultDeviceController.ts:444</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L434">src/devicecontroller/DefaultDeviceController.ts:434</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -595,7 +595,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1498">src/devicecontroller/DefaultDeviceController.ts:1498</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1488">src/devicecontroller/DefaultDeviceController.ts:1488</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -618,7 +618,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L525">src/devicecontroller/DefaultDeviceController.ts:525</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L515">src/devicecontroller/DefaultDeviceController.ts:515</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -678,7 +678,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideoinput">startVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L376">src/devicecontroller/DefaultDeviceController.ts:376</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L366">src/devicecontroller/DefaultDeviceController.ts:366</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -702,7 +702,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L504">src/devicecontroller/DefaultDeviceController.ts:504</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L494">src/devicecontroller/DefaultDeviceController.ts:494</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -744,7 +744,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideoinput">stopVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L411">src/devicecontroller/DefaultDeviceController.ts:411</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L401">src/devicecontroller/DefaultDeviceController.ts:401</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -762,7 +762,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L520">src/devicecontroller/DefaultDeviceController.ts:520</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L510">src/devicecontroller/DefaultDeviceController.ts:510</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -786,7 +786,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#unmutelocalaudioinputstream">unmuteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L691">src/devicecontroller/DefaultDeviceController.ts:691</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L681">src/devicecontroller/DefaultDeviceController.ts:681</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -803,7 +803,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1483">src/devicecontroller/DefaultDeviceController.ts:1483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1473">src/devicecontroller/DefaultDeviceController.ts:1473</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -820,7 +820,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L746">src/devicecontroller/DefaultDeviceController.ts:746</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L736">src/devicecontroller/DefaultDeviceController.ts:736</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -837,7 +837,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1469">src/devicecontroller/DefaultDeviceController.ts:1469</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1459">src/devicecontroller/DefaultDeviceController.ts:1459</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -854,7 +854,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L712">src/devicecontroller/DefaultDeviceController.ts:712</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L702">src/devicecontroller/DefaultDeviceController.ts:702</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -877,7 +877,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L750">src/devicecontroller/DefaultDeviceController.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L740">src/devicecontroller/DefaultDeviceController.ts:740</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/defaultvideotransformdevice.html
+++ b/docs/classes/defaultvideotransformdevice.html
@@ -199,7 +199,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L154">src/videoframeprocessor/DefaultVideoTransformDevice.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L128">src/videoframeprocessor/DefaultVideoTransformDevice.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -300,7 +300,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotransformdevice.html">VideoTransformDevice</a>.<a href="../interfaces/videotransformdevice.html#onoutputstreamdisconnect">onOutputStreamDisconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L115">src/videoframeprocessor/DefaultVideoTransformDevice.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L89">src/videoframeprocessor/DefaultVideoTransformDevice.ts:89</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videoframeprocessorpipelineobserver.html">VideoFrameProcessorPipelineObserver</a>.<a href="../interfaces/videoframeprocessorpipelineobserver.html#processingdidfailtostart">processingDidFailToStart</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L182">src/videoframeprocessor/DefaultVideoTransformDevice.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L156">src/videoframeprocessor/DefaultVideoTransformDevice.ts:156</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videoframeprocessorpipelineobserver.html">VideoFrameProcessorPipelineObserver</a>.<a href="../interfaces/videoframeprocessorpipelineobserver.html#processingdidstart">processingDidStart</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L165">src/videoframeprocessor/DefaultVideoTransformDevice.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L139">src/videoframeprocessor/DefaultVideoTransformDevice.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -362,7 +362,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videoframeprocessorpipelineobserver.html">VideoFrameProcessorPipelineObserver</a>.<a href="../interfaces/videoframeprocessorpipelineobserver.html#processingdidstop">processingDidStop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L191">src/videoframeprocessor/DefaultVideoTransformDevice.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L165">src/videoframeprocessor/DefaultVideoTransformDevice.ts:165</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -380,7 +380,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videoframeprocessorpipelineobserver.html">VideoFrameProcessorPipelineObserver</a>.<a href="../interfaces/videoframeprocessorpipelineobserver.html#processinglatencytoohigh">processingLatencyTooHigh</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L174">src/videoframeprocessor/DefaultVideoTransformDevice.ts:174</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L148">src/videoframeprocessor/DefaultVideoTransformDevice.ts:148</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -403,7 +403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L161">src/videoframeprocessor/DefaultVideoTransformDevice.ts:161</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L135">src/videoframeprocessor/DefaultVideoTransformDevice.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -432,7 +432,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotransformdevice.html">VideoTransformDevice</a>.<a href="../interfaces/videotransformdevice.html#stop">stop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L138">src/videoframeprocessor/DefaultVideoTransformDevice.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L112">src/videoframeprocessor/DefaultVideoTransformDevice.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotransformdevice.html">VideoTransformDevice</a>.<a href="../interfaces/videotransformdevice.html#transformstream">transformStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L103">src/videoframeprocessor/DefaultVideoTransformDevice.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videoframeprocessor/DefaultVideoTransformDevice.ts#L77">src/videoframeprocessor/DefaultVideoTransformDevice.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -1033,7 +1033,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1553">src/devicecontroller/DefaultDeviceController.ts:1553</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1543">src/devicecontroller/DefaultDeviceController.ts:1543</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -356,17 +356,7 @@ export default class DefaultDeviceController
 
     // Update device and stream
     this.chosenVideoTransformDevice = device;
-    const newMediaStream = this.activeDevices['video'].stream;
     this.logger.info('video transform device uses previous stream');
-
-    // Input is not a MediaStream. Update constraints
-    if (!(inner as MediaStream).id) {
-      const constraint = inner as MediaTrackConstraints;
-      constraint.width = constraint.width || this.videoInputQualitySettings.videoWidth;
-      constraint.height = constraint.height || this.videoInputQualitySettings.videoHeight;
-      constraint.frameRate = constraint.frameRate || this.videoInputQualitySettings.videoFrameRate;
-      await newMediaStream.getVideoTracks()[0].applyConstraints(constraint);
-    }
 
     // `transformStream` will start processing.
     this.logger.info('apply processors to transform');

--- a/src/videoframeprocessor/DefaultVideoTransformDevice.ts
+++ b/src/videoframeprocessor/DefaultVideoTransformDevice.ts
@@ -67,33 +67,7 @@ export default class DefaultVideoTransformDevice
   }
 
   async intrinsicDevice(): Promise<Device> {
-    const trackConstraints: MediaTrackConstraints = {};
-
-    // Empty string and null.
-    if (!this.device) {
-      return trackConstraints;
-    }
-
-    // Device ID.
-    if (typeof this.device === 'string') {
-      if (this.browserBehavior.requiresNoExactMediaStreamConstraints()) {
-        trackConstraints.deviceId = this.device;
-      } else {
-        trackConstraints.deviceId = { exact: this.device };
-      }
-      return trackConstraints;
-    }
-
-    if ((this.device as MediaStream).id) {
-      // Nothing we can do.
-      return this.device;
-    }
-
-    // It's constraints.
-    return {
-      ...this.device,
-      ...trackConstraints,
-    };
+    return this.device;
   }
 
   /**

--- a/test/videoframeprocessor/DefaultVideoTransformDevice.test.ts
+++ b/test/videoframeprocessor/DefaultVideoTransformDevice.test.ts
@@ -184,31 +184,7 @@ describe('DefaultVideoTransformDevice', () => {
     it('returns the intrinsicDevice', async () => {
       const processor = new NoOpVideoFrameProcessor();
       const device = new DefaultVideoTransformDevice(logger, 'test', [processor]);
-      expect(await device.intrinsicDevice()).to.deep.equal({ deviceId: { exact: 'test' } });
-    });
-
-    it('returns the correct intrinsicDevice', async () => {
-      const device = new DefaultVideoTransformDevice(logger, null, []);
-      expect(await device.intrinsicDevice()).to.deep.equal({});
-    });
-
-    it('returns the correct intrinsicDevice for browsers with no exact deviceId', async () => {
-      domMockBehavior = new DOMMockBehavior();
-      domMockBehavior.browserName = 'samsung';
-      domMockBuilder = new DOMMockBuilder(domMockBehavior);
-      const processor = new NoOpVideoFrameProcessor();
-      const device = new DefaultVideoTransformDevice(logger, 'test', [processor]);
-      expect(await device.intrinsicDevice()).to.deep.equal({ deviceId: 'test' });
-    });
-
-    it('returns the correct intrinsicDevice', async () => {
-      const device = new DefaultVideoTransformDevice(logger, mockVideoStream, []);
-      expect(await device.intrinsicDevice()).to.deep.equal(mockVideoStream);
-    });
-
-    it('returns the correct intrinsicDevice', async () => {
-      const device = new DefaultVideoTransformDevice(logger, { width: 1280 }, []);
-      expect(await device.intrinsicDevice()).to.deep.equal({ width: 1280 });
+      expect(await device.intrinsicDevice()).to.equal('test');
     });
   });
 


### PR DESCRIPTION
**Issue #2210 :**
In V3, when toggle video with some video transformation (such as background blur), the video resolution will be default from browser (e.g., in Chrome its 480p).
This is because in V3, we would not try to modify if the input device pass to `chooseInputIntrinsicDevice` is a `MediaTrackConstraints` (whereas previously in v2, we will try to add in video resolution, framerate, or audio augmented properpties like `googEchoCancellation`).
However, in `intrinsicDevice` in `DefaultVideoTransformDevice` always returns `MediaTrackConstraints` even when the device is device Id. The code is unnecessary because it is the same logic as in `DefaultDeviceController`.

This is not an issue with `VoiceFocusTransformDevice`, because there we try to override some default constraints such as turn off `echoCancellation` from browser etc.

**Description of changes:**
- Change `intrinsicDevice` in `DefaultVideoTransformDevice` to just return the original device information.
- Delete the code path in `DefaultDeviceController` where we try to re-apply the video resolution and framerate when reusing the current video stream. That should not be needed. This is needed before in case the original input is a media track constraints and we always try to augment video resolution and frame rate.
- Unrelated but update the meeting demo to disable changing video input quality in simulcast case as we only support 720p for simulcast right now. Using other video input resolution might cause issues.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Test case 1:
- Join a meeting and turn on video and background blur.
- Turn on video stats and confirm your video resolution is correct (default is 540p in the meeting demo).
- Toggle video off then on again.
- Confirm your video resolution is still the same as before.

Test case 2:
- Enable simulcast
- In the preview screen make sure the video input quality is disable and locked to 720p.
- Join and turn on video and verify that your video is 720p.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

