### PR TITLE
Fix VF bug when toggling mute and then quickly changing device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issue where Amazon Voice Focus stops working after changing device while muted.
+- Fix issue where Amazon Voice Focus could stop working after changing the mute state of a null device or changing the device shortly after.
 - Fix an issue for mute local when there is no audio input.
 - Fix trucation of video subscriptions not occuring if the resubscribe was driven by `MonitorTask`.
 - Fix protobuf generation script for upgrade.

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -352,7 +352,9 @@ export class DemoMeetingApp
   // and fix some state (e.g., video buttons).
   // Holding Shift while hitting the Leave button is handled by setting
   // this to `halt`, which allows us to stop and measure memory leaks.
-  behaviorAfterLeave: 'spa' | 'reload' | 'halt' = 'reload';
+  // The `nothing` option can be used to stop cleanup from happening allowing
+  // `audioVideo` to be reused without stopping the meeting.
+  behaviorAfterLeave: 'spa' | 'reload' | 'halt' | 'nothing' = 'reload';
 
   videoMetricReport: { [id: string]: { [id: string]: {} } } = {};
 
@@ -3430,6 +3432,9 @@ export class DemoMeetingApp
 
   audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
     this.log(`session stopped from ${JSON.stringify(sessionStatus)}`);
+    if(this.behaviorAfterLeave === 'nothing') {
+      return;
+    }
     this.log(`resetting stats`);
     this.resetStats();
 

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L90">src/devicecontroller/DefaultDeviceController.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L92">src/devicecontroller/DefaultDeviceController.ts:92</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -208,7 +208,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquireaudioinputstream">acquireAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L556">src/devicecontroller/DefaultDeviceController.ts:556</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L559">src/devicecontroller/DefaultDeviceController.ts:559</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquiredisplayinputstream">acquireDisplayInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L579">src/devicecontroller/DefaultDeviceController.ts:579</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L582">src/devicecontroller/DefaultDeviceController.ts:582</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -261,7 +261,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#acquirevideoinputstream">acquireVideoInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L569">src/devicecontroller/DefaultDeviceController.ts:569</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L572">src/devicecontroller/DefaultDeviceController.ts:572</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -285,7 +285,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#adddevicechangeobserver">addDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L427">src/devicecontroller/DefaultDeviceController.ts:427</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L430">src/devicecontroller/DefaultDeviceController.ts:430</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -314,7 +314,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1490">src/devicecontroller/DefaultDeviceController.ts:1490</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -343,7 +343,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#chooseaudiooutput">chooseAudioOutput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L418">src/devicecontroller/DefaultDeviceController.ts:418</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L421">src/devicecontroller/DefaultDeviceController.ts:421</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -374,7 +374,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#choosevideoinputquality">chooseVideoInputQuality</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L543">src/devicecontroller/DefaultDeviceController.ts:543</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L546">src/devicecontroller/DefaultDeviceController.ts:546</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#createanalysernodeforaudioinput">createAnalyserNodeForAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L441">src/devicecontroller/DefaultDeviceController.ts:441</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L444">src/devicecontroller/DefaultDeviceController.ts:444</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -440,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L469">src/devicecontroller/DefaultDeviceController.ts:469</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L472">src/devicecontroller/DefaultDeviceController.ts:472</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="../interfaces/removableanalysernode.html" class="tsd-signature-type" data-tsd-kind="Interface">RemovableAnalyserNode</a></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/destroyable.html">Destroyable</a>.<a href="../interfaces/destroyable.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L178">src/devicecontroller/DefaultDeviceController.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L180">src/devicecontroller/DefaultDeviceController.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#getvideoinputqualitysettings">getVideoInputQualitySettings</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L552">src/devicecontroller/DefaultDeviceController.ts:552</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L555">src/devicecontroller/DefaultDeviceController.ts:555</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -503,7 +503,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1370">src/devicecontroller/DefaultDeviceController.ts:1370</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1374">src/devicecontroller/DefaultDeviceController.ts:1374</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -521,7 +521,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudioinputdevices">listAudioInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L189">src/devicecontroller/DefaultDeviceController.ts:189</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L191">src/devicecontroller/DefaultDeviceController.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -550,7 +550,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listaudiooutputdevices">listAudioOutputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L201">src/devicecontroller/DefaultDeviceController.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L203">src/devicecontroller/DefaultDeviceController.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -579,7 +579,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#listvideoinputdevices">listVideoInputDevices</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L195">src/devicecontroller/DefaultDeviceController.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L197">src/devicecontroller/DefaultDeviceController.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -608,7 +608,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mixintoaudioinput">mixIntoAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L530">src/devicecontroller/DefaultDeviceController.ts:530</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L533">src/devicecontroller/DefaultDeviceController.ts:533</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -637,7 +637,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#mutelocalaudioinputstream">muteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L677">src/devicecontroller/DefaultDeviceController.ts:677</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L680">src/devicecontroller/DefaultDeviceController.ts:680</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -660,7 +660,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removedevicechangeobserver">removeDeviceChangeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L434">src/devicecontroller/DefaultDeviceController.ts:434</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L437">src/devicecontroller/DefaultDeviceController.ts:437</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -689,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1498">src/devicecontroller/DefaultDeviceController.ts:1498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -718,7 +718,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#setdevicelabeltrigger">setDeviceLabelTrigger</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L515">src/devicecontroller/DefaultDeviceController.ts:515</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L518">src/devicecontroller/DefaultDeviceController.ts:518</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -761,7 +761,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startaudioinput">startAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L219">src/devicecontroller/DefaultDeviceController.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L221">src/devicecontroller/DefaultDeviceController.ts:221</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -795,7 +795,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideoinput">startVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L366">src/devicecontroller/DefaultDeviceController.ts:366</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L369">src/devicecontroller/DefaultDeviceController.ts:369</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -827,7 +827,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#startvideopreviewforvideoinput">startVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L494">src/devicecontroller/DefaultDeviceController.ts:494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L497">src/devicecontroller/DefaultDeviceController.ts:497</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -860,7 +860,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopaudioinput">stopAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L256">src/devicecontroller/DefaultDeviceController.ts:256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L259">src/devicecontroller/DefaultDeviceController.ts:259</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -884,7 +884,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideoinput">stopVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L401">src/devicecontroller/DefaultDeviceController.ts:401</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L404">src/devicecontroller/DefaultDeviceController.ts:404</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -908,7 +908,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#stopvideopreviewforvideoinput">stopVideoPreviewForVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L510">src/devicecontroller/DefaultDeviceController.ts:510</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L513">src/devicecontroller/DefaultDeviceController.ts:513</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -938,7 +938,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#unmutelocalaudioinputstream">unmuteLocalAudioInputStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L681">src/devicecontroller/DefaultDeviceController.ts:681</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L684">src/devicecontroller/DefaultDeviceController.ts:684</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -960,7 +960,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1479">src/devicecontroller/DefaultDeviceController.ts:1479</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1483">src/devicecontroller/DefaultDeviceController.ts:1483</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -977,7 +977,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L742">src/devicecontroller/DefaultDeviceController.ts:742</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L746">src/devicecontroller/DefaultDeviceController.ts:746</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -994,7 +994,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1465">src/devicecontroller/DefaultDeviceController.ts:1465</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1469">src/devicecontroller/DefaultDeviceController.ts:1469</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -1011,7 +1011,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L708">src/devicecontroller/DefaultDeviceController.ts:708</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L712">src/devicecontroller/DefaultDeviceController.ts:712</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1034,7 +1034,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L746">src/devicecontroller/DefaultDeviceController.ts:746</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L750">src/devicecontroller/DefaultDeviceController.ts:750</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -75,6 +75,8 @@ export default class DefaultDeviceController
   private audioInputTaskQueue: PromiseQueue = new PromiseQueue();
   private videoInputTaskQueue: PromiseQueue = new PromiseQueue();
 
+  private muted: boolean = false;
+
   // This handles the dispatch of `mute` and `unmute` events from audio tracks.
   // There's a bit of a semantic mismatch here if input streams allow individual component tracks to be muted,
   // but addressing that gap is not feasible in our stream-oriented world.
@@ -243,6 +245,7 @@ export default class DefaultDeviceController
       if (this.useWebAudio) {
         this.attachAudioInputStreamToAudioContext(this.activeDevices['audio'].stream);
         this.pushAudioMeetingStateForPermissions(this.getMediaStreamDestinationNode().stream);
+        await this.transform?.device.mute(this.muted);
         return this.getMediaStreamDestinationNode().stream;
       } else {
         this.publishAudioInputDidChangeEvent(this.activeDevices['audio'].stream);
@@ -692,6 +695,7 @@ export default class DefaultDeviceController
     if (!audioDevice) {
       return;
     }
+    this.muted = !enabled;
     let isChanged = false;
     for (const track of audioDevice.stream.getTracks()) {
       if (track.enabled === enabled) {
@@ -701,7 +705,7 @@ export default class DefaultDeviceController
       isChanged = true;
     }
     if (isChanged) {
-      this.transform?.device.mute(!enabled);
+      this.transform?.device.mute(this.muted);
     }
   }
 

--- a/test/devicecontroller/DefaultDeviceController.test.ts
+++ b/test/devicecontroller/DefaultDeviceController.test.ts
@@ -404,7 +404,7 @@ describe('DefaultDeviceController', () => {
       deviceController.muteLocalAudioInputStream();
       deviceController.muteLocalAudioInputStream();
 
-      expect(device.muted).to.deep.equal([true, false, true]);
+      expect(device.muted).to.deep.equal([false, true, false, true]);
     });
   });
 


### PR DESCRIPTION
**Issue #:**
- When device was muted as a normal device and is then change to null and unmute then swapped to a valid device Amazon Voice Focus stops working
- When device is muted/unmuted and then swapped shortly after Amazon Voice Focus stops working

**Description of changes:**
- Keep track of mute state in device controller and apply to newly selected transform devices, to prevent the mute state from being made out of sync. 
- Added new behavior to meeting demo that will prevent resources from being cleaned up after `audioVideo.stop()` this allows for reuse of meeting components
**Testing:**
- Tested that VF will work under the following condtions:
     - When device is muted when it's null and then swapped to a valid device Amazon Voice Focus stops working
     - When device is muted/unmuted and then swapped shortly after Amazon Voice Focus stops working

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

