### PR TITLE
Fix video test for meeting readiness checker in v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Replace `startVideoInput(null)` and `startAudioInput(null)` with`stopVideoInput` and `stopAudioInput` for video, audio test in meeting readiness checker to stop video, audio input.
+- Replace the deprecated API `getRTCPeerConnectionStats` with `metricsDidReceive` in meeting readiness checker. 
 
 ## [3.2.0] - 2022-04-27
 

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L39">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L40">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:40</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioconnectivity">checkAudioConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L266">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:266</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L267">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:267</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioinput">checkAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L47">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L48">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -199,7 +199,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L61">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L62">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:62</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -241,7 +241,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcameraresolution">checkCameraResolution</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L163">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L164">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:164</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -271,7 +271,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcontentshareconnectivity">checkContentShareConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L217">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L218">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:218</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L397">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:397</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L395">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:395</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworktcpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkTCPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L355">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:355</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L351">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:351</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../enums/checknetworkudpconnectivityfeedback.html" class="tsd-signature-type">CheckNetworkUDPConnectivityFeedback</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -331,7 +331,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L315">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:315</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L308">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:308</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -355,7 +355,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoinput">checkVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L149">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L150">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:150</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>


### PR DESCRIPTION
**Issue #2236:**

**Description of changes:**
- Replace `startVideoInput(null)` and `startAudioInput(null)` with`stopVideoInput` and `stopAudioInput` for video, audio test in meeting readiness checker to stop video, audio input.  This also causes camera LED to be on after video test.
- Replace the deprecated API `getRTCPeerConnectionStats` with `metricsDidReceive` in meeting readiness checker. 

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Run meeting readiness checker demo and verify there is no camera LED after finishing as well as no error about `invalid video input` or deprecated API.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

