### PR TITLE
Bumps brotobufjs from 6.8.8 to 6.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `protobufjs` from 6.8.8 to 6.11.3.
+- Update `DOMBlobMock` to accommodate `@types/node` changes.
+
 ### Fixed
 
 ## [2.31.0] - 2022-03-21

--- a/docs/classes/getusermediaerror.html
+++ b/docs/classes/getusermediaerror.html
@@ -204,7 +204,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Error.prepareStackTrace</p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Error.stackTraceLimit</p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -255,14 +255,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from Error.captureStackTrace</p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/docs/classes/intervalscheduler.html
+++ b/docs/classes/intervalscheduler.html
@@ -144,7 +144,7 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
 					<a name="timer" class="tsd-anchor"></a>
 					<h3>timer</h3>
-					<div class="tsd-signature tsd-kind-icon">timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Timeout</span></div>
+					<div class="tsd-signature tsd-kind-icon">timer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Timer</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/scheduler/IntervalScheduler.ts#L10">src/scheduler/IntervalScheduler.ts:10</a></li>

--- a/docs/classes/notfounderror.html
+++ b/docs/classes/notfounderror.html
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#preparestacktrace">prepareStackTrace</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -225,7 +225,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stacktracelimit">stackTraceLimit</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -236,14 +236,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#capturestacktrace">captureStackTrace</a></p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/docs/classes/notreadableerror.html
+++ b/docs/classes/notreadableerror.html
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#preparestacktrace">prepareStackTrace</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -225,7 +225,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stacktracelimit">stackTraceLimit</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -236,14 +236,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#capturestacktrace">captureStackTrace</a></p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/docs/classes/overconstrainederror.html
+++ b/docs/classes/overconstrainederror.html
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#preparestacktrace">prepareStackTrace</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -236,7 +236,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stacktracelimit">stackTraceLimit</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -247,14 +247,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#capturestacktrace">captureStackTrace</a></p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/docs/classes/permissiondeniederror.html
+++ b/docs/classes/permissiondeniederror.html
@@ -188,7 +188,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#preparestacktrace">prepareStackTrace</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -228,7 +228,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stacktracelimit">stackTraceLimit</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -239,14 +239,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#capturestacktrace">captureStackTrace</a></p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -257,7 +257,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/docs/classes/typeerror.html
+++ b/docs/classes/typeerror.html
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#preparestacktrace">prepareStackTrace</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:140</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:11</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -225,7 +225,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#stacktracelimit">stackTraceLimit</a></p>
 						<ul>
-							<li>Defined in node_modules/@types/node/globals.d.ts:142</li>
+							<li>Defined in node_modules/@types/node/globals.d.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -236,14 +236,14 @@
 					<a name="capturestacktrace" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> capture<wbr>Stack<wbr>Trace</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited tsd-is-static tsd-is-external">
-						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">capture<wbr>Stack<wbr>Trace<span class="tsd-signature-symbol">(</span>targetObject<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span>, constructorOpt<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="getusermediaerror.html">GetUserMediaError</a>.<a href="getusermediaerror.html#capturestacktrace">captureStackTrace</a></p>
 								<ul>
-									<li>Defined in node_modules/@types/node/globals.d.ts:133</li>
+									<li>Defined in node_modules/@types/node/globals.d.ts:4</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>targetObject: <span class="tsd-signature-type">Object</span></h5>
+									<h5>targetObject: <span class="tsd-signature-type">object</span></h5>
 								</li>
 								<li>
 									<h5><span class="tsd-flag ts-flagOptional">Optional</span> constructorOpt: <span class="tsd-signature-type">Function</span></h5>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "~6.8.8",
+        "protobufjs": "~6.11.3",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       },
@@ -669,9 +669,9 @@
       "dev": true
     },
     "node_modules/@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/mocha": {
       "version": "5.2.7",
@@ -680,9 +680,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
     },
     "node_modules/@types/sinon": {
       "version": "7.5.0",
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -4092,8 +4092,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       },
       "bin": {
@@ -6095,9 +6095,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -6106,9 +6106,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
     },
     "@types/sinon": {
       "version": "7.5.0",
@@ -8705,9 +8705,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8719,8 +8719,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@types/ua-parser-js": "^0.7.35",
     "detect-browser": "^5.2.0",
     "pako": "^2.0.4",
-    "protobufjs": "~6.8.8",
+    "protobufjs": "~6.11.3",
     "resize-observer": "^1.0.0",
     "ua-parser-js": "^1.0.1"
   },

--- a/test/domblobmock/DOMBlobMock.ts
+++ b/test/domblobmock/DOMBlobMock.ts
@@ -20,8 +20,11 @@ export default class DOMBlobMock implements Blob {
     throw new Error('Unimplemented.');
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream(): ReadableStream<any> {
+  stream(): NodeJS.ReadableStream;
+
+  stream(): ReadableStream;
+
+  stream(): NodeJS.ReadableStream | ReadableStream {
     throw new Error('Unimplemented.');
   }
 


### PR DESCRIPTION
**Description of changes:**

-  Bump protobufjs from 6.88 to 6.11.3.
- Implement the missing property stream required by type Blob in DOMBolbMock due to changes in @types/node (the version is newer than in v3 so there are more changes to doc change.

This is the same as the PR https://github.com/aws/amazon-chime-sdk-js/pull/2269 in v3.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Run an basic e2e testing and verify functionality is working as expected.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

