### PR TITLE
Fix meeting demo join in older Safari

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -67,7 +67,7 @@
       <div class="row mt-3">
         <div class="btn-group p-0" role="group">
           <button id="authenticate" class="btn btn-lg btn-secondary w-100" type="submit">Continue</button>
-          <button id="quick-join" class="btn btn-lg btn-success"type="submit" title="Skip Device Selection"><%= require('../../node_modules/open-iconic/svg/bolt.svg') %></button>
+          <button id="quick-join" class="btn btn-lg btn-success" title="Skip Device Selection"><%= require('../../node_modules/open-iconic/svg/bolt.svg') %></button>
         </div>
       </div>
       <div class="row mt-3">


### PR DESCRIPTION
**Issue #:**
In Safari 15.3 or older, joining the meeting demo will result in a crash due to this recent change here https://github.com/aws/amazon-chime-sdk-js/blob/main/demos/browser/app/meetingV2/meetingV2.ts. 
Submitter event is not supported before Safari 15.4 

**Description of changes:**

Move the quick join event from submit to click (does not make sense to have 2 button trigger submit in a form anyway).

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Join meeting in previous Safari 15.3 or older version and verify there is no crash. 
Also test quick join and verify that it works (default audio input is selected when joining meeting).

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

