### PR TITLE
[Demo] Make sure to only deploy fetch_credentials lambda for messaging session demo

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -42,7 +42,7 @@
     },
     "../..": {
       "name": "amazon-chime-sdk-js",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -281,6 +281,8 @@ let parameterOverrides = `Region=${region} UseChimeSDKMeetings=${useChimeSDKMeet
 if (app === 'meetingV2' && captureOutputPrefix) {
     parameterOverrides += ` ChimeMediaCaptureS3BucketPrefix=${captureOutputPrefix}`;
     createCaptureS3Buckets(captureOutputPrefix, mediaCaptureRegions);
+} else if (app === 'messagingSession') {
+    parameterOverrides += ` UseFetchCredentialLambda=true`
 }
 spawnOrFail('sam', ['deploy', '--template-file', './build/packaged.yaml', '--stack-name', `${stack}`,
                     '--parameter-overrides', parameterOverrides,

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -32,8 +32,14 @@ Parameters:
     Description: Prefix of S3 bucket to write capture artifacts.  The bucket name will be suffixed with the region.
     Default: ""
     Type: String
+  UseFetchCredentialLambda:
+    Description: Set to true to deploy a lambda to return AWS credentials with limited privileges. This should be disabled in most demo.
+    Default: false
+    Type: String
+    AllowedValues: [ true, false ]
 Conditions:
   ShouldUseEventBridge: !Equals [true, !Ref UseEventBridge]
+  ShouldDeployFetchCredentialLambda: !Equals [true, !Ref UseFetchCredentialLambda]
 Globals:
   Function:
     Runtime: nodejs14.x
@@ -91,6 +97,7 @@ Resources:
         - Ref: ChimeSdkEndCaptureLambdaRole
   ChimeMessagingAccessPolicy:
     Type: AWS::IAM::Policy
+    Condition: ShouldDeployFetchCredentialLambda
     Properties:
       PolicyName: ChimeMeetingsAccess
       PolicyDocument:
@@ -418,6 +425,7 @@ Resources:
             Method: POST
   ChimeSdkBrowserFetchCredentialsLambda:
     Type: AWS::Serverless::Function
+    Condition: ShouldDeployFetchCredentialLambda
     Properties:
       Handler: handlers.fetch_credentials
       CodeUri: src/


### PR DESCRIPTION
**Description of changes:**
Modify the CloudFormation template to only deploy fetch_credentials lambda for messaging session demo. 

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Verify that calling fetch_credentials endpoint will result in internal server in meeting demo but works in messaging session demo
- Check CF template to make sure the lambda is not created for meeting demo.


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

