### PR TITLE
Bumps brotobufjs from 6.8.8 to 6.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `protobufjs` from 6.8.8 to 6.11.3.
+- Update `DOMBlobMock` to accommodate `@types/node` changes.
+
 ### Fixed
 
 ## [3.4.0] - 2022-05-24
 
 ### Added
+
 - Add the reserved status code AudioDisconnectAudio.
 - Add support in `MessagingSession` to allow websocket connection for messaging service to enable Prefetch feature.
 
 ### Removed
 
 ### Changed
+
 - Add reset function to uplink policy interface, and ignore indexes in nscale policy if the number of published videos did not change.
 
 ### Fixed
+
 - Rate limited CPU warnings to at most once a minute in Voice Focus library, so that builder logs are not flooded.
 
 ## [3.3.0] - 2022-05-12
@@ -36,17 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+
 - Assume SDP section is sendrecv if no direction is present. This should have no impact on media negotiation.
 
 ### Fixed
+
 - Replace `startVideoInput(null)` and `startAudioInput(null)` with`stopVideoInput` and `stopAudioInput` for video, audio test in meeting readiness checker to stop video, audio input.
-- Replace the deprecated API `getRTCPeerConnectionStats` with `metricsDidReceive` in meeting readiness checker. 
+- Replace the deprecated API `getRTCPeerConnectionStats` with `metricsDidReceive` in meeting readiness checker.
 - Prevent `realtimeUnsubscribeFromVolumeIndicator` from causing a fatal error when there are no subscriptions for the `attendeeId`.
 - Subscribe to `audioOutputDidChange` in audio mix controller to fix the issue where the audio output is not updated before meeting start.
 
 ## [3.2.0] - 2022-04-27
 
 ### Added
+
 - Add browser support information to content share guide.
 
 - Readd layers allocation negotiation in Chromium based browsers to avoid resubscribing to preemptively turn off simulcast streams or to switch layers. Avoid duplicate RTP header extension and changing extension id.
@@ -58,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean up the HTML video element bounded to `VideoTileState` using `unbindVideoElement` API to fix Safari memory leak. If you do not intend to clean the video element, call `unbindVideoElement` API with `cleanUpVideoElement` set to `false`. Check [PR#2217](https://github.com/aws/amazon-chime-sdk-js/pull/2217) for detailed information.
 
 ### Fixed
+
 - Fix issue where video resolution and framerate changes when toggle video transform.
 
 ## [3.1.0] - 2022-04-07
@@ -77,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `getMediaType` method to check the property `kind` instead of `mediaType` of a `RawMetricReport`.
 
 ### Fixed
+
 - Fixed state not being reset if an `AudioVideoController` is reused after `stop`.
 
 - Fix a bug that `remote-inbound-rtp` `RTCStatsReport` and `remote-outbound-rtp` `RTCStatsReport` of "video" `kind` are accidentally filtered.
@@ -86,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Amazon Chime SDK for JavaScript v3 is here !! 🎉🎉🎉
 
-Amazon Chime SDK for JavaScript v3 includes major improvements for device management, WebRTC metrics, and the 
+Amazon Chime SDK for JavaScript v3 includes major improvements for device management, WebRTC metrics, and the
 messaging session.
 
 - **Device management:** Decouple audio and video device management from the meeting sessions. For example, a user can select their preferred devices on a video preview page and continue using the same devices to join the session. After joining the session, a user can instantly switch devices without interrupting the ongoing meeting session.
@@ -94,7 +105,7 @@ messaging session.
 - **Messaging session:** Add support for AWS SDK for JavaScript v3 for messaging session.
 - **Dropping support:** Deprecate Safari 12 support and Plan B in Session Description Protocol (SDP) negotiations.
 
-Below is a list of all changes in the Chime SDK for JavaScript v3. Please refer to the [Migraton guide from v2 to v3](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_3_0.html) for 
+Below is a list of all changes in the Chime SDK for JavaScript v3. Please refer to the [Migraton guide from v2 to v3](https://aws.github.io/amazon-chime-sdk-js/modules/migrationto_3_0.html) for
 more information.
 
 ### Added
@@ -102,6 +113,7 @@ more information.
 - Add `rtcStatsReport` property to `ClientMetricReport` to store raw [`RTCStatsReport`](https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport) and expose it via `metricsDidReceive` event.
 
 ### Removed
+
 - Remove support for Plan B as well as Safari (and iOS) 12+. The minimum Safari and iOS supported version is now 13.
 - Remove [legacy (non-promise-based) `getStats` API](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats#obsolete_syntax) call in `DefaultStatsCollector`. This API was previously used to obtain WebRTC metrics only for Chromium-based browsers. Now SDK obtains WebRTC metrics for all browsers via [standardized (promise-based) `getStats` API](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats#syntax).  
 - Remove all deprecated meeting status code.  
@@ -112,8 +124,8 @@ more information.
 - Remove `StatsCollector` interface.
 - Remove `ClientMetricReport` interface.
 
-
 ### Changed
+
 - Rename `DefaultStatsCollector` to `StatsCollector`.
 - Rename `DefaultClientMetricReport` to `ClientMetricReport`.
 - Change `chooseAudioInputDevice` to explicit APIs `startAudioInput` and `stopAudioInput`. Application will need to
@@ -124,7 +136,7 @@ more information.
 - `startVideoPreviewForVideoInput` and `stopVideoPreviewForVideoInput` will no longer turn on and off video stream.
   This allows applications to join meeting without reselecting video again.
 - Remove max bandwidth kbps parameter in `chooseVideoInputQuality` as it is not related to device. Applications can
-  set video max bandwidth kbps from `audioVideo.setVideoMaxBandwidthKbps`. 
+  set video max bandwidth kbps from `audioVideo.setVideoMaxBandwidthKbps`.
 - Extend the `DeviceController` interface to include `Destroyable`  
 - Rename `MeetingSessionPOSTLogger` to `POSTLogger`.
 - Update `POSTLogger` to implement the `Logger` interface.
@@ -134,8 +146,9 @@ more information.
 - Decoupled `EventController` from `AudioVideo` and `MeetingSession`.
 
 ### Fixed
+
 - Fix a bug where joining without selecting any audio device failed when Web Audio is enabled.
-- Fix a minor log info for video input ended event where we say resetting to null device when we just stop the video 
+- Fix a minor log info for video input ended event where we say resetting to null device when we just stop the video
   input.
 
 ## [3.0.0-beta.2] - 2022-03-09
@@ -157,12 +170,12 @@ more information.
 - Rename `DefaultClientMetricReport` to `ClientMetricReport`.
 - Change `chooseAudioInputDevice` to explicit APIs `startAudioInput` and `stopAudioInput`. Application will need to
   call `stopVideoInput` at the end of the call to explicitly stop active audio stream.
-- Change `chooseVideoInputDevice` to explicit APIs `startVideoInput` and `stopVideoInput`. Application will need to 
+- Change `chooseVideoInputDevice` to explicit APIs `startVideoInput` and `stopVideoInput`. Application will need to
   call `stopVideoInput` now to explicitly stop active video stream.
 - Minor name change to `chooseAudioOutputDevice` to `chooseAudioOutput`.
-- `startVideoPreviewForVideoInput` and `stopVideoPreviewForVideoInput` will no longer turn on and off video stream. 
+- `startVideoPreviewForVideoInput` and `stopVideoPreviewForVideoInput` will no longer turn on and off video stream.
   This allows applications to join meeting without reselecting video again.
-- Remove max bandwidth kbps parameter in `chooseVideoInputQuality` as it is not related to device. Applications can 
+- Remove max bandwidth kbps parameter in `chooseVideoInputQuality` as it is not related to device. Applications can
   set video max bandwidth kbps from `audioVideo.setVideoMaxBandwidthKbps`.
 - Rename `MeetingSessionPOSTLogger` to `POSTLogger`.
 - Update `POSTLogger` to implement the `Logger` interface.

--- a/docs/assets/js/search.json
+++ b/docs/assets/js/search.json
@@ -7344,7 +7344,7 @@
 "parent":"GetUserMediaError"},
 {"id":1882,"kind":1024,"name":"stack",
 "url":"classes/getusermediaerror.html#stack",
-"classes":"tsd-kind-property tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited",
+"classes":"tsd-kind-property tsd-parent-kind-class tsd-is-inherited",
 "parent":"GetUserMediaError"},
 {"id":1883,"kind":1024,"name":"Error",
 "url":"classes/getusermediaerror.html#error",

--- a/docs/classes/getusermediaerror.html
+++ b/docs/classes/getusermediaerror.html
@@ -112,7 +112,7 @@
 								<li class="tsd-kind-property tsd-parent-kind-class"><a href="getusermediaerror.html#cause" class="tsd-kind-icon">cause</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="getusermediaerror.html#message" class="tsd-kind-icon">message</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="getusermediaerror.html#name" class="tsd-kind-icon">name</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited"><a href="getusermediaerror.html#stack" class="tsd-kind-icon">stack</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a href="getusermediaerror.html#stack" class="tsd-kind-icon">stack</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><a href="getusermediaerror.html#error" class="tsd-kind-icon">Error</a></li>
 							</ul>
 						</section>
@@ -182,13 +182,12 @@
 						</ul>
 					</aside>
 				</section>
-				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited">
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 					<a name="stack" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagOptional">Optional</span> stack</h3>
 					<div class="tsd-signature tsd-kind-icon">stack<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stack">stack</a></p>
-						<p>Overrides <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stack">stack</a></p>
 						<ul>
 							<li>Defined in node_modules/typescript/lib/lib.es5.d.ts:975</li>
 						</ul>
@@ -233,7 +232,7 @@
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 								<a href="getusermediaerror.html#name" class="tsd-kind-icon">name</a>
 							</li>
-							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-overwrite tsd-is-inherited">
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-inherited">
 								<a href="getusermediaerror.html#stack" class="tsd-kind-icon">stack</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-static">

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "~6.8.8",
+        "protobufjs": "^6.11.3",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       },
@@ -635,9 +635,9 @@
       "dev": true
     },
     "node_modules/@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/mocha": {
       "version": "5.2.7",
@@ -646,9 +646,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g=="
     },
     "node_modules/@types/sinon": {
       "version": "7.5.0",
@@ -3714,9 +3714,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3729,8 +3729,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       },
       "bin": {
@@ -5515,9 +5515,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -5526,9 +5526,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g=="
     },
     "@types/sinon": {
       "version": "7.5.0",
@@ -7837,9 +7837,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -7851,8 +7851,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -103,10 +103,10 @@
     "@types/dom-mediacapture-record": "^1.0.7",
     "@types/ua-parser-js": "^0.7.35",
     "detect-browser": "^5.2.0",
-    "protobufjs": "~6.8.8",
+    "pako": "^2.0.4",
+    "protobufjs": "^6.11.3",
     "resize-observer": "^1.0.0",
-    "ua-parser-js": "^1.0.1",
-    "pako": "^2.0.4"
+    "ua-parser-js": "^1.0.1"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/script/audit-deps
+++ b/script/audit-deps
@@ -11,5 +11,5 @@ system('npm audit --only dev')
 puts '---'
 
 # Do not pull in package fixes automatically: it will cause the build to fail.
-# puts 'Auditing production dependencies. You must address these.'
-# verbose('npm audit --audit-level=moderate --production')
+puts 'Auditing production dependencies. You must address these.'
+verbose('npm audit --audit-level=moderate --production')

--- a/test/domblobmock/DOMBlobMock.ts
+++ b/test/domblobmock/DOMBlobMock.ts
@@ -20,8 +20,11 @@ export default class DOMBlobMock implements Blob {
     throw new Error('Unimplemented.');
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream(): ReadableStream<any> {
+  stream(): NodeJS.ReadableStream;
+
+  stream(): ReadableStream;
+
+  stream(): NodeJS.ReadableStream | ReadableStream {
     throw new Error('Unimplemented.');
   }
 


### PR DESCRIPTION
**Issue #:**
Current version `protobufjs` has high severity issue, we need to upgrade it to the latest version to be able to successfully run `npm run build:release`.

**Description of changes:**
* Bump `protobufjs` from 6.88 to 6.11.3.
* Implement the missing property `stream` required by type `Blob` in `DOMBolbMock`.
* Add back the `npm audit` step in `prebuild` script

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
Update the `protobufjs` dependency that is used in our wire protocol. However the wire compatibility will never be broken by version change so that is fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

