### PR TITLE
Fix canary names in deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_DEFAULT_OUTPUT: text
-      NAME: ChimeSDKMeetings_ChimeSDKMediaPipelines_beta
+      NAME: ChimeSDKMeetings_ChimeSDKMediaPipelinesBeta
       GAMMA_CHIME_ENDPOINT: ${{secrets.GAMMA_CHIME_ENDPOINT}}
       GAMMA_CHIME_ENDPOINT_US_EAST_1: ${{secrets.GAMMA_CHIME_ENDPOINT_US_EAST_1}}
       GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1: ${{secrets.GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1}}
@@ -130,7 +130,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-east-1
       AWS_DEFAULT_OUTPUT: text
-      NAME: Chime_ChimeSDKMediaPipelines_beta
+      NAME: Chime_ChimeSDKMediaPipelinesBeta
       GAMMA_CHIME_ENDPOINT: ${{secrets.GAMMA_CHIME_ENDPOINT}}
       GAMMA_CHIME_ENDPOINT_US_EAST_1: ${{secrets.GAMMA_CHIME_ENDPOINT_US_EAST_1}}
       GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1: ${{secrets.GAMMA_CHIME_ENDPOINT_EU_CENTRAL_1}}


### PR DESCRIPTION


**Issue #:** N/A

**Description of changes:**

The deploy workflows used different names than the script that actually deployed the demo apps for the beta stage canaries.  This change updates the workflow to have matching names.

**Testing:**

N/A github actions change


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

