### PR TITLE
Optional chain signaling client observer removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue for mute local when there is no audio input.
 - Fixed trucation of video subscriptions not occuring if the resubscribe was driven by `MonitorTask`.
 - Fix protobuf generation script for upgrade.
+- Optional chain signaling client observer removal to fix [issue](https://github.com/aws/amazon-chime-sdk-js/issues/2265) if  `audioVideo.stop()` is called before `audioVideo.start()`.
+
 
 ## [3.4.0] - 2022-05-24
 

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -292,7 +292,7 @@ export default class DefaultAudioVideoController
   }
 
   private uninstallPreStartObserver(): void {
-    this.meetingSessionContext.signalingClient.removeObserver(this.preStartObserver);
+    this.meetingSessionContext.signalingClient?.removeObserver(this.preStartObserver);
     this.preStartObserver = undefined;
   }
 

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -1217,6 +1217,19 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.stop();
     });
 
+    it('can be stopped before stop and then stopped again', () => {
+      audioVideoController = new DefaultAudioVideoController(
+        configuration,
+        new NoOpDebugLogger(),
+        webSocketAdapter,
+        new NoOpMediaStreamBroker(),
+        reconnectController
+      );
+      audioVideoController.stop();
+      audioVideoController.start();
+      audioVideoController.stop();
+    });
+
     it('disables reconnecting once stop is called', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');


### PR DESCRIPTION
**Issue #:**
#2265 

**Description of changes:**
- Optional chain signaling client observer removal to fix if  `audioVideo.stop` is called before `audioVideo.start`.
- Add a  unit test for the use-case.

**Cause**
Seems like the `meetingSessionContext.signalingClient` is not valid in `uninstallPreStartObserver` [here](https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L295). I suspect if these two lines race sometime.

https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L737-L738

The `uninstallPreStartObserver` is called when the signaling client receives a `close` event. Thus, it might be happening that the `signalingClient.closeConnection` triggers the event but the `signalingClient` is nullified in above two lines.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Regular sanity tests in meeting JS SDK browser demo should cover this.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

