### PR TITLE
Add AWS SDK version in event ingestion guide

### DIFF
--- a/docs/modules/clientevent_ingestion.html
+++ b/docs/modules/clientevent_ingestion.html
@@ -97,7 +97,7 @@
 					<a href="#opt-out-of-event-ingestion" id="opt-out-of-event-ingestion" style="color: inherit; text-decoration: none;">
 						<h2>Opt out of Event Ingestion</h2>
 					</a>
-					<p>To opt out of event ingestion, provide <code>NoOpEventReporter</code> to <code>DefaultMeetingSession</code> while creating the meeting session.</p>
+					<p>Event ingestion is enabled for clients using <a href="https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#29340">AWS SDK v2.934.0</a> and above. To opt out of event ingestion, provide <code>NoOpEventReporter</code> to <code>DefaultMeetingSession</code> while creating the meeting session.</p>
 					<pre><code class="language-js"><span class="hljs-keyword">import</span> {
   ConsoleLogger,
   DefaultDeviceController,

--- a/guides/12_Client_Event_Ingestion.md
+++ b/guides/12_Client_Event_Ingestion.md
@@ -13,7 +13,7 @@ The Amazon Chime SDK for JavaScript will not send below sensitive attributes to 
 
 ## Opt out of Event Ingestion
    
-To opt out of event ingestion, provide `NoOpEventReporter` to `DefaultMeetingSession` while creating the meeting session.
+Event ingestion is enabled for clients using [AWS SDK v2.934.0](https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#29340) and above. To opt out of event ingestion, provide `NoOpEventReporter` to `DefaultMeetingSession` while creating the meeting session.
 
 ```js
 import {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Update the docs with AWS SDK version with which builders get `EventIngestionUrl` and then the client side event ingestion starts.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

