### PR TITLE
Assume SDP section is sendrecv if no direction is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Assume SDP section is sendrecv if no direction is present. This should have no impact on media negotiation.
 
 ### Fixed
 - Replace `startVideoInput(null)` and `startAudioInput(null)` with`stopVideoInput` and `stopAudioInput` for video, audio test in meeting readiness checker to stop video, audio input.

--- a/docs/classes/sdp.html
+++ b/docs/classes/sdp.html
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L622">src/sdp/SDP.ts:622</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L630">src/sdp/SDP.ts:630</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L349">src/sdp/SDP.ts:349</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L357">src/sdp/SDP.ts:357</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L187">src/sdp/SDP.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L195">src/sdp/SDP.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L198">src/sdp/SDP.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L206">src/sdp/SDP.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L639">src/sdp/SDP.ts:639</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L647">src/sdp/SDP.ts:647</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -362,7 +362,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L180">src/sdp/SDP.ts:180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L188">src/sdp/SDP.ts:188</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -384,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L173">src/sdp/SDP.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L181">src/sdp/SDP.ts:181</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -406,7 +406,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L570">src/sdp/SDP.ts:570</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L578">src/sdp/SDP.ts:578</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L488">src/sdp/SDP.ts:488</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L496">src/sdp/SDP.ts:496</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -450,7 +450,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L444">src/sdp/SDP.ts:444</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L452">src/sdp/SDP.ts:452</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -472,7 +472,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L471">src/sdp/SDP.ts:471</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L479">src/sdp/SDP.ts:479</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -500,7 +500,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L223">src/sdp/SDP.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L231">src/sdp/SDP.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -528,7 +528,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L241">src/sdp/SDP.ts:241</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L249">src/sdp/SDP.ts:249</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -550,7 +550,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L335">src/sdp/SDP.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L343">src/sdp/SDP.ts:343</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -573,7 +573,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L380">src/sdp/SDP.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L388">src/sdp/SDP.ts:388</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -603,7 +603,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L207">src/sdp/SDP.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L215">src/sdp/SDP.ts:215</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -631,7 +631,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L216">src/sdp/SDP.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L224">src/sdp/SDP.ts:224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -709,7 +709,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L156">src/sdp/SDP.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L164">src/sdp/SDP.ts:164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -738,7 +738,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L260">src/sdp/SDP.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L268">src/sdp/SDP.ts:268</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -772,7 +772,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L605">src/sdp/SDP.ts:605</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L613">src/sdp/SDP.ts:613</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -859,7 +859,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L164">src/sdp/SDP.ts:164</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L172">src/sdp/SDP.ts:172</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -946,7 +946,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L291">src/sdp/SDP.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/sdp/SDP.ts#L299">src/sdp/SDP.ts:299</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/sdp/SDP.ts
+++ b/src/sdp/SDP.ts
@@ -134,7 +134,15 @@ export default class SDP {
     let hasCamera = false;
     for (const sec of sections) {
       if (/^m=video/.test(sec)) {
-        if (sec.indexOf('sendrecv') > -1) {
+        if (
+          sec.indexOf('sendrecv') > -1 ||
+          // RFC 4566: If none of the attributes "sendonly", "recvonly", "inactive",
+          // and "sendrecv" is present, "sendrecv" SHOULD be assumed as the
+          // default for sessions
+          (sec.indexOf('sendonly') === -1 &&
+            sec.indexOf('recvonly') === -1 &&
+            sec.indexOf('inactive') === -1)
+        ) {
           hasCamera = true;
           break;
         }

--- a/test/sdp/SDP.test.ts
+++ b/test/sdp/SDP.test.ts
@@ -350,6 +350,11 @@ describe('SDP', () => {
       expect(sdpPlanB.ssrcForVideoSendingSection()).to.deep.equal('');
     });
 
+    it('video without direction', () => {
+      const sdp = new SDP(SDPMock.LOCAL_OFFER_WITH_AUDIO_VIDEO_NO_DIRECTION);
+      expect(sdp.ssrcForVideoSendingSection()).to.deep.equal('138036785');
+    });
+
     it('video sendrecv', () => {
       const sdp = new SDP(SafariSDPMock.SAFARI_AUDIO_VIDEO_SENDING);
       expect(sdp.ssrcForVideoSendingSection()).to.deep.equal('2209845614');

--- a/test/sdp/SDPMock.ts
+++ b/test/sdp/SDPMock.ts
@@ -179,6 +179,144 @@ a=ssrc:138036787 msid:j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP ecf9934b-2914-4e1d-a2
 a=ssrc-group:FID 138036786 138036787\r
 `;
 
+  static readonly LOCAL_OFFER_WITH_AUDIO_VIDEO_NO_DIRECTION: string = `v=0\r
+o=- 8360888182273689563 3 IN IP4 127.0.0.1\r
+s=-\r
+t=0 0\r
+a=group:BUNDLE audio video\r
+a=msid-semantic: WMS j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP vF4Jw4SEKVInbC6ELS82CbkoHH28gJF3YwCI\r
+m=audio 58349 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
+c=IN IP4 10.78.67.19\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=candidate:26124455 1 udp 2122260223 10.78.67.19 58349 typ host generation 0 network-id 1 network-cost 10\r
+a=candidate:1326275671 1 tcp 1518280447 10.78.67.19 9 typ host tcptype active generation 0 network-id 1 network-cost 10\r
+a=ice-ufrag:XWdt\r
+a=ice-pwd:fake\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 fake\r
+a=setup:actpass\r
+a=mid:audio\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=sendrecv\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtcp-fb:111 transport-cc\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:103 ISAC/16000\r
+a=rtpmap:104 ISAC/32000\r
+a=rtpmap:9 G722/8000\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:106 CN/32000\r
+a=rtpmap:105 CN/16000\r
+a=rtpmap:13 CN/8000\r
+a=rtpmap:110 telephone-event/48000\r
+a=rtpmap:112 telephone-event/32000\r
+a=rtpmap:113 telephone-event/16000\r
+a=rtpmap:126 telephone-event/8000\r
+a=ssrc:3647729951 cname:87eXz3QiQBBvJFID\r
+a=ssrc:3647729951 msid:vF4Jw4SEKVInbC6ELS82CbkoHH28gJF3YwCI eb624d61-a40b-41ff-a6a3-520452a0e8e1\r
+a=ssrc:3647729951 mslabel:vF4Jw4SEKVInbC6ELS82CbkoHH28gJF3YwCI\r
+a=ssrc:3647729951 label:eb624d61-a40b-41ff-a6a3-520452a0e8e1\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 122 127 121 125 107 108 109 124 120 123\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:XWdt\r
+a=ice-pwd:fake\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 fake\r
+a=setup:actpass\r
+a=mid:video\r
+a=extmap:14 urn:ietf:params:rtp-hdrext:toffset\r
+a=extmap:13 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r
+a=extmap:3 urn:3gpp:video-orientation\r
+a=extmap:2 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r
+a=extmap:8 http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07\r
+a=extmap:9 http://www.webrtc.org/experiments/rtp-hdrext/color-space\r
+a=rtcp-mux\r
+a=rtcp-rsize\r
+a=rtpmap:96 VP8/90000\r
+a=rtcp-fb:96 goog-remb\r
+a=rtcp-fb:96 transport-cc\r
+a=rtcp-fb:96 ccm fir\r
+a=rtcp-fb:96 nack\r
+a=rtcp-fb:96 nack pli\r
+a=rtpmap:97 rtx/90000\r
+a=fmtp:97 apt=96\r
+a=rtpmap:98 VP9/90000\r
+a=rtcp-fb:98 goog-remb\r
+a=rtcp-fb:98 transport-cc\r
+a=rtcp-fb:98 ccm fir\r
+a=rtcp-fb:98 nack\r
+a=rtcp-fb:98 nack pli\r
+a=fmtp:98 profile-id=0\r
+a=rtpmap:99 rtx/90000\r
+a=fmtp:99 apt=98\r
+a=rtpmap:100 VP9/90000\r
+a=rtcp-fb:100 goog-remb\r
+a=rtcp-fb:100 transport-cc\r
+a=rtcp-fb:100 ccm fir\r
+a=rtcp-fb:100 nack\r
+a=rtcp-fb:100 nack pli\r
+a=fmtp:100 profile-id=2\r
+a=rtpmap:101 rtx/90000\r
+a=fmtp:101 apt=100\r
+a=rtpmap:102 H264/90000\r
+a=rtcp-fb:102 goog-remb\r
+a=rtcp-fb:102 transport-cc\r
+a=rtcp-fb:102 ccm fir\r
+a=rtcp-fb:102 nack\r
+a=rtcp-fb:102 nack pli\r
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r
+a=rtpmap:122 rtx/90000\r
+a=fmtp:122 apt=102\r
+a=rtpmap:127 H264/90000\r
+a=rtcp-fb:127 goog-remb\r
+a=rtcp-fb:127 transport-cc\r
+a=rtcp-fb:127 ccm fir\r
+a=rtcp-fb:127 nack\r
+a=rtcp-fb:127 nack pli\r
+a=fmtp:127 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f\r
+a=rtpmap:121 rtx/90000\r
+a=fmtp:121 apt=127\r
+a=rtpmap:125 H264/90000\r
+a=rtcp-fb:125 goog-remb\r
+a=rtcp-fb:125 transport-cc\r
+a=rtcp-fb:125 ccm fir\r
+a=rtcp-fb:125 nack\r
+a=rtcp-fb:125 nack pli\r
+a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r
+a=rtpmap:107 rtx/90000\r
+a=fmtp:107 apt=125\r
+a=rtpmap:108 H264/90000\r
+a=rtcp-fb:108 goog-remb\r
+a=rtcp-fb:108 transport-cc\r
+a=rtcp-fb:108 ccm fir\r
+a=rtcp-fb:108 nack\r
+a=rtcp-fb:108 nack pli\r
+a=fmtp:108 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f\r
+a=rtpmap:109 rtx/90000\r
+a=fmtp:109 apt=108\r
+a=rtpmap:124 red/90000\r
+a=rtpmap:120 rtx/90000\r
+a=fmtp:120 apt=124\r
+a=rtpmap:123 ulpfec/90000\r
+a=ssrc:138036785 cname:87eXz3QiQBBvJFID\r
+a=ssrc:138036785 msid:j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP ecf9934b-2914-4e1d-a2f8-8bbd1fb31b8c\r
+a=ssrc:1579984795 cname:87eXz3QiQBBvJFID\r
+a=ssrc:1579984795 msid:j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP ecf9934b-2914-4e1d-a2f8-8bbd1fb31b8c\r
+a=ssrc-group:FID 138036785 1579984795\r
+a=ssrc:138036786 cname:87eXz3QiQBBvJFID\r
+a=ssrc:138036786 msid:j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP ecf9934b-2914-4e1d-a2f8-8bbd1fb31b8c\r
+a=ssrc:138036787 cname:87eXz3QiQBBvJFID\r
+a=ssrc:138036787 msid:j5DVeGxmzCUECATU1d9Ni641UdUJ86wVscmP ecf9934b-2914-4e1d-a2f8-8bbd1fb31b8c\r
+a=ssrc-group:FID 138036786 138036787\r
+`;
+
   static readonly LOCAL_OFFER_WITH_AUDIO_VIDEO_WITH_HEADER_EXTENSION: string = `v=0\r
 o=- 8360888182273689563 3 IN IP4 127.0.0.1\r
 s=-\r


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/1919

**Description of changes:** Can't reproduce issue currently but don't see any risk of making the change. TBH (perhaps a bit off topic):
* We should not be relying on the direction to know what corresponds to our local transceiver (as we should know MID, etc.). Though I guess that refactoring can be done if we add multiple send stream on PC support.
* Overriding the camera section as `sendrecv` when it should be `sendonly` (carryover from plan-b days i assume) is silly and unnecessary.

**Testing:** Smoke tested and added unit tests.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

