### PR TITLE
Revert "Force clean install to bypass resolving dependency issue (#2283)

### DIFF
--- a/.github/actions/setup-integration-test/action.yml
+++ b/.github/actions/setup-integration-test/action.yml
@@ -65,5 +65,5 @@ runs:
       run: integration/js/script/install-kite
       shell: bash
     - name: Clean Install
-      run: npm ci -f
+      run: npm ci
       shell: bash

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@
           with:
             node-version: 16.x
         - name: Clean Install
-          run: npm ci -f
+          run: npm ci
         - name: Build
           run: npm run build:release
 

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -65,7 +65,7 @@ jobs:
           npm uninstall amazon-chime-sdk-js
           npm install ../../amazon-chime-sdk-js-${{ steps.prev.outputs.prev_version }}.tgz
       - name: Clean Install
-        run: npm ci -f
+        run: npm ci
       - name: Run Audio Integration Test
         run: npm run test:integration-audio
       - name: Run Video Integ Test

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Kite
         run: integration/js/script/install-kite
       - name: Clean Install
-        run: npm ci -f
+        run: npm ci
       - name: Run Audio Integration Test
         run: npm run test:integration-audio
       - name: Run Video Integ Test

--- a/script/conditional-install
+++ b/script/conditional-install
@@ -12,7 +12,7 @@ expected = File.read(hashfile) if File.exists?(hashfile)
 
 if expected != current
   puts 'Running npm ci to regenerate node_modules.'
-  verbose('npm ci -f')
+  verbose('npm ci')
   File.write(hashfile, current)
 else
   puts 'node_modules is up to date.'

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -5,7 +5,7 @@ canarySuffix=${1+$1}
 chimeSDKMediaPipelinesStackId="mp"
 
 cd $GITHUB_WORKSPACE/demos/serverless
-npm ci -f
+npm ci
 
 case $NAME in
 


### PR DESCRIPTION
**Issue #:**
In #2290 we solve the npm dependency resolving issue, check details in description of #2283. No we are good to revert previous workaround in #2283.

**Description of changes:**
Revert "Force clean install to bypass resolving dependency issue (#2283)

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A, but did a basic e2e test using browser demo and confirms it works fine.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

