### PR TITLE
Simplify media-pipeline integration tests by removing unrelated checks.

### DIFF
--- a/integration/js/MediaCaptureTest.js
+++ b/integration/js/MediaCaptureTest.js
@@ -1,5 +1,5 @@
 const { AuthenticateUserStep, JoinMeetingStep, OpenAppStep, ClickContentShareButton, ClickVideoButton, ClickMediaCaptureButton, EndMeetingStep } = require('./steps');
-const { ContentShareVideoCheck, LocalVideoCheck, RosterCheck, UserAuthenticationCheck, UserJoinedMeetingCheck } = require('./checks');
+const { RosterCheck, UserAuthenticationCheck, UserJoinedMeetingCheck } = require('./checks');
 const { AppPage } = require('./pages/AppPage');
 const { TestUtils } = require('./node_modules/kite-common');
 const SdkBaseTest = require('./utils/SdkBaseTest');
@@ -28,14 +28,11 @@ class MediaCaptureTest extends SdkBaseTest {
     await testWindow.runCommands(async () => await this.addUserToMeeting(testAttendeeId, session, this.region));
     await testWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
     await testWindow.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
+
     await TestUtils.waitAround(5000);
-    await testWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
-    await testWindow.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", testAttendeeId));
 
     await monitorWindow.runCommands(async () => await this.addUserToMeeting(monitorAttendeeId, session, this.region));
     await monitorWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await monitorWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
-    await monitorWindow.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", testAttendeeId));
 
     // Start media capture session
     await testWindow.runCommands(async () => await ClickMediaCaptureButton.executeStep(this, session));
@@ -50,26 +47,11 @@ class MediaCaptureTest extends SdkBaseTest {
 
     await TestUtils.waitAround(5000);
 
-    await testWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_OFF'));
-    await testWindow.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", testAttendeeId));
     await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
     await monitorWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
 
     await testWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
     await testWindow.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
-
-    await TestUtils.waitAround(5000);
-
-    await testWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
-    await testWindow.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", testAttendeeId));
-    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await monitorWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-
-    await monitorWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await monitorWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_OFF'));
-
-    await monitorWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await monitorWindow.runCommands(async () => await LocalVideoCheck.executeStep(this, session, 'VIDEO_ON'));
 
     await TestUtils.waitAround(5000);
 


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Simplify media-pipeline integration tests by removing unrelated checks.

**Testing:**
`npm run build:release` and verified all unit tests succeed.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No. This change is just removing some unrelated checks from the media-pipeline integration tests.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
> Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
> No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
> No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
> Yes
