### PR TITLE
Add support to select the attendee list and enable media capture for the selected attendees.

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "../..": {
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -5,7 +5,6 @@ const AWS = require('aws-sdk');
 const compression = require('compression');
 const fs = require('fs');
 const http = require('http');
-const { reject } = require('lodash');
 const url = require('url');
 const { v4: uuidv4 } = require('uuid');
 
@@ -394,7 +393,7 @@ function log(message) {
 
 async function handleStartCaptureRequest(request) {
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     let body = '';
     request.on('data', function(chunk) {
       body += chunk;

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -202,29 +202,34 @@ function serve(host = '127.0.0.1:8080') {
           attendeeIds = requestBody.attendeeIds
         }
 
+        let chimeSDKConfig = {
+          ArtifactsConfiguration: {
+            Audio: {
+              MuxType: "AudioWithActiveSpeakerVideo"
+            },
+            Video: {
+              State: "Enabled",
+              MuxType: "VideoOnly"
+            },
+            Content: {
+              State: "Enabled",
+              MuxType: "ContentOnly"
+            }
+          }
+        }
+      
+        if (attendeeIds.length > 0) {
+          chimeSDKConfig["SourceConfiguration"] = {
+            SelectedVideoStreams : {
+              AttendeeIds: attendeeIds
+            }
+          }
+        }        
+
         if (captureS3Destination) {
           const callerInfo = await sts.getCallerIdentity().promise()
           pipelineInfo = await chime.createMediaCapturePipeline({
-            ChimeSdkMeetingConfiguration: {
-              ArtifactsConfiguration: {
-                Audio: {
-                  MuxType: "AudioWithActiveSpeakerVideo"
-                },
-                Video: {
-                  State: "Enabled",
-                  MuxType: "VideoOnly"
-                },
-                Content: {
-                  State: "Enabled",
-                  MuxType: "ContentOnly"
-                }
-              },
-              SourceConfiguration: { 
-                SelectedVideoStreams : {
-                  AttendeeIds: attendeeIds
-                }
-              }
-            },           
+            ChimeSdkMeetingConfiguration: chimeSDKConfig,           
             SourceType: "ChimeSdkMeeting",
             SourceArn: `arn:aws:chime::${callerInfo.Account}:meeting:${meetingTable[requestUrl.query.title].Meeting.MeetingId}`,
             SinkType: "S3Bucket",


### PR DESCRIPTION
**Issue #:**
None.

**Description of changes:**
Added support for selecting the attendees from the roster and enabling media capture for the selected attendees. This feature is useful, while testing media capture for certain selected number of attendees.

**Testing:**
Below is a snapshot of the attendee for whom we intend to capture the media.
![Screen Shot 2022-06-02 at 11 04 37 PM](https://user-images.githubusercontent.com/3948470/171797194-57ad08c3-c9ff-480a-b38b-1f36c104f435.png)

**Can these tested using a demo application?**
Yes

**Please provide reproducible step-by-step instructions.**
1. Launch the demo application in browser.
2. Select the attendee that you want to capture the media for
3. Click the Media capture option to start recording the media for that particular attendee.
4. Make sure the Media Pipeline attendee joins the meeting.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

5. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

6. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.