### PR TITLE
adding live transcription support for govcloud regions PVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.32.0] - 2022-06-03
 
 ### Added
-- Add support for hosting meetings in US GovCloud regions.
-- Add support for starting live transcription in US GovCloud regions.
+
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.32.0] - 2022-06-03
 
 ### Added
-
+- Add support for hosting meetings in US GovCloud regions.
+- Add support for starting live transcription in US GovCloud regions.
 ### Removed
 
 ### Changed

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -52,6 +52,8 @@
           <option value="us-east-2">United States (Ohio)</option>
           <option value="us-west-1">United States (N. California)</option>
           <option value="us-west-2">United States (Oregon)</option>
+          <option value="us-gov-west-1">GovCloud (US-West)</option>
+          <option value="us-gov-east-1">GovCloud (US-East)</option>
         </select>
       </div>
       <div class="row mt-3">
@@ -363,6 +365,7 @@
             <option value="us-east-1">United States (N. Virginia)</option>
             <option value="us-east-2">United States (Ohio)</option>
             <option value="us-west-2">United States (Oregon)</option>
+            <option value="us-gov-west-1">GovCloud (US-West)</option>
           </select>
         </div>
         <div id="engine-transcribe-medical-region" class="hidden">

--- a/demos/browser/package.json
+++ b/demos/browser/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "amazon-chime-sdk-js": "file:../..",
-    "aws-sdk": "^2.1105.0",
+    "aws-sdk": "^2.1152.0",
     "bootstrap": "^4.5.2",
     "compression": "^1.7.4",
     "jquery": "^3.5.1",

--- a/demos/serverless/src/package.json
+++ b/demos/serverless/src/package.json
@@ -4,7 +4,7 @@
   "description": "Amazon Chime SDK JavaScript Serverless Demos Lambda Handler",
   "dependencies": {
     "aws-embedded-metrics": "^2.0.4",
-    "aws-sdk": "^2.1105.0",
+    "aws-sdk": "^2.1152.0",
     "uuid": "^8.3.2"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Adds support live transcriptions in GovCloud regions.
PDT -> us-gov-west-1,
OSU - > us-gov-east-1.
**Testing:**
local build and testing. 
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
yes, changes are only to demo app changes. Start the meeting in GovCloud (US-WEST) region, and select GovCloud (US-WEST) region for live transcriptions settings to enable live transcriptions in PDT.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes 

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

no
3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

no
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

