### PR TITLE
Prevent realtimeUnsubscribeFromVolumeIndicator error when no matching attendeeId is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Replace `startVideoInput(null)` and `startAudioInput(null)` with`stopVideoInput` and `stopAudioInput` for video, audio test in meeting readiness checker to stop video, audio input.
 - Replace the deprecated API `getRTCPeerConnectionStats` with `metricsDidReceive` in meeting readiness checker. 
+- Prevent `realtimeUnsubscribeFromVolumeIndicator` from causing a fatal error when there are no subscriptions for the `attendeeId`.
 
 ## [3.2.0] - 2022-04-27
 

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -261,17 +261,17 @@ export default class DefaultRealtimeController implements RealtimeController {
     attendeeId: string,
     callback?: VolumeIndicatorCallback
   ): void {
-    try {
-      if (callback) {
-        const index = this.state.volumeIndicatorCallbacks[attendeeId].indexOf(callback);
-        if (index !== -1) {
-          this.state.volumeIndicatorCallbacks[attendeeId].splice(index, 1);
-        }
-      } else {
-        delete this.state.volumeIndicatorCallbacks[attendeeId];
+    const callbacks = this.state.volumeIndicatorCallbacks[attendeeId];
+    if (!callbacks) {
+      return;
+    }
+    if (callback) {
+      const index = this.state.volumeIndicatorCallbacks[attendeeId].indexOf(callback);
+      if (index >= 0) {
+        this.state.volumeIndicatorCallbacks[attendeeId].splice(index, 1);
       }
-    } catch (e) {
-      this.onError(e);
+    } else {
+      delete this.state.volumeIndicatorCallbacks[attendeeId];
     }
   }
 

--- a/test/realtimecontroller/DefaultRealtimeController.test.ts
+++ b/test/realtimecontroller/DefaultRealtimeController.test.ts
@@ -548,6 +548,16 @@ describe('DefaultRealtimeController', () => {
       expect(state.volumeIndicatorCallbacks).to.equal(expectedResult);
     });
 
+    it('will not error if unsubscribed from a non-exist attendeeId', () => {
+      const callback = (
+        _attendeeId: string,
+        _volume: number | null,
+        _muted: boolean | null,
+        _signalStrength: number | null
+      ): void => {};
+      rt.realtimeUnsubscribeFromVolumeIndicator('bar-attendee', callback);
+    });
+
     it('will tolerate an exception thrown in a volume indicator callback', () => {
       const sentAttendeeId = 'foo-attendee';
       const sentVolume = 0.5;
@@ -1192,29 +1202,6 @@ describe('DefaultRealtimeController', () => {
         "Cannot read property 'indexOf' of undefined",
         "Cannot read properties of undefined (reading 'indexOf')"
       );
-      expect(fatal.calledWith(matchUn)).to.be.true;
-    });
-
-    it('handles broken volume callbacks', () => {
-      const fatal = sinon.stub();
-      rt.realtimeSubscribeToFatalError(fatal);
-
-      // Break it.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const state: RealtimeState = ((rt as unknown) as any).state as RealtimeState;
-      state.volumeIndicatorCallbacks = undefined;
-
-      rt.realtimeSubscribeToVolumeIndicator('a', (_a, _v, _m, _s) => {});
-      expect(fatal.calledOnce).to.be.true;
-      const match = matchError(
-        "Cannot read property 'hasOwnProperty' of undefined",
-        "Cannot read properties of undefined (reading 'hasOwnProperty')"
-      );
-      expect(fatal.calledWith(match)).to.be.true;
-      fatal.reset();
-
-      rt.realtimeUnsubscribeFromVolumeIndicator('a');
-      const matchUn = matchError('Cannot convert undefined or null to object');
       expect(fatal.calledWith(matchUn)).to.be.true;
     });
 


### PR DESCRIPTION
**Issue #2235 :**
`realtimeUnsubscribeFromVolumeIndicator` throw a fatal error when there are no subscriptions for the  given`attendeeId`. This results in being disconnected.

**Description of changes:**
Check that the subscription for the given `attendeeId` exists to prevent an error thrown when calling `indexOf`. There is no longer anything that would cause the try/catch to occur, so I removed that code to fix coverage.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

