### PR TITLE
Re-wire up send codec from additional options menu

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -3570,6 +3570,20 @@ export class DemoMeetingApp
         break;
     }
 
+    const chosenVideoSendCodec = (document.getElementById('videoCodecSelect') as HTMLSelectElement).value;
+    switch (chosenVideoSendCodec) {
+      case 'vp8':
+        this.videoCodecPreferences = [VideoCodecCapability.vp8()];
+        break;
+      case 'h264ConstrainedBaselineProfile':
+        this.videoCodecPreferences = [VideoCodecCapability.h264ConstrainedBaselineProfile(), VideoCodecCapability.vp8()];
+        break;
+      default:
+        // If left on 'Meeting Default', use the existing behavior when `setVideoCodecSendPreferences` is not called
+        // which should be equivalent to `this.videoCodecPreferences = [VideoCodecCapability.h264ConstrainedBaselineProfile()]`
+        break;
+    }
+
     AsyncScheduler.nextTick(
       async (): Promise<void> => {
         let chimeMeetingId: string = '';

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "../..": {
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
@@ -89,7 +89,7 @@
         "typescript": "^4.2.3"
       },
       "engines": {
-        "node": "^12 || ^14 || ^15 || ^16",
+        "node": "^12 || ^14 || ^15 || ^16 || ^18",
         "npm": "^6 || ^7 || ^8"
       }
     },


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** Just a bit a missing code from previous PR.

**Testing:** Retested VP8 send works.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not-relevant, just reverts this to previous behavior.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

