### PR TITLE
Update bootstrap to 5 and move additional options to modal

### DIFF
--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.html
@@ -19,19 +19,19 @@
       <h1 class="h3 mb-3 font-weight-normal">Amazon Chime SDK Readiness Checker</h1>
       <div class="row mt-3">
         <label for="audio-output block" class="text-center p-2">Speaker</label>
-        <select id="audio-output" class="custom-select" style="width:100%"></select>
+        <select id="audio-output" class="form-select" style="width:100%"></select>
       </div>
       <div class="row mt-3">
         <label for="audio-input block">Microphone</label>
-        <select id="audio-input" class="custom-select" style="width:100%"></select>
+        <select id="audio-input" class="form-select" style="width:100%"></select>
       </div>
       <div class="row mt-3">
         <label for="video-input block">Camera</label>
-        <select id="video-input" class="custom-select" style="width:100%"></select>
+        <select id="video-input" class="form-select" style="width:100%"></select>
       </div>
       <div class="row mt-3">
         <label for="inputRegion block">Media Region</label>
-        <select id="inputRegion" class="custom-select" style="width:100%">
+        <select id="inputRegion" class="form-select" style="width:100%">
           <option value="us-east-1" selected>United States (N. Virginia)</option>
           <option value="ap-northeast-1">Japan (Tokyo)</option>
           <option value="ap-southeast-1">Singapore</option>
@@ -53,7 +53,7 @@
         </select>
       </div>
       <div class="row mt-3">
-        <button id="authenticate" class="btn btn-lg btn-primary btn-block" type="submit" disabled>Check my device</button>
+        <button id="authenticate" class="btn btn-lg btn-primary" type="submit" disabled>Check my device</button>
       </div>
       <div class="row mt-3">
         <p>This page will check whether your devices are able to reach the Amazon Chime SDK services.</p>
@@ -89,7 +89,7 @@
           <button id="speakertest-button" type="button" class="btn btn-sm btn-secondary" title="Play tone">
             Play Tone
           </button>
-          <span id="speaker-test" class="badge badge-secondary" style="display:none">Not Started</span>
+          <span id="speaker-test" class="badge bg-secondary" style="display:none">Not Started</span>
           <span id="speaker-user-feedback" style="display:none">
             <span>Can you hear a sound?</span>
             <label>
@@ -103,35 +103,35 @@
       </tr>
       <tr>
         <td class="text-left">Mic</td>
-        <td><span id="mic-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="mic-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Camera</td>
-        <td><span id="video-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="video-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Resolution</td>
         <td>
           <span id="camera-test1" ></span>
-          <span id="camera-test2" class="badge badge-secondary">Not Started</span>
+          <span id="camera-test2" class="badge bg-secondary">Not Started</span>
           <span id="camera-test3" ></span>
         </td>
       </tr>
       <tr>
         <td class="text-left">Network - UDP</td>
-        <td><span id="networkudp-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="networkudp-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Network - TCP</td>
-        <td><span id="networktcp-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="networktcp-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Audio Connectivity</td>
-        <td><span id="audioconnectivity-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="audioconnectivity-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Video Connectivity</td>
-        <td><span id="videoconnectivity-test" class="badge badge-secondary">Not Started</span></td>
+        <td><span id="videoconnectivity-test" class="badge bg-secondary">Not Started</span></td>
       </tr>
       <tr>
         <td class="text-left">Content Share</td>
@@ -140,7 +140,7 @@
                   title="Start content share test" disabled>
             Start
           </button>
-          <span id="contentshare-test" class="badge badge-secondary" style="display:none">Not Started</span>
+          <span id="contentshare-test" class="badge bg-secondary" style="display:none">Not Started</span>
         </td>
       </tr>
       </tbody>
@@ -160,7 +160,9 @@
           <small id="failed-meeting-error" class="text-muted"></small>
         </div>
       </div>
-      <button class="btn btn-lg btn-outline-warning btn-block" type="submit">OK</button>
+      <div class="d-grid gap-2">
+        <button class="btn btn-lg btn-outline-warning" type="submit">OK</button>
+      </div>
     </form>
   </div>
 </div>

--- a/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
+++ b/demos/browser/app/meetingReadinessChecker/meetingReadinessChecker.ts
@@ -350,9 +350,9 @@ export class DemoMeetingApp {
       readinessElement.className = 'spinner-border';
     } else if (textToDisplay.includes('Succeeded')) {
       readinessElement.className = '';
-      readinessElement.className = 'badge badge-success';
+      readinessElement.className = 'badge bg-success';
     } else {
-      readinessElement.className = 'badge badge-warning';
+      readinessElement.className = 'badge bg-warning';
     }
   }
 

--- a/demos/browser/app/meetingV2/component/Roster.ts
+++ b/demos/browser/app/meetingV2/component/Roster.ts
@@ -153,18 +153,18 @@ export default class Roster {
 
     private handleRosterStatusUpdate(attendeeId: string): void {
         let statusText = '\xa0'; // &nbsp
-        let statusClass = 'status badge badge-pill ';
+        let statusClass = 'status badge rounded-pill ';
         const attendee: Attendee =  this.attendeeInfoMap.get(attendeeId);        
         if (attendee.signalStrength < 1) {
-            statusClass += 'badge-warning';
+            statusClass += 'bg-warning';
         } else if (attendee.signalStrength === 0) {
-            statusClass = 'badge-danger';
+            statusClass = 'bg-danger';
         } else if (attendee.muted) {
             statusText = 'MUTED';
-            statusClass += 'badge-secondary';
+            statusClass += 'bg-secondary';
         } else if (attendee.speaking) {
             statusText = 'SPEAKING';
-            statusClass += 'badge-success';
+            statusClass += 'bg-success';
         }
 
         const attendeeElement : HTMLLIElement = document.getElementById(Roster.ATTENDEE_ELEMENT_PREFIX + attendeeId) as HTMLLIElement;

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -10,10 +10,12 @@
 
 <div id="flow-fatal" class="flow">
   <div style="vertical-align: middle; text-align: left; width: 40%; margin: 10em 30% 10em 30%;">
-  <h1>Fatal error</h1>
-  <p>An error was thrown that should not occur in ordinary use. This should be considered a fatal error for testing and canary purposes.</p>
-  <p>This error will ordinarily be muffled, but you should consider removing this code if you are building an app based on this demo.</p>
-  <code id="stack"></code>
+    <h1>Fatal error</h1>
+    <p>An error was thrown that should not occur in ordinary use. This should be considered a fatal error for testing
+      and canary purposes.</p>
+    <p>This error will ordinarily be muffled, but you should consider removing this code if you are building an app
+      based on this demo.</p>
+    <code id="stack"></code>
   </div>
 </div>
 
@@ -22,18 +24,17 @@
   <div class="text-muted" style="position:fixed;right:3px;bottom:3px" id="sdk-version"></div>
   <div class="container">
     <form id="form-authenticate">
-      <h1 class="h3 mb-3 font-weight-normal">Join a meeting</h1>
-      <div class="row mt-3">
-        <label for="inputMeeting" class="sr-only">Meeting Title or ID</label>
+      <h1 class="h3 mb-3 fw-normal">Join a meeting</h1>
+      <div class="form-floating row mt-3">
         <input type="name" id="inputMeeting" class="form-control" placeholder="Meeting Title or ID" required autofocus>
+        <label for="inputMeeting" style="text-align: left;">Meeting Title or ID</label>
       </div>
-      <div class="row mt-3">
-        <label for="inputName" class="sr-only">Your Name</label>
+      <div class="form-floating row mt-3">
         <input type="name" id="inputName" class="form-control" placeholder="Your Name" required>
+        <label for="inputName" style="text-align: left;">Your Name</label>
       </div>
-      <div class="row mt-3" title="Used only for meeting creation. Ignored if meeting already exists">
-        <label for="inputRegion" class="sr-only"> Media Region</label>
-        <select id="inputRegion" class="custom-select" style="width:100%">
+      <div class="form-floating row mt-3" title="Used only for meeting creation. Ignored if meeting already exists">
+        <select id="inputRegion" class="form-select" style="width:100%">
           <option value="us-east-1" selected>United States (N. Virginia)</option>
           <option value="ap-northeast-1">Japan (Tokyo)</option>
           <option value="ap-southeast-1">Singapore</option>
@@ -53,104 +54,135 @@
           <option value="us-west-1">United States (N. California)</option>
           <option value="us-west-2">United States (Oregon)</option>
         </select>
+        <label for="inputRegion" style="text-align: left;"> Media Region</label>
       </div>
       <div class="row mt-3">
-        <div class="col-12">
-          <fieldset>
-            <legend>Choose your optional features</legend>
-            <div class="custom-control" style="text-align: left;">
-              <label for="logLevel">Choose a Log Level:</label>
-              <select name="logLevel" id="logLevelSelect">
-                <option value="INFO">INFO</option>
-                <option value="DEBUG">DEBUG</option>
-                <option value="WARN">WARN</option>
-                <option value="ERROR">ERROR</option>
-                <option value="OFF">OFF</option>
-              </select>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="webaudio" class="custom-control-input">
-              <label for="webaudio" class="custom-control-label">Use WebAudio</label>
-            </div>
-            <div class="custom-control custom-checkbox" id='echo-reduction-checkbox' style="text-align: left; display: none;">
-              <input type="checkbox" id="echo-reduction-capability" class="custom-control-input">
-              <label for="echo-reduction-capability" class="custom-control-label">Use Echo Reduction (new meetings only)</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="fullband-speech-mono-quality" class="custom-control-input">
-              <label for="fullband-speech-mono-quality" class="custom-control-label">Set fullband speech (mono) quality</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="fullband-music-mono-quality" class="custom-control-input">
-              <label for="fullband-music-mono-quality" class="custom-control-label">Set fullband music (mono) quality</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="fullband-music-stereo-quality" class="custom-control-input">
-              <label for="fullband-music-stereo-quality" class="custom-control-label">Set fullband music (stereo) quality</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="simulcast" class="custom-control-input">
-              <label for="simulcast" class="custom-control-label">Enable Simulcast for Chrome</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="priority-downlink-policy" class="custom-control-input">
-              <label for="priority-downlink-policy" class="custom-control-label">Use Priority-Based Downlink Policy</label>
-              <select id="priority-downlink-policy-preset" class="custom-select" style="width:100%; display: none;">
-                <option value="default" selected>Default</option>
-                <option value="stable">Stable Network</option>
-                <option value="unstable">Unstable Network</option>
-              </select>
-              <div class="custom-control custom-checkbox"  id="enable-pagination-checkbox" style="text-align: left; display: none;">
-                <input type="checkbox" id="enable-pagination" class="custom-control-input">
-                <label for="enable-pagination" class="custom-control-label">Paginate displayed video tiles</label>
-              </div>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" checked id="preconnect" class="custom-control-input">
-              <label for="preconnect" class="custom-control-label">Open signaling connection early</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="join-view-only" class="custom-control-input">
-              <label for="join-view-only" class="custom-control-label">Join with view-only mode</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="pause-last-frame" class="custom-control-input">
-              <label for="pause-last-frame" class="custom-control-label">Keep Video Last Frame When Paused</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="event-reporting" class="custom-control-input">
-              <label for="event-reporting" class="custom-control-label">Enable event reporting</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="replica-meeting-input" class="custom-control-input">
-              <label for="replica-meeting-input" class="custom-control-label">Create meeting as replica</label>
-              <input type="name" id="primary-meeting-external-id" class="form-control" placeholder="Primary Meeting Title or ID">
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="delete-attendee" class="custom-control-input">
-              <label for="delete-attendee" class="custom-control-label">Delete own attendee to leave</label>
-            </div>
-            <div class="custom-control custom-checkbox" style="text-align: left;">
-              <input type="checkbox" id="die" class="custom-control-input">
-              <label for="die" class="custom-control-label">Abort on fatal errors</label>
-            </div>
-          </fieldset>
+        <button type="button" class="btn btn-outline-secondary h-50 d-sm-block" data-bs-toggle="modal" id="additional-options-button"
+          data-bs-target="#additional-options-modal">
+          Additional Options
+        </button>
+      </div>
+      <div class="row mt-3">
+        <div class="btn-group p-0" role="group">
+          <button id="authenticate" class="btn btn-lg btn-secondary w-100" type="submit">Continue</button>
+          <button id="quick-join" class="btn btn-lg btn-success"type="submit" title="Skip Device Selection"><%= require('../../node_modules/open-iconic/svg/bolt.svg') %></button>
         </div>
-      </div>
-      <div class="row mt-3">
-        <button id="authenticate" class="btn btn-lg btn-primary btn-block" type="submit">Continue</button>
       </div>
       <div class="row mt-3">
         <p>Anyone with access to the meeting link can join.</p>
       </div>
-      <a id="to-sip-flow" class="row mt-3" href="#">Joining via SIP? Click here.</a>
+      <div class="row mt-3">
+        <a id="to-sip-flow" href="#">Joining via SIP? Click here.</a>
+      </div>
       <div class="row mt-3">
         <div id="progress-authenticate" class="w-100 progress progress-hidden">
-          <div class="w-100 progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+          <div class="w-100 progress-bar progress-bar-striped progress-bar-animated" role="progressbar"
+            aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
         </div>
       </div>
     </form>
   </div>
+</div>
+
+<!-- Additional options modal -->
+
+<div class="modal fade" id="additional-options-modal" tabindex="-1"
+aria-labelledby="additional-options-modal-label" aria-hidden="true">
+<div class="modal-dialog">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title" id="additional-options-modal-label">Additional Options</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+    </div>
+    <div class="modal-body">
+      <fieldset>
+        <div class="custom-control" style="text-align: left;">
+          <label for="logLevel">Choose a Log Level:</label>
+          <select name="logLevel" class="form-select" id="logLevelSelect">
+            <option value="INFO">INFO</option>
+            <option value="DEBUG">DEBUG</option>
+            <option value="WARN">WARN</option>
+            <option value="ERROR">ERROR</option>
+            <option value="OFF">OFF</option>
+          </select>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="webaudio" class="form-check-input">
+          <label for="webaudio" class="form-check-label">Use WebAudio</label>
+        </div>
+        <div class="form-check" id='echo-reduction-checkbox' style="text-align: left; display: none;">
+          <input type="checkbox" id="echo-reduction-capability" class="form-check-input">
+          <label for="echo-reduction-capability" class="form-check-label">Use Echo Reduction (new meetings
+            only)</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="fullband-speech-mono-quality" class="form-check-input">
+          <label for="fullband-speech-mono-quality" class="form-check-label">Set fullband speech (mono)
+            quality</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="fullband-music-mono-quality" class="form-check-input">
+          <label for="fullband-music-mono-quality" class="form-check-label">Set fullband music (mono)
+            quality</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="fullband-music-stereo-quality" class="form-check-input">
+          <label for="fullband-music-stereo-quality" class="form-check-label">Set fullband music (stereo)
+            quality</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="simulcast" class="form-check-input">
+          <label for="simulcast" class="form-check-label">Enable Simulcast for Chrome</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="priority-downlink-policy" class="form-check-input">
+          <label for="priority-downlink-policy" class="form-check-label">Use Priority-Based Downlink
+            Policy</label>
+          <select id="priority-downlink-policy-preset" class="form-select" style="width:100%; display: none;">
+            <option value="default" selected>Default</option>
+            <option value="stable">Stable Network</option>
+            <option value="unstable">Unstable Network</option>
+          </select>
+          <div class="form-check" id="enable-pagination-checkbox" style="text-align: left; display: none;">
+            <input type="checkbox" id="enable-pagination" class="form-check-input">
+            <label for="enable-pagination" class="form-check-label">Paginate displayed video tiles</label>
+          </div>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" checked id="preconnect" class="form-check-input">
+          <label for="preconnect" class="form-check-label">Open signaling connection early</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="join-view-only" class="form-check-input">
+          <label for="join-view-only" class="form-check-label">Join with view-only mode</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="pause-last-frame" class="form-check-input">
+          <label for="pause-last-frame" class="form-check-label">Keep Video Last Frame When Paused</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="event-reporting" class="form-check-input">
+          <label for="event-reporting" class="form-check-label">Enable event reporting</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="replica-meeting-input" class="form-check-input">
+          <label for="replica-meeting-input" class="form-check-label">Create meeting as replica</label>
+          <input type="name" id="primary-meeting-external-id" class="form-control"
+            placeholder="Primary Meeting Title or ID">
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="delete-attendee" class="form-check-input">
+          <label for="delete-attendee" class="form-check-label">Delete own attendee to leave</label>
+        </div>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="die" class="form-check-input">
+          <label for="die" class="form-check-label">Abort on fatal errors</label>
+        </div>
+      </fieldset>
+    </div>
+    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="additional-options-save-button">Save</button>
+  </div>
+</div>
 </div>
 
 <!-- Authenticate for SIP with meeting and voice connector ID -->
@@ -160,15 +192,15 @@
     <form id="form-sip-authenticate">
       <h1 class="h3 mb-3 font-weight-normal">Join a meeting via SIP</h1>
       <div class="row mt-3">
-        <label for="sip-inputMeeting" class="sr-only">Meeting Title</label>
+        <label for="sip-inputMeeting" class="visually-hidden">Meeting Title</label>
         <input type="name" id="sip-inputMeeting" class="form-control" placeholder="Meeting Title" required autofocus>
       </div>
       <div class="row mt-3">
-        <label for="voiceConnectorId" class="sr-only">Voice Connector ID</label>
+        <label for="voiceConnectorId" class="visually-hidden">Voice Connector ID</label>
         <input type="name" id="voiceConnectorId" class="form-control" placeholder="Voice Connector ID" required>
       </div>
       <div class="row mt-3">
-        <button id="button-sip-authenticate" class="btn btn-lg btn-primary btn-block" type="submit">Continue</button>
+        <button id="button-sip-authenticate" class="btn btn-lg btn-primary" type="submit">Continue</button>
       </div>
       <div class="row mt-3">
         <p>You will need a SIP client in order to join the meeting.</p>
@@ -186,11 +218,14 @@
         <div id="failed-meeting" class="card-header"></div>
         <div class="card-body">
           <h4 class="card-title">Unable to find meeting</h4>
-          <p class="card-text">There was an issue finding that meeting. The meeting may have already ended, or your authorization may have expired.</p>
+          <p class="card-text">There was an issue finding that meeting. The meeting may have already ended, or your
+            authorization may have expired.</p>
           <small id="failed-meeting-error" class="text-muted"></small>
         </div>
       </div>
-      <button class="btn btn-lg btn-outline-warning btn-block" type="submit">OK</button>
+      <div class="d-grid gap-2">
+        <button class="btn btn-lg btn-outline-warning" type="submit">OK</button>
+      </div>
     </form>
   </div>
 </div>
@@ -204,7 +239,8 @@
         <div class="card-header">Permissions check</div>
         <div class="card-body">
           <h4 class="card-title">Unable to get device labels</h4>
-          <p class="card-text">In order to select media devices, we need to do a quick permissions check of your mic and camera. When the pop-up appears, choose <b>Allow</b>.</p>
+          <p class="card-text">In order to select media devices, we need to do a quick permissions check of your mic
+            and camera. When the pop-up appears, choose <b>Allow</b>.</p>
         </div>
       </div>
     </form>
@@ -241,13 +277,14 @@
       <div class="row mt-3">
         <div class="col-12">
           <label for="audio-input block">Microphone</label>
-          <select id="audio-input" class="custom-select" style="width:100%"></select>
+          <select id="audio-input" class="form-select" style="width:100%"></select>
         </div>
 
         <div class="text-center col-12 d-sm-block">
           <label>Preview</label>
           <div class="w-100 progress" style="margin-top:0.75rem">
-            <div id="audio-preview" class="progress-bar bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+            <div id="audio-preview" class="progress-bar bg-success" role="progressbar" aria-valuenow="0"
+              aria-valuemin="0" aria-valuemax="100"></div>
           </div>
         </div>
       </div>
@@ -260,14 +297,14 @@
       <div class="row mt-3">
         <div class="col-12">
           <label for="video-input block">Camera</label>
-          <select id="video-input" class="custom-select" style="width:100%"></select>
+          <select id="video-input" class="form-select" style="width:100%"></select>
         </div>
 
       </div>
       <div class="row mt-3">
         <div class="col-12">
           <label for="video-input-quality block">Resolution</label>
-          <select id="video-input-quality" class="custom-select" style="width:100%">
+          <select id="video-input-quality" class="form-select" style="width:100%">
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
             <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
             <option value="720p">720p (HD) @ 15 fps (1.4 Mbps max)</option>
@@ -277,7 +314,7 @@
       <div class="row mt-3" id="video-input-filter-container">
         <div class="col-12">
           <label for="video-input-filter block">Video Filter</label>
-          <select id="video-input-filter" class="custom-select" style="width:100%">
+          <select id="video-input-filter" class="form-select" style="width:100%">
             <option value="None" selected>None</option>
           </select>
         </div>
@@ -285,16 +322,18 @@
       <div class="row mt-3">
         <div class="col-12">
           <label for="audio-output block">Speaker</label>
-          <select id="audio-output" class="custom-select" style="width:100%"></select>
+          <select id="audio-output" class="form-select" style="width:100%"></select>
         </div>
         <div class="col-12">
-          <button id="button-test-sound" class="btn btn-outline-secondary btn-block h-50 d-sm-block" style="margin-top:2rem">Test Speaker</button>
+          <button id="button-test-sound" class="btn btn-outline-secondary h-50 d-sm-block"
+            style="width:100%;margin-top:2rem">Test Speaker</button>
         </div>
       </div>
 
       <div class="row mt-3">
         <div class="col-lg">
-          <button id="joinButton" class="btn btn-lg btn-primary btn-block" type="submit">Join</button>
+          <button id="joinButton" class="btn btn-lg btn-primary" style="width:100%"
+            type="submit">Join</button>
         </div>
       </div>
       <div class="row mt-3">
@@ -304,7 +343,8 @@
       </div>
     </form>
     <div id="progress-join" class="w-100 progress progress-hidden">
-      <div class="w-100 progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+      <div class="w-100 progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="100"
+        aria-valuemin="0" aria-valuemax="100"></div>
     </div>
   </div>
 </div>
@@ -322,13 +362,14 @@
       <div id="engine-option-group active">
         <input type="radio" id="engine-transcribe" name="transcription-engine" value="engine-transcribe" checked=true>
         <label for="engine-transcribe">Amazon Transcribe</label><br>
-        <input type="radio" id="engine-transcribe-medical" name="transcription-engine" value="engine-transcribe-medical">
+        <input type="radio" id="engine-transcribe-medical" name="transcription-engine"
+          value="engine-transcribe-medical">
         <label for="engine-transcribe-medical">Amazon Transcribe Medical</label><br>
       </div>
       <div id="engine-language-group">
         <div id="engine-transcribe-language">
-          <label for="transcribe-language" class="sr-only">Language</label>
-          <select id="transcribe-language" class="custom-select"  style="width:100%">
+          <label for="transcribe-language" class="visually-hidden">Language</label>
+          <select id="transcribe-language" class="form-select" style="width:100%">
             <option value="en-US" selected>US English (en-US)</option>
             <option value="en-GB">British English (en-GB)</option>
             <option value="en-AU">Australian English (en-AU)</option>
@@ -344,16 +385,16 @@
           </select>
         </div>
         <div id="engine-transcribe-medical-language" class="hidden">
-          <label for="transcribe-medical-language" class="sr-only">Language</label>
-          <select id="transcribe-medical-language" class="custom-select"  style="width:100%">
+          <label for="transcribe-medical-language" class="visually-hidden">Language</label>
+          <select id="transcribe-medical-language" class="form-select" style="width:100%">
             <option value="en-US" selected>US English (en-US)</option>
           </select>
         </div>
       </div>
       <div id="transcription-region-group">
         <div id="engine-transcribe-region">
-          <label for="transcribe-region" class="sr-only">Region</label>
-          <select id="transcribe-region" class="custom-select"  style="width:100%">
+          <label for="transcribe-region" class="visually-hidden">Region</label>
+          <select id="transcribe-region" class="form-select" style="width:100%">
             <option value="auto" selected>Auto</option>
             <option value="">Not specified</option>
             <option value="ap-northeast-1">Japan (Tokyo)</option>
@@ -370,8 +411,8 @@
           </select>
         </div>
         <div id="engine-transcribe-medical-region" class="hidden">
-          <label for="transcribe-medical-region" class="sr-only">Language</label>
-          <select id="transcribe-medical-region" class="custom-select"  style="width:100%">
+          <label for="transcribe-medical-region" class="visually-hidden">Language</label>
+          <select id="transcribe-medical-region" class="form-select" style="width:100%">
             <option value="auto" selected>Auto</option>
             <option value="">Not specified</option>
             <option value="ap-southeast-2">Australia (Sydney)</option>
@@ -384,14 +425,20 @@
         </div>
       </div>
       <div id="engine-transcribe-language-identification">
-        <div id="engine-transcribe-identify-language" class="custom-control custom-checkbox" style="text-align: left;">
-          <input type="checkbox" id="identify-language-checkbox" class="custom-control-input">
-          <label for="identify-language-checkbox" class="custom-control-label" title="Automatically identify the language spoken in a media file without you having to specify a language code">Enable Automatic Language Identification</label>
+        <div id="engine-transcribe-identify-language" class="form-check" style="text-align: left;">
+          <input type="checkbox" id="identify-language-checkbox" class="form-check-input">
+          <label for="identify-language-checkbox" class="form-check-label"
+            title="Automatically identify the language spoken in a media file without you having to specify a language code">Enable
+            Automatic Language Identification</label>
         </div>
         <div id="language-options" class="hidden">
-          <label for="language-options" class="sr-only">Language Options</label>
-          <p title="For better accuracy of automatic language identification, select at least 2 languages, one from each group."><small>Select a minimum of 2 language options</small></p>
-          <select name="language-options" id="language-options" multiple="multiple" class="custom-select" style="width:100%">
+          <label for="language-options" class="visually-hidden">Language Options</label>
+          <p
+            title="For better accuracy of automatic language identification, select at least 2 languages, one from each group.">
+            <small>Select a minimum of 2 language options</small>
+          </p>
+          <select name="language-options" id="language-options" multiple="multiple" class="form-select"
+            style="width:100%">
             <optgroup id="group1" label="English">
               <option value="en-US">US English (en-US)</option>
               <option value="en-GB">British English (en-GB)</option>
@@ -426,30 +473,33 @@
           <div id="language-options-error-message"></div>
         </div>
         <div id="preferred-language" class="hidden" style="margin-top: 10px">
-          <label for="preferred-language-selection" class="sr-only">Preferred Language</label>
-          <p title="Help Amazon Transcribe identify the language in the first few seconds of your stream."><small>Specify one preferred language</small></p>
-          <select id="preferred-language-selection" class="custom-select" style="width:100%">
+          <label for="preferred-language-selection" class="visually-hidden">Preferred Language</label>
+          <p title="Help Amazon Transcribe identify the language in the first few seconds of your stream.">
+            <small>Specify one preferred language</small>
+          </p>
+          <select id="preferred-language-selection" class="form-select" style="width:100%">
             <option value="" selected> -- Optional -- </option>
           </select>
         </div>
       </div>
       <div id="engine-transcribe-custom-language-model">
-        <div id="engine-transcribe-language-model" class="custom-control custom-checkbox" style="text-align: left;">
-          <input type="checkbox" id="custom-language-model-checkbox" class="custom-control-input">
-          <label for="custom-language-model-checkbox" class="custom-control-label">Enable Custom Language Model</label>
+        <div id="engine-transcribe-language-model" class="form-check" style="text-align: left;">
+          <input type="checkbox" id="custom-language-model-checkbox" class="form-check-input">
+          <label for="custom-language-model-checkbox" class="form-check-label">Enable Custom Language Model</label>
         </div>
         <div id="language-model" class="hidden">
           <input type="text" id="language-model-input-text" style="text-align: left; width:100%">
         </div>
       </div>
       <div id="engine-transcribe-stability">
-        <div id="engine-transcribe-partial-stabilization" class="custom-control custom-checkbox" style="text-align: left;">
-          <input type="checkbox" id="partial-stabilization-checkbox" class="custom-control-input">
-          <label for="partial-stabilization-checkbox" class="custom-control-label">Enable Partial Results Stabilization</label>
+        <div id="engine-transcribe-partial-stabilization" class="form-check" style="text-align: left;">
+          <input type="checkbox" id="partial-stabilization-checkbox" class="form-check-input">
+          <label for="partial-stabilization-checkbox" class="form-check-label">Enable Partial Results
+            Stabilization</label>
         </div>
         <div id="transcribe-partial-stability" class="hidden">
-          <label for="partial-stability" class="sr-only">Transcribe Entities</label>
-          <select id="partial-stability" class="custom-select"  style="width:100%">
+          <label for="partial-stability" class="visually-hidden">Transcribe Entities</label>
+          <select id="partial-stability" class="form-select" style="width:100%">
             <option value="" selected> -- DEFAULT (HIGH) -- </option>
             <option value="low">LOW</option>
             <option value="medium">MEDIUM</option>
@@ -457,21 +507,23 @@
           </select>
         </div>
       </div>
-      <div id="engine-transcribe-content-identification" class="custom-control custom-checkbox" style="text-align: left;">
-        <input type="checkbox" id="content-identification-checkbox" class="custom-control-input">
-        <label for="content-identification-checkbox" class="custom-control-label">Enable PII Content Identification</label>
+      <div id="engine-transcribe-content-identification" class="form-check" style="text-align: left;">
+        <input type="checkbox" id="content-identification-checkbox" class="form-check-input">
+        <label for="content-identification-checkbox" class="form-check-label">Enable PII Content
+          Identification</label>
       </div>
-      <div id="engine-transcribe-medical-content-identification" class="custom-control custom-checkbox hidden" style="text-align: left;">
-        <input type="checkbox" id="medical-content-identification-checkbox" class="custom-control-input">
-        <label for="medical-content-identification-checkbox" class="custom-control-label">Enable PHI Content Identification</label>
+      <div id="engine-transcribe-medical-content-identification" class="form-check hidden" style="text-align: left;">
+        <input type="checkbox" id="medical-content-identification-checkbox" class="form-check-input">
+        <label for="medical-content-identification-checkbox" class="form-check-label">Enable PHI Content
+          Identification</label>
       </div>
-      <div id="engine-transcribe-redaction" class="custom-control custom-checkbox" style="text-align: left;">
-        <input type="checkbox" id="content-redaction-checkbox" class="custom-control-input">
-        <label for="content-redaction-checkbox" class="custom-control-label">Enable PII Content Redaction</label>
+      <div id="engine-transcribe-redaction" class="form-check" style="text-align: left;">
+        <input type="checkbox" id="content-redaction-checkbox" class="form-check-input">
+        <label for="content-redaction-checkbox" class="form-check-label">Enable PII Content Redaction</label>
       </div>
       <div id="transcribe-entity-types" class="hidden">
-        <label for="transcribe-entity" class="sr-only">Transcribe Entities</label>
-        <select id="transcribe-entity" class="custom-select"  style="width:100%" multiple>
+        <label for="transcribe-entity" class="visually-hidden">Transcribe Entities</label>
+        <select id="transcribe-entity" class="form-select" style="width:100%" multiple>
           <option selected value> -- DEFAULT (ALL) -- </option>
           <option value="BANK_ROUTING">BANK ROUTING</option>
           <option value="CREDIT_DEBIT_NUMBER">CREDIT/DEBIT NUMBER</option>
@@ -485,7 +537,8 @@
           <option value="SSN">SSN</option>
         </select>
       </div>
-      <button id="button-start-transcription" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Start" data-toggle="button" aria-pressed="false" autocomplete="off">
+      <button id="button-start-transcription" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Start"
+        data-bs-toggle="button" aria-pressed="false" autocomplete="off">
         <%= require('../../node_modules/open-iconic/svg/caret-right.svg') %>
       </button>
     </div>
@@ -498,13 +551,17 @@
       </div>
       <div class="col">
         <div class="btn-group" role="group" style="width: 100%;">
-          <button type="button" id="video-paginate-left" class="btn btn-secondary" style="display: none;"><%= require('../../node_modules/open-iconic/svg/caret-left.svg') %></button>
-          <button type="button" id="video-paginate-right" class="btn btn-secondary" style="display: none;"><%= require('../../node_modules/open-iconic/svg/caret-right.svg') %></button>
+          <button type="button" id="video-paginate-left" class="btn btn-secondary" style="display: none;">
+            <%= require('../../node_modules/open-iconic/svg/caret-left.svg') %>
+          </button>
+          <button type="button" id="video-paginate-right" class="btn btn-secondary" style="display: none;">
+            <%= require('../../node_modules/open-iconic/svg/caret-right.svg') %>
+          </button>
         </div>
       </div>
       <div class="col d-none d-lg-block">
-        <div id="video-uplink-bandwidth" class="text-muted text-right"></div>
-        <div id="video-downlink-bandwidth" class="text-muted text-right"></div>
+        <div id="video-uplink-bandwidth" class="text-muted text-end"></div>
+        <div id="video-downlink-bandwidth" class="text-muted text-end"></div>
       </div>
     </div>
   </div>
@@ -516,29 +573,30 @@
         <div id="mobile-chime-meeting-id" class="text-muted d-block d-sm-none" style="font-size:0.65rem;"></div>
         <div id="mobile-attendee-id" class="text-muted d-block d-sm-none mb-2" style="font-size:0.65rem;"></div>
         <div id="mobile-video-uplink-bandwidth" class="text-muted d-block d-sm-none" style="font-size:0.65rem;"></div>
-        <div id="mobile-video-downlink-bandwidth" class="text-muted d-block d-sm-none mb-2" style="font-size:0.65rem;"></div>
+        <div id="mobile-video-downlink-bandwidth" class="text-muted d-block d-sm-none mb-2" style="font-size:0.65rem;">
+        </div>
       </div>
       <div class="col-8 col-lg-6 order-2 order-lg-2 text-left text-lg-center">
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle microphone">
           <button id="button-microphone" type="button" class="btn btn-success" title="Toggle microphone">
             <%= require('../../node_modules/open-iconic/svg/microphone.svg') %>
           </button>
-          <div class="btn-group" role="group">
-            <button id="button-microphone-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select microphone"></button>
-            <div id="dropdown-menu-microphone" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-microphone-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
-              <a class="dropdown-item" href="#">Default microphone</a>
-            </div>
+          <button id="button-microphone-drop" type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown"
+            aria-expanded="false" title="Select microphone"><span class="visually-hidden">Toggle Dropdown</span></button>
+          <div id="dropdown-menu-microphone" class="dropdown-menu dropdown-menu-end"
+          aria-labelledby="button-microphone-drop" x-placement="bottom-start"
+          style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <a class="dropdown-item" href="#">Default microphone</a>
           </div>
         </div>
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle camera">
           <button id="button-camera" type="button" class="btn btn-success" title="Toggle camera">
             <%= require('../../node_modules/open-iconic/svg/video.svg') %>
           </button>
-          <div class="btn-group" role="group">
-            <button id="button-camera-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select camera"></button>
-            <div id="dropdown-menu-camera" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-camera-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
-              <a class="dropdown-item" href="#">Default camera</a>
-            </div>
+          <button id="button-camera-drop" type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown"
+            aria-expanded="false" title="Select camera"><span class="visually-hidden">Toggle Dropdown</span></button>
+          <div id="dropdown-menu-camera" class="dropdown-menu dropdown-menu-end">
+            <a class="dropdown-item" href="#">Default camera</a>
           </div>
         </div>
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Apply filter">
@@ -546,8 +604,10 @@
             <%= require('../../node_modules/open-iconic/svg/contrast.svg') %>
           </button>
           <div class="btn-group" role="group">
-            <button id="button-video-filter-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select filter"></button>
-            <div id="dropdown-menu-filter" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-video-filter-drop" x-placement="bottom-start">
+            <button id="button-video-filter-drop" type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split"
+            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select filter"></button>
+            <div id="dropdown-menu-filter" class="dropdown-menu dropdown-menu-end"
+              aria-labelledby="button-video-filter-drop" x-placement="bottom-start">
               <a class="dropdown-item" href="#">No filter</a>
             </div>
           </div>
@@ -557,19 +617,29 @@
             <%= require('../../node_modules/open-iconic/svg/camera-slr.svg') %>
           </button>
           <div class="btn-group" role="group">
-            <button id="button-content-share-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select content to share"></button>
-            <div id="dropdown-menu-content-share" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-content-share-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <button id="button-content-share-drop" type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+              title="Select content to share"></button>
+            <div id="dropdown-menu-content-share" class="dropdown-menu dropdown-menu-end"
+              aria-labelledby="button-content-share-drop" x-placement="bottom-start"
+              style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a id="dropdown-item-content-share-screen-capture" class="dropdown-item" href="#">Screen Capture...</a>
               <a id="dropdown-item-content-share-screen-test-video" class="dropdown-item" href="#">Test Video</a>
-              <a id="dropdown-item-content-share-test-mono-audio-speech" class="dropdown-item" href="#">Test Mono Audio Speech</a>
-              <a id="dropdown-item-content-share-test-stereo-audio-speech" class="dropdown-item" href="#">Test Stereo Audio Speech</a>
-              <a id="dropdown-item-content-share-test-stereo-audio-tone" class="dropdown-item" href="#">Test Stereo Tone (L-500Hz R-1000Hz)</a>
-              <a id="dropdown-item-content-share-file-item" class="dropdown-item" href="#"><input id="content-share-item" type="file"></a>
-              <a id="dropdown-item-content-share-stop" style="display:none" class="dropdown-item" href="#">Stop Sharing</a>
+              <a id="dropdown-item-content-share-test-mono-audio-speech" class="dropdown-item" href="#">Test Mono
+                Audio Speech</a>
+              <a id="dropdown-item-content-share-test-stereo-audio-speech" class="dropdown-item" href="#">Test Stereo
+                Audio Speech</a>
+              <a id="dropdown-item-content-share-test-stereo-audio-tone" class="dropdown-item" href="#">Test Stereo
+                Tone (L-500Hz R-1000Hz)</a>
+              <a id="dropdown-item-content-share-file-item" class="dropdown-item" href="#"><input
+                  id="content-share-item" type="file"></a>
+              <a id="dropdown-item-content-share-stop" style="display:none" class="dropdown-item" href="#">Stop
+                Sharing</a>
             </div>
           </div>
         </div>
-        <button id="button-pause-content-share" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Pause and unpause content share">
+        <button id="button-pause-content-share" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Pause and unpause content share">
           <%= require('../../node_modules/open-iconic/svg/media-pause.svg') %>
         </button>
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle speaker">
@@ -577,33 +647,47 @@
             <%= require('../../node_modules/open-iconic/svg/volume-low.svg') %>
           </button>
           <div class="btn-group" role="group">
-            <button id="button-speaker-drop" type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select speaker"></button>
-            <div id="dropdown-menu-speaker" class="dropdown-menu dropdown-menu-right" aria-labelledby="button-speaker-drop" x-placement="bottom-start" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+            <button id="button-speaker-drop" type="button" class="btn btn-success dropdown-toggle dropdown-toggle-split"
+              data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Select speaker"></button>
+            <div id="dropdown-menu-speaker" class="dropdown-menu dropdown-menu-end"
+              aria-labelledby="button-speaker-drop" x-placement="bottom-start"
+              style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
               <a class="dropdown-item" href="#">Default speaker</a>
             </div>
           </div>
         </div>
-        <button id="button-live-transcription" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Toggle live transcription display" data-toggle="button" aria-pressed="false" autocomplete="off" style="display: none">
+        <button id="button-live-transcription" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Toggle live transcription display" data-bs-toggle="button" aria-pressed="false" autocomplete="off"
+          style="display: none">
           <%= require('../../node_modules/open-iconic/svg/code.svg') %>
         </button>
-        <button id="button-video-stats" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Toggle video WebRTC stats display" data-toggle="button" aria-pressed="false" autocomplete="off">
+        <button id="button-video-stats" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Toggle video WebRTC stats display" data-bs-toggle="button" aria-pressed="false" autocomplete="off">
           <%= require('../../node_modules/open-iconic/svg/signal.svg') %>
         </button>
-        <button id="button-record-self" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Record my audio and video" data-toggle="button" aria-pressed="false" autocomplete="off">
-          <svg class="svg"><circle id="rec-svg" cx="10" cy="10" r="8" fill="red"></circle></svg>
+        <button id="button-record-self" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Record my audio and video" data-bs-toggle="button" aria-pressed="false" autocomplete="off">
+          <svg class="svg">
+            <circle id="rec-svg" cx="10" cy="10" r="8" fill="red"></circle>
+          </svg>
         </button>
-        <button id="button-record-cloud" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Capture audio and video in the cloud" data-toggle="button" aria-pressed="false" autocomplete="off">
+        <button id="button-record-cloud" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Capture audio and video in the cloud" data-bs-toggle="button" aria-pressed="false" autocomplete="off">
           <%= require('../../node_modules/open-iconic/svg/cloud-upload.svg') %>
         </button>
-        <button id="button-promote-to-primary" type="button" class="btn btn-success mx-1 mx-xl-2 my-2" title="Promote to or demote from Primary meeting" data-toggle="button" aria-pressed="false" autocomplete="off">
-            <%= require('../../node_modules/open-iconic/svg/badge.svg') %>
+        <button id="button-promote-to-primary" type="button" class="btn btn-success mx-1 mx-xl-2 my-2"
+          title="Promote to or demote from Primary meeting" data-bs-toggle="button" aria-pressed="false"
+          autocomplete="off">
+          <%= require('../../node_modules/open-iconic/svg/badge.svg') %>
         </button>
       </div>
-      <div class="col-4 col-lg-3 order-3 order-lg-3 text-right text-lg-right">
-        <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4" title="Leave meeting">
+      <div class="col-4 col-lg-3 order-3 order-lg-3 text-end text-lg-right">
+        <button id="button-meeting-leave" type="button" class="btn btn-outline-success mx-1 mx-xl-2 my-2 px-4"
+          title="Leave meeting">
           <%= require('../../node_modules/open-iconic/svg/account-logout.svg') %>
         </button>
-        <button id="button-meeting-end" type="button" class="btn btn-outline-danger mx-1 mx-xl-2 my-2 px-4" title="End meeting">
+        <button id="button-meeting-end" type="button" class="btn btn-outline-danger mx-1 mx-xl-2 my-2 px-4"
+          title="End meeting">
           <%= require('../../node_modules/open-iconic/svg/power-standby.svg') %>
         </button>
       </div>
@@ -617,12 +701,14 @@
           <div class="list-group receive-message" id="receive-message" style="flex: 1 1 auto; overflow-y: auto;
             border: 1px solid rgba(0, 0, 0, 0.125); background-color: #fff"></div>
           <div class="input-group send-message" style="display:flex;flex:0 0 auto;margin-top:0.2rem">
-            <textarea class="form-control shadow-none" id="send-message" rows="1" placeholder="Type a message (markdown supported)" style="display:inline-block; width:100%;
+            <textarea class="form-control shadow-none" id="send-message" rows="1"
+              placeholder="Type a message (markdown supported)" style="display:inline-block; width:100%;
               resize:none; border-color: rgba(0, 0, 0, 0.125); outline: none; padding-left: 1.4rem"></textarea>
           </div>
         </div>
       </div>
-      <div id="tile-transcript-container" class="d-flex flex-column col-12 col-sm-7 col-md-8 col-lg-9 my-4 my-sm-0 h-100" style="overflow-y: scroll">
+      <div id="tile-transcript-container"
+        class="d-flex flex-column col-12 col-sm-7 col-md-8 col-lg-9 my-4 my-sm-0 h-100" style="overflow-y: scroll">
         <div id="tile-area" class="v-grid"></div>
         <div id="transcript-container" class="transcript-container" style="display:none"></div>
       </div>
@@ -647,7 +733,9 @@
           <small id="failed-join-error" class="text-muted"></small>
         </div>
       </div>
-      <button class="btn btn-lg btn-outline-warning btn-block" type="submit">OK</button>
+      <div class="d-grid gap-2">
+        <button class="btn btn-lg btn-outline-warning" type="submit">OK</button>
+      </div>
     </form>
   </div>
 </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -705,7 +705,15 @@ export class DemoMeetingApp
             this.setButtonVisibility('button-record-cloud', false);
             this.updateUXForReplicaMeetingPromotionState('demoted');
           }
-
+          /* @ts-ignore */
+          if ((e as SubmitEvent).submitter.id == 'quick-join') {
+            await this.openAudioOutputFromSelection();
+            await this.join();
+            this.displayButtonStates();
+            this.switchToFlow('flow-meeting');
+            this.hideProgress('progress-authenticate');
+            return;
+          }
           this.switchToFlow('flow-devices');
           await this.openAudioInputFromSelectionAndPreview();
           try {

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -29,9 +29,10 @@ $light: $gray-200;
 $dark: $gray-700;
 $yiq-contrasted-threshold: 175;
 $link-color: $success;
-$font-family-sans-serif: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+$font-family-base: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
   'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 $font-size-base: 0.9375rem;
+$form-select-color: $gray-700;
 $h1-font-size: 3rem;
 $h2-font-size: 2.5rem;
 $h3-font-size: 2rem;
@@ -95,10 +96,29 @@ $overlay-z-index: 10;
 // Buttons =====================================================================
 
 .btn {
+  &-success,
+  &-success:hover,
+  &-success:focus,
   &-secondary,
   &-secondary:hover,
+  &-secondary:focus,
   &-warning,
-  &-warning:hover {
+  &-warning:hover,
+  &-warning:focus {
+    color: #fff;
+  }
+}
+
+.btn-check:checked + .btn {
+  &-success,
+  &-success:hover,
+  &-success:checked,
+  &-secondary,
+  &-secondary:hover,
+  &-secondary:checked,
+  &-warning,
+  &-warning:hover,
+  &-warning:checked {
     color: #fff;
   }
 }
@@ -344,6 +364,7 @@ $overlay-z-index: 10;
 // Progress bars ===============================================================
 
 // Containers ==================================================================
+
 .modal .close {
   color: $black;
 
@@ -351,6 +372,10 @@ $overlay-z-index: 10;
   &:not(:disabled):not(.disabled):focus {
     color: $black;
   }
+}
+
+.modal-backdrop {
+  z-index: -1;
 }
 
 // Custom
@@ -378,6 +403,10 @@ svg {
   width: 20px;
   height: 20px;
   fill: lighten($secondary, 15%);
+}
+
+#form-authenticate svg {
+  fill: $white !important;
 }
 
 .svg-active {

--- a/demos/browser/app/meetingV2/video/VideoTile.ts
+++ b/demos/browser/app/meetingV2/video/VideoTile.ts
@@ -8,42 +8,48 @@ export class DemoVideoTile extends HTMLElement {
   <div class="video-tile-nameplate"></div>
   <div class="video-tile-pause-state"></div>
   <div class="button-video-tile-config" role="group">
-    <button type="button" class="btn btn-success dropdown-toggle button-video-tile-config-drop" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Video Tile Settings"><%= require('../../../node_modules/open-iconic/svg/cog.svg') %></button>
-    <div class="dropdown-menu dropdown-menu-right dropdown-video-tile-config" aria-labelledby="button-video-tile-config-drop" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
+    <button type="button" class="btn btn-success dropdown-toggle button-video-tile-config-drop" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="Video Tile Settings"><%= require('../../../node_modules/open-iconic/svg/cog.svg') %></button>
+    <div class="dropdown-menu dropdown-menu-end dropdown-video-tile-config" aria-labelledby="button-video-tile-config-drop" style="position: absolute; transform: translate3d(0px, 38px, 0px); top: 0px; left: 0px; will-change: transform;">
       <a class="dropdown-item video-tile-pause">Pause</a>
       <div class="dropdown-divider"></div>
       <h6 class="dropdown-header target-resolution-header">Target Resolution</h6>
-      <form class="btn-group btn-group-toggle video-tile-config-toggle target-resolution-toggle" data-toggle="buttons">
-        <label class="btn btn-secondary">
-          <input type="radio" name="level" value="low" autocomplete="off">Low
-        </label>
-        <label class="btn btn-secondary">
-          <input type="radio" name="level" value="medium" autocomplete="off">Medium
-        </label>
-        <label class="btn btn-secondary active">
-          <input type="radio" name="level" value="high" autocomplete="off" checked>High
-        </label>
+      <form class="btn-group video-tile-config-toggle target-resolution-toggle" role="group">
+        <input type="radio" class="btn-check" name="level" value="low" id="resolution-low">
+        <label class="btn btn-secondary" id="resolution-low-label" for="low">Low</label>
+        <input type="radio" class="btn-check" name="level" value="medium" id="resolution-medium">
+        <label class="btn btn-secondary" id="resolution-medium-label" for="medium">Medium</label>
+        <input type="radio" class="btn-check" name="level" value="high" id="resolution-high" checked>
+        <label class="btn btn-secondary" id="resolution-high-label" for="high">High</label>
       </form>
       <h6 class="dropdown-header video-priority-header">Video Priority</h6>
-      <form class="btn-group btn-group-toggle video-tile-config-toggle video-priority-toggle" data-toggle="buttons">
-        <label class="btn btn-secondary">
-          <input type="radio" name="level" value="low" autocomplete="off">Low
-        </label>
-        <label class="btn btn-secondary active">
-          <input type="radio" name="level" value="medium" autocomplete="off" checked>Medium
-        </label>
-        <label class="btn btn-secondary">
-            <input type="radio" name="level" value="high" autocomplete="off">High
-        </label>
+      <form class="btn-group video-tile-config-toggle video-priority-toggle">
+        <input type="radio" class="btn-check" name="level" value="low" id="priority-low">
+        <label class="btn btn-secondary" id="priority-low-label" for="low">Low</label>
+        <input type="radio" class="btn-check" name="level" value="medium" id="priority-medium" checked>
+        <label class="btn btn-secondary" id="priority-medium-label" for="medium">Medium</label>
+        <input type="radio" class="btn-check" name="level" value="high" id="priority-high">
+        <label class="btn btn-secondary" id="priority-high-label" for="high">High</label>
       </form>
     </div>
   </div>
 `;
 
+
   public set tileIndex(tileIndex: number) {
     // Update IDs for integration tests which need them
     this.querySelector('.video-tile-nameplate').id = `nameplate-${tileIndex}`;
     this.querySelector('.video-tile-video').id = `video-${tileIndex}`;
+
+    // Bootstrap is not easy to get working with shadow DOMs, and also requires the use of IDs for radio buttons
+    // (putting the input within the label doesn't work in Bootstrap 5), so we manually update these IDs to make them
+    // unique
+    const nonUniqueInputAndLabelIdPrefixes = [
+      'priority-low', 'priority-medium', 'priority-high', 'resolution-low', 'resolution-medium', 'resolution-high'];
+    for (const prefix of nonUniqueInputAndLabelIdPrefixes) {
+      this.querySelector(`#${prefix}`).id = `${prefix}-${tileIndex}`;
+      this.querySelector(`#${prefix}-label`).setAttribute('for', `${prefix}-${tileIndex}`);
+      this.querySelector(`#${prefix}-label`).id = `${prefix}-label-${tileIndex}`;
+    }
   }
 
   public set showConfigDropdown(shouldShow: boolean) {

--- a/demos/browser/app/meetingV2/video/VideoTileCollection.ts
+++ b/demos/browser/app/meetingV2/video/VideoTileCollection.ts
@@ -170,11 +170,11 @@ export default class VideoTileCollection implements AudioVideoObserver {
     if (this.videoPreferenceManager !== undefined && !tileState.localTile) { // No current config possible on local tile
       this.logger.info('adding config listeners for tileIndex ' + tileIndex);
       demoVideoTile.targetResolutionRadioElement.removeEventListener('click', this.tileIndexToTargetResolutionEventListener[tileIndex]);
-      this.tileIndexToTargetResolutionEventListener[tileIndex] = this.createTargetResolutionListener(tileState, demoVideoTile.targetResolutionRadioElement);
+      this.tileIndexToTargetResolutionEventListener[tileIndex] = this.createTargetResolutionListener(tileState);
       demoVideoTile.targetResolutionRadioElement.addEventListener('click', this.tileIndexToTargetResolutionEventListener[tileIndex]);
 
       demoVideoTile.videoPriorityRadioElement.removeEventListener('click', this.tileIndexToPriorityEventListener[tileIndex]);
-      this.tileIndexToPriorityEventListener[tileIndex] = this.createVideoPriorityListener(tileState, demoVideoTile.videoPriorityRadioElement);
+      this.tileIndexToPriorityEventListener[tileIndex] = this.createVideoPriorityListener(tileState);
       demoVideoTile.videoPriorityRadioElement.addEventListener('click', this.tileIndexToPriorityEventListener[tileIndex]);
     }
 
@@ -388,28 +388,28 @@ export default class VideoTileCollection implements AudioVideoObserver {
     document.getElementById('video-paginate-right').style.display = display(this.pagination.hasNextPage());
   }
 
-  private createTargetResolutionListener(tileState: VideoTileState, form: HTMLFormElement): (event: Event) => void {
+  private createTargetResolutionListener(tileState: VideoTileState): (event: Event) => void {
     return (event: Event): void => {
       if (!(event.target instanceof HTMLInputElement)) {
         // Ignore the Label event which will have a stale value
         return;
       }
       const attendeeId = tileState.boundAttendeeId;
-      const value = (form.elements.namedItem('level') as RadioNodeList).value;
+      const value = (event.target as HTMLInputElement).value;
       this.logger.info(`target resolution changed for: ${attendeeId} to ${value}`);
       const targetDisplaySize = ConfigLevelToTargetDisplaySize[value as ConfigLevel];
       this.videoPreferenceManager.setAttendeeTargetDisplaySize(attendeeId, targetDisplaySize);
     }
   }
 
-  private createVideoPriorityListener(tileState: VideoTileState, form: HTMLFormElement): (event: Event) => void {
+  private createVideoPriorityListener(tileState: VideoTileState): (event: Event) => void {
     return (event: Event): void => {
       if (!(event.target instanceof HTMLInputElement)) {
         // Ignore the Label event which will have a stale value
         return;
       }
       const attendeeId = tileState.boundAttendeeId;
-      const value = (form.elements.namedItem('level') as RadioNodeList).value;
+      const value = (event.target as HTMLInputElement).value;
       this.logger.info(`priority changed for: ${attendeeId} to ${value}`);
       const priority = ConfigLevelToVideoPriority[value as ConfigLevel];
       this.videoPreferenceManager.setAttendeePriority(attendeeId, priority);

--- a/demos/browser/app/messagingSession/messagingSession.html
+++ b/demos/browser/app/messagingSession/messagingSession.html
@@ -16,21 +16,23 @@
       <form>
         <h1 class="h3 mb-3 font-weight-normal">Messaging Session</h1>
         <div class="row mt-3">
-          <label for="userArn" class="sr-only">UserArn:</label>
+          <label for="userArn" class="visually-hidden">UserArn:</label>
           <input type="text" id="userArn" name="userArn" class="form-control" placeholder="userArn" required>
         </div>
         <div class="row mt-3">
-          <label for="sessionId" class="sr-only">SessionId(optional):</label>
+          <label for="sessionId" class="visually-hidden">SessionId(optional):</label>
           <input type="text" id="sessionId" name="sessionId" class="form-control" placeholder="SessionId">
         </div>
-        <div class="custom-control custom-checkbox" style="text-align: left;">
-          <input type="checkbox" id="prefetchOn" class="custom-control-input">
-          <label for="prefetchOn" class="custom-control-label">Connect with prefetch on</label>
+        <div class="form-check" style="text-align: left;">
+          <input type="checkbox" id="prefetchOn" class="form-check-input">
+          <label for="prefetchOn" class="form-check-label">Connect with prefetch on</label>
         </div>
         <div class="row mt-3">
-          <button id="connect" type="button" class="btn btn-lg btn-primary btn-block">
-            Connect
-          </button>
+          <div class="d-grid gap-2">
+            <button id="connect" type="button" class="btn btn-lg btn-primary">
+              Connect
+            </button>
+          </div>
         </div>
       </form>
     </div>

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-chime-sdk-messaging": "^3.47.0",
         "amazon-chime-sdk-js": "file:../..",
         "aws-sdk": "^2.1105.0",
-        "bootstrap": "^4.5.2",
+        "bootstrap": "^5.1.3",
         "compression": "^1.7.4",
         "jquery": "^3.5.1",
         "lodash": "^4.17.20",
@@ -5585,7 +5585,6 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.2",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -6284,15 +6283,15 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.5.2",
-      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.10.2"
       }
     },
     "node_modules/bowser": {
@@ -11693,8 +11692,7 @@
     },
     "@popperjs/core": {
       "version": "2.11.2",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
-      "dev": true
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -15654,8 +15652,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.5.2",
-      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "requires": {}
     },
     "bowser": {

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/client-chime-sdk-messaging": "^3.47.0",
     "amazon-chime-sdk-js": "file:../..",
     "aws-sdk": "^2.1105.0",
-    "bootstrap": "^4.5.2",
+    "bootstrap": "^5.1.3",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",

--- a/demos/browser/style.scss
+++ b/demos/browser/style.scss
@@ -29,12 +29,11 @@ $light: $gray-200;
 $dark: $gray-700;
 $yiq-contrasted-threshold: 175;
 $link-color: $success;
-$font-family-sans-serif: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-base: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-size-base: 0.9375rem;
 $h1-font-size: 3rem;
 $h2-font-size: 2.5rem;
 $h3-font-size: 2rem;
-$table-accent-bg: $gray-200;
 $dropdown-link-color: $gray-700;
 $dropdown-link-hover-color: $white;
 $dropdown-link-hover-bg: $primary;
@@ -94,6 +93,8 @@ $close-text-shadow: none;
 // Buttons =====================================================================
 
 .btn {
+  &-success,
+  &-success,
   &-secondary,
   &-secondary:hover,
   &-warning,

--- a/integration/js/EchoReductionEnabledTest.js
+++ b/integration/js/EchoReductionEnabledTest.js
@@ -46,7 +46,9 @@ class EchoReductionEnabledTest extends SdkBaseTest {
 
   async addUserToMeeting(attendee_id, sessionInfo, useWebAudioFlag) {
     await OpenAppStep.executeStep(this, sessionInfo);
+    await sessionInfo.page.openAdditionalOptions();
     await sessionInfo.page.chooseEchoReduction();
+    await sessionInfo.page.closeAdditionalOptions();
     await AuthenticateUserStep.executeStep(this, sessionInfo, attendee_id, false, useWebAudioFlag);
     await UserAuthenticationCheck.executeStep(this, sessionInfo);
     await JoinMeetingStep.executeStep(this, sessionInfo);

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -13,6 +13,8 @@ function findAllElements() {
     voiceConnectorIdInput: By.id('voiceConnectorId'),
     attendeeNameInput: By.id('inputName'),
     authenticateButton: By.id('authenticate'),
+    additionalOptionsButton: By.id('additional-options-button'),
+    additionalOptionsSaveButton: By.id('additional-options-save-button'),
     localVideoButton: By.id('button-camera'),
     mediaCaptureButton: By.id('button-record-cloud'),
     addVoiceFocusInput: By.id('add-voice-focus'),        // Checkbox.
@@ -122,6 +124,18 @@ class AppPage {
   async authenticate() {
     let authenticateButton = await this.driver.findElement(elements.authenticateButton);
     await clickElement(this.driver, authenticateButton);
+  }
+
+  async openAdditionalOptions() {
+    let additionalOptionsButton = await this.driver.findElement(elements.additionalOptionsButton);
+    await clickElement(this.driver, additionalOptionsButton);
+    await TestUtils.waitAround(200);
+  }
+
+  async closeAdditionalOptions() {
+    let additionalOptionsSaveButton = await this.driver.findElement(elements.additionalOptionsSaveButton);
+    await clickElement(this.driver, additionalOptionsSaveButton);
+    await TestUtils.waitAround(200);
   }
 
   async chooseUseWebAudio() {

--- a/integration/js/pages/MeetingReadinessCheckerPage.js
+++ b/integration/js/pages/MeetingReadinessCheckerPage.js
@@ -22,7 +22,7 @@ const elements = {
   readinessCheckerFlow: By.id('flow-readinesstest'),
 };
 
-const badgeSuccessLabel = 'badge-success';
+const badgeSuccessLabel = 'bg-success';
 
 class MeetingReadinessCheckerPage {
   constructor(driver, logger) {

--- a/integration/js/pages/TestAppPage.js
+++ b/integration/js/pages/TestAppPage.js
@@ -89,6 +89,10 @@ class TestAppPage {
     await joinMeetingButton.click();
   }
 
+  async openAdditionalOptions() {}
+
+  async closeAdditionalOptions() {}
+
   async waitForDeviceFlow() {
     await TestUtils.waitAround(5000);
   }

--- a/integration/js/steps/AuthenticateUserStep.js
+++ b/integration/js/steps/AuthenticateUserStep.js
@@ -55,6 +55,7 @@ class AuthenticateUserStep extends AppTestStep {
   async run() {
     this.logger("attendee id: " + this.attendee_id);
     await this.page.enterAttendeeName(this.attendee_id);
+    await this.page.openAdditionalOptions();
     if (this.useSimulcastFlag) {
       this.logger("choose to use simulcast");
       await this.page.chooseUseSimulcast();
@@ -75,6 +76,8 @@ class AuthenticateUserStep extends AppTestStep {
       this.logger("Using stereo music audio profile");
       await this.page.chooseStereoMusicAudioProfile();
     }
+    await this.page.closeAdditionalOptions();
+
     await this.page.authenticate();
     this.logger("waiting to authenticate");
     let authenticationState = await this.page.waitForDeviceFlow();

--- a/integration/js/steps/AuthenticateUserStep.js
+++ b/integration/js/steps/AuthenticateUserStep.js
@@ -55,6 +55,10 @@ class AuthenticateUserStep extends AppTestStep {
   async run() {
     this.logger("attendee id: " + this.attendee_id);
     await this.page.enterAttendeeName(this.attendee_id);
+    if (this.region !== '') {
+      this.logger(`selecting region ${this.region}`);
+      await this.page.selectRegion(this.region);
+    }
     await this.page.openAdditionalOptions();
     if (this.useSimulcastFlag) {
       this.logger("choose to use simulcast");
@@ -67,10 +71,6 @@ class AuthenticateUserStep extends AppTestStep {
     if (this.enableEventReporting) {
       this.logger("Event reporting enabled");
       await this.page.chooseEnableEventReporting();
-    }
-    if (this.region !== '') {
-      this.logger(`selecting region ${this.region}`);
-      await this.page.selectRegion(this.region);
     }
     if (this.useStereoMusicAudioProfile) {
       this.logger("Using stereo music audio profile");

--- a/integration/js/steps/JoinVideoTestMeetingStep.js
+++ b/integration/js/steps/JoinVideoTestMeetingStep.js
@@ -24,6 +24,7 @@ class JoinVideoTestMeetingStep extends AppTestStep {
 
   async run() {
     await this.page.enterAttendeeName();
+    await this.page.openAdditionalOptions();
     if (this.useSimulcastFlag) {
       this.logger("choose to use simulcast");
       await this.page.chooseUseSimulcast();
@@ -32,6 +33,7 @@ class JoinVideoTestMeetingStep extends AppTestStep {
       this.logger("choose to use Web Audio");
       await this.page.chooseUseWebAudio();
     }
+    await this.page.closeAdditionalOptions();
     this.logger("meeting title: " + this.meeting_title);
     await this.page.enterMeetingTitle(this.meeting_title);
     this.logger("waiting to authenticate");


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** See title. Being on latest bootstrap just allows us to use latest functionality if we ever need it, I was looking to do some refactoring and figured it'd be nice to do (I'm also due for some spring cleaning).

Switching additional options to modal gives me less guilt when adding to it. I may eventually compartmentalize it in the JS code as well so that it is easy for copy pasting builders to remove.

![Screen Shot 2022-06-10 at 9 36 32 AM](https://user-images.githubusercontent.com/36210679/173111844-79f2b6be-a645-413c-8374-427ea024ddec.png)


![Screen Shot 2022-06-09 at 12 51 08 PM](https://user-images.githubusercontent.com/36210679/172932525-7b6173f9-b1f6-4f34-b0c0-97c187320db4.png)

**Testing:**
Tested each app to make sure they look about the same. Pressed a lot of buttons.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Sanity checking all buttons still work.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
y

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

