### PR TITLE
Update Pre-run script id for Background Blur and Replacement integrat…

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,7 +104,7 @@ const getPrerunScript = (capabilities) =>{
   const name = capabilities.name;
   const blurName = "Background Blur Test";
   const repName = "Background Replacement Test";
-  return (name.includes(blurName) || name.includes(repName)) ?  'storage:d733d11b-a2cb-41c5-9dba-15abbd52c919' : "";
+  return (name.includes(blurName) || name.includes(repName)) ?  'storage:536cbb62-064a-44c1-8eca-0b1e16b03402' : "";
 }
 const getChromeCapabilities = capabilities => {
   let cap = Capabilities.chrome();


### PR DESCRIPTION
**Issue #:**
Background Replacement PMV canaries are failing as pre-run script is expired. We've an open PR https://github.com/aws/amazon-chime-sdk-js/pull/2346  that automatically updates this pre-run script storage id. However, github checks does not run on that PR, so created this PR manually, hoping that github checks work on this PR .

**Description of changes:**
Update pre-run script similar to https://github.com/aws/amazon-chime-sdk-js/pull/2345/commits

**Testing:**
NA

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes
2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No
3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

