### PR TITLE
Add ability to join meetings not created with demo from the demo apps

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -24,8 +24,8 @@
     <form id="form-authenticate">
       <h1 class="h3 mb-3 font-weight-normal">Join a meeting</h1>
       <div class="row mt-3">
-        <label for="inputMeeting" class="sr-only">Meeting Title</label>
-        <input type="name" id="inputMeeting" class="form-control" placeholder="Meeting Title" required autofocus>
+        <label for="inputMeeting" class="sr-only">Meeting Title or ID</label>
+        <input type="name" id="inputMeeting" class="form-control" placeholder="Meeting Title or ID" required autofocus>
       </div>
       <div class="row mt-3">
         <label for="inputName" class="sr-only">Your Name</label>
@@ -124,7 +124,7 @@
             <div class="custom-control custom-checkbox" style="text-align: left;">
               <input type="checkbox" id="replica-meeting-input" class="custom-control-input">
               <label for="replica-meeting-input" class="custom-control-label">Create meeting as replica</label>
-              <input type="name" id="primary-meeting-external-id" class="form-control" placeholder="Primary Meeting ID">
+              <input type="name" id="primary-meeting-external-id" class="form-control" placeholder="Primary Meeting Title or ID">
             </div>
             <div class="custom-control custom-checkbox" style="text-align: left;">
               <input type="checkbox" id="delete-attendee" class="custom-control-input">

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -59,12 +59,13 @@ exports.index = async (event, context, callback) => {
 };
 
 exports.join = async (event, context) => {
+  const meetingIdFormat = /^[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$/
   const query = event.queryStringParameters;
   if (!query.title || !query.name) {
     return response(400, 'application/json', JSON.stringify({ error: 'Need parameters: title, name' }));
   }
 
-  // Look up the meeting by its title. If it does not exist, create the meeting.
+  // Look up the meeting by its title
   let meeting = await getMeeting(query.title);
 
   let client = getClientForMeeting(meeting);
@@ -72,9 +73,23 @@ exports.join = async (event, context) => {
   let primaryMeeting = undefined
   if (query.primaryExternalMeetingId) {
     primaryMeeting = await getMeeting(query.primaryExternalMeetingId)
-    if (primaryMeeting !== undefined) {
+    if (primaryMeeting) {
       console.info(`Retrieved primary meeting ID ${primaryMeeting.Meeting.MeetingId} for external meeting ID ${query.primaryExternalMeetingId}`)
-    } else {
+    } else if (meetingIdFormat.test(query.primaryExternalMeetingId)) {
+      // Just in case, check if we were passed a regular meeting ID instead of an external ID
+      try {
+        primaryMeeting = await client.getMeeting({
+          MeetingId: query.primaryExternalMeetingId
+        }).promise();
+        if (primaryMeeting !== undefined) {
+          console.info(`Retrieved primary meeting id ${primaryMeeting.Meeting.MeetingId}`);
+          await putMeeting(query.primaryExternalMeetingId, primaryMeeting);
+        }
+      } catch (error) {
+        console.info("Meeting ID doesnt' exist as a conference ID: " + error);
+      }
+    }
+    if (!primaryMeeting) {
       return response(400, 'application/json', JSON.stringify({ error: 'Primary meeting has not been created' }));
     }
   }
@@ -83,40 +98,54 @@ exports.join = async (event, context) => {
     if (!query.region) {
       return response(400, 'application/json', JSON.stringify({ error: 'Need region parameter set if meeting has not yet been created' }));
     }
-    let request = {
-      // Use a UUID for the client request token to ensure that any request retries
-      // do not create multiple meetings.
-      ClientRequestToken: uuidv4(),
-
-      // Specify the media region (where the meeting is hosted).
-      // In this case, we use the region selected by the user.
-      MediaRegion: query.region,
-
-      // Set up SQS notifications if being used
-      NotificationsConfiguration: USE_EVENT_BRIDGE === 'false' ? { SqsQueueArn: SQS_QUEUE_ARN } : {},
-
-      // Any meeting ID you wish to associate with the meeting.
-      // For simplicity here, we use the meeting title.
-      ExternalMeetingId: query.title.substring(0, 64),
-    };
-    if (primaryMeeting !== undefined) {
-      request.PrimaryMeetingId = primaryMeeting.Meeting.MeetingId;
+    // If the meeting does not exist, check if we were passed in a meeting ID instead of an external meeting ID.  If so, use that one
+    try {
+      if (meetingIdFormat.test(query.title)) {
+        meeting = await client.getMeeting({
+          MeetingId: query.title
+        }).promise();
+      }
+    } catch (error) {
+      console.info("Meeting ID doesn't exist as a conference ID: " + error);
     }
-    if (query.ns_es === 'true') {
-      client = chimeSDKMeetings;
-      request.MeetingFeatures = {
-        Audio: {
-          // The EchoReduction parameter helps the user enable and use Amazon Echo Reduction.
-          EchoReduction: 'AVAILABLE'
-        }
+
+    // If still no meeting, create one
+    if (!meeting) {
+      let request = {
+        // Use a UUID for the client request token to ensure that any request retries
+        // do not create multiple meetings.
+        ClientRequestToken: uuidv4(),
+
+        // Specify the media region (where the meeting is hosted).
+        // In this case, we use the region selected by the user.
+        MediaRegion: query.region,
+
+        // Set up SQS notifications if being used
+        NotificationsConfiguration: USE_EVENT_BRIDGE === 'false' ? { SqsQueueArn: SQS_QUEUE_ARN } : {},
+
+        // Any meeting ID you wish to associate with the meeting.
+        // For simplicity here, we use the meeting title.
+        ExternalMeetingId: query.title.substring(0, 64),
       };
-    }
-    console.info('Creating new meeting: ' + JSON.stringify(request));
-    meeting = await client.createMeeting(request).promise();
+      if (primaryMeeting !== undefined) {
+        request.PrimaryMeetingId = primaryMeeting.Meeting.MeetingId;
+      }
+      if (query.ns_es === 'true') {
+        client = chimeSDKMeetings;
+        request.MeetingFeatures = {
+          Audio: {
+            // The EchoReduction parameter helps the user enable and use Amazon Echo Reduction.
+            EchoReduction: 'AVAILABLE'
+          }
+        };
+      }
+      console.info('Creating new meeting: ' + JSON.stringify(request));
+      meeting = await client.createMeeting(request).promise();
 
-    // Extend meeting with primary external meeting ID if it exists
-    if (primaryMeeting !== undefined) {
-      meeting.Meeting.PrimaryExternalMeetingId = primaryMeeting.Meeting.ExternalMeetingId;
+      // Extend meeting with primary external meeting ID if it exists
+      if (primaryMeeting !== undefined) {
+        meeting.Meeting.PrimaryExternalMeetingId = primaryMeeting.Meeting.ExternalMeetingId;
+      }
     }
 
     // Store the meeting in the table using the meeting title as the key.


### PR DESCRIPTION
**Issue #:**
None

**Description of changes:** 
 Normally you can only join other meetings created with the demo app from the demo app.  Sometimes it is helpful to debug issues with other clients to join the same meeting using the demo app, this change lets you join such a meeting by meeting ID.

**Testing:**

I deployed it and tried this out, see steps below

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Create a meeting using the AWS CLI: `chime-sdk-meetings create-meeting --media-region us-east-1 --external-meeting-id some-id`
2. Take the `MeetingId` returned from the CLI and put it in the meeting title field of the demo app, attempt to join the meeting.
3. Once joined from the demo app, use the AWS CLI to confirm the attendee was added to the same meeting: `aws chime-sdk-meetings list-attendees --meeting-id <meeting id>`

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
