### PR TITLE
Fix release script 2x

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "amazon-chime-sdk-js": "file:../..",
-        "aws-sdk": "^2.1088.0",
+        "aws-sdk": "^2.1105.0",
         "bootstrap": "^4.5.2",
         "compression": "^1.7.4",
         "jquery": "^3.5.1",
@@ -5573,9 +5573,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1093.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1093.0.tgz",
-      "integrity": "sha512-YD6VNemoKkzDMHsUiGP/MwpM0T20ukp3KTSxPY34Xw3Ww0zP19C54CfjaXhn//R27f2c57BtVez+he2RZ5GwyQ==",
+      "version": "2.1105.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1105.0.tgz",
+      "integrity": "sha512-YZ6IbKvtiw8noD/Iuyp3hXNX5NmhJ2xSU4598pZr55CfnIQ0oU5ZwtQqLPG8E07ouA363/moCYddIAVGYSkQ+A==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -16514,9 +16514,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1093.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1093.0.tgz",
-      "integrity": "sha512-YD6VNemoKkzDMHsUiGP/MwpM0T20ukp3KTSxPY34Xw3Ww0zP19C54CfjaXhn//R27f2c57BtVez+he2RZ5GwyQ==",
+      "version": "2.1105.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1105.0.tgz",
+      "integrity": "sha512-YZ6IbKvtiw8noD/Iuyp3hXNX5NmhJ2xSU4598pZr55CfnIQ0oU5ZwtQqLPG8E07ouA363/moCYddIAVGYSkQ+A==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.1088.0",
+    "aws-sdk": "^2.1105.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/demos/serverless/src/package-lock.json
+++ b/demos/serverless/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "aws-embedded-metrics": "^2.0.4",
-        "aws-sdk": "^2.1088.0",
+        "aws-sdk": "^2.1105.0",
         "uuid": "^8.3.2"
       }
     },
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1088.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
-      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
+      "version": "2.1105.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1105.0.tgz",
+      "integrity": "sha512-YZ6IbKvtiw8noD/Iuyp3hXNX5NmhJ2xSU4598pZr55CfnIQ0oU5ZwtQqLPG8E07ouA363/moCYddIAVGYSkQ+A==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -166,9 +166,9 @@
       "integrity": "sha512-b4+3BC8e3DE3HdZkmzlozvS8wU45w9M+4eAd2R4Z62N+ihiCuwndEh15Yj/scCKRq/FTO3rfKnzlvUMsuJtzLg=="
     },
     "aws-sdk": {
-      "version": "2.1088.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
-      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
+      "version": "2.1105.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1105.0.tgz",
+      "integrity": "sha512-YZ6IbKvtiw8noD/Iuyp3hXNX5NmhJ2xSU4598pZr55CfnIQ0oU5ZwtQqLPG8E07ouA363/moCYddIAVGYSkQ+A==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/demos/serverless/src/package.json
+++ b/demos/serverless/src/package.json
@@ -4,7 +4,7 @@
   "description": "Amazon Chime SDK JavaScript Serverless Demos Lambda Handler",
   "dependencies": {
     "aws-embedded-metrics": "^2.0.4",
-    "aws-sdk": "^2.1088.0",
+    "aws-sdk": "^2.1105.0",
     "uuid": "^8.3.2"
   },
   "license": "Apache-2.0",

--- a/script/release.js
+++ b/script/release.js
@@ -8,12 +8,12 @@ const currentBranch = (spawnOrFail('git', [' branch --show-current'], { skipOutp
 const deployDemo = (version) => {
   const formattedVersion = `${version.replace(/\./g, "-")}`;
   process.chdir(path.join(__dirname, '../demos/serverless'));
-  const meetingDemoName = `chime-sdk-demo-${formattedVersion}`;
+  const meetingDemoName = `chime-sdk-demo-global-${formattedVersion}`;
   logger.log(`Deploying ${meetingDemoName} ...`);
-  spawnOrFail('npm', [`run deploy -- -b ${meetingDemoName} -s ${meetingDemoName} -o ${meetingDemoName} -u false`], { printErr: true });
+  spawnOrFail('npm', [`run deploy -- -b ${meetingDemoName} -s ${meetingDemoName} -o chime-sdk-demo-global -u false`], { printErr: true });
   const meetingDemoNameRegional = `chime-sdk-demo-${formattedVersion}-regional`;
   logger.log(`Deploying ${meetingDemoNameRegional} ...`);
-  spawnOrFail('npm', [`run deploy -- -b ${meetingDemoNameRegional} -s ${meetingDemoNameRegional}`], { printErr: true });
+  spawnOrFail('npm', [`run deploy -- -b ${meetingDemoNameRegional} -s ${meetingDemoNameRegional} -o chime-sdk-demo-regional`], { printErr: true });
   const readinessCheckerDemoName = `chime-sdk-meeting-readiness-checker-${formattedVersion}`;
   logger.log(`Deploying ${readinessCheckerDemoName} ...`);
   spawnOrFail('npm', [`run deploy -- -b ${readinessCheckerDemoName} -s ${readinessCheckerDemoName} -a meetingReadinessChecker -u false`], { printErr: true });


### PR DESCRIPTION
**Description of changes:**
Push some previous changes from v3 to v2.
- Fix demo to use later version of aws-sdk to support replica meeting.
- Fix release script to deploy s3 bucket for regional demo 

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Run the release script and use regional demo for regression test that replica meeting and media capture works.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

