### PR TITLE
Fix Saucelabs screen resolution to display meeting ID

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -128,6 +128,7 @@ const getSauceLabsConfig = (capabilities) => {
     name: capabilities.name,
     tags: [capabilities.name],
     seleniumVersion: '3.141.59',
+    screenResolution: '1280x960',
     tunnelIdentifier: process.env.JOB_ID,
     ...((capabilities.platform.toUpperCase() !== 'LINUX' &&
       !((capabilities.name).includes('ContentShare'))) && {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Currently Meeting ID is hidden/cropped in saucelabs session. This change adds the screen resolution option to saucelabs config to enable sessions to display meeting ID correctly. 

**Testing:**
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No. This change is a part of integration test running on Saucelabs. It can be tested in Saucelabs which now will display the meeting ID without getting cropped in the Saucelabs sessions.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

