### PR TITLE
Remove the isChanged flag that breaks some old muting cases in VF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix issue where Amazon Voice Focus stops working after changing device while muted.
+- Remove the `isChanged` flag as it breaks some old muting funtionality causing Amazon Voice Focus to stop working.
 - Fix issue where Amazon Voice Focus could stop working after changing the mute state of a null device or changing the device shortly after.
 - Fix an issue for mute local when there is no audio input.
 - Fix trucation of video subscriptions not occuring if the resubscribe was driven by `MonitorTask`.

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -314,7 +314,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1492">src/devicecontroller/DefaultDeviceController.ts:1492</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -503,7 +503,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1374">src/devicecontroller/DefaultDeviceController.ts:1374</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1372">src/devicecontroller/DefaultDeviceController.ts:1372</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -689,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1498">src/devicecontroller/DefaultDeviceController.ts:1498</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1496">src/devicecontroller/DefaultDeviceController.ts:1496</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -960,7 +960,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1483">src/devicecontroller/DefaultDeviceController.ts:1483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1481">src/devicecontroller/DefaultDeviceController.ts:1481</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -977,7 +977,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L746">src/devicecontroller/DefaultDeviceController.ts:746</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L744">src/devicecontroller/DefaultDeviceController.ts:744</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">MediaStream</span></h4>
@@ -994,7 +994,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1469">src/devicecontroller/DefaultDeviceController.ts:1469</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1467">src/devicecontroller/DefaultDeviceController.ts:1467</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">AudioContext</span></h4>
@@ -1011,7 +1011,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L712">src/devicecontroller/DefaultDeviceController.ts:712</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L710">src/devicecontroller/DefaultDeviceController.ts:710</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1034,7 +1034,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L750">src/devicecontroller/DefaultDeviceController.ts:750</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L748">src/devicecontroller/DefaultDeviceController.ts:748</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -230,7 +230,7 @@ export default class DefaultDeviceController
 
     try {
       if (isAudioTransformDevice(device)) {
-        // N.B., do not JSON.stringify here — for some kinds of devices this
+        // N.B., do not JSON.stringify here — for some kinds of devices this
         // will cause a cyclic object reference error.
         this.logger.info(`Choosing transform input device ${device}`);
 
@@ -695,16 +695,14 @@ export default class DefaultDeviceController
     if (!audioDevice) {
       return;
     }
-    this.muted = !enabled;
-    let isChanged = false;
     for (const track of audioDevice.stream.getTracks()) {
       if (track.enabled === enabled) {
         continue;
       }
       track.enabled = enabled;
-      isChanged = true;
     }
-    if (isChanged) {
+    if (this.muted !== !enabled) {
+      this.muted = !enabled;
       this.transform?.device.mute(this.muted);
     }
   }


### PR DESCRIPTION
**Issue #:**
- Under some old use cases the isChanged flag was not detecting a change in the mute state causing Amazon Voice Focus to stop working.

**Description of changes:**
- Removed the flag and now detect a change through the muted state boolean.

**Testing:**
- Tested that it works using old use case.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

