### PR TITLE
Use the region from test payload for skipping medical transcription i…

### DIFF
--- a/integration/js/TranscriptionTest.js
+++ b/integration/js/TranscriptionTest.js
@@ -65,7 +65,7 @@ class TranscriptionTest extends SdkBaseTest {
     await this.runTranscriptionTest(session, testWindow1, testWindow2, false, testWindow1, testWindow2, testWindow1, attendeeId1, compareFn);
 
     // Transcribe Medical
-    if (process.env.REGION !== 'us-gov-east-1' && process.env.REGION !== 'us-gov-west-1') {
+    if (this.region !== 'us-gov-east-1' && this.region !== 'us-gov-west-1') {
       await this.runTranscriptionTest(session, testWindow1, testWindow2, true, testWindow2, testWindow1, testWindow2, attendeeId2, compareFn);
     }
 


### PR DESCRIPTION
…ntegration test

**Issue #:** N/A

**Description of changes:** Fixing a [recent change](https://github.com/aws/amazon-chime-sdk-js/pull/2319) which added logic to skip Transcribe Medical integration test in GovCloud regions as Transcribe Medical is not yet available in GovCloud. This change updates the code to reference the value from the payload block of the test configuration (`this.region`) rather than `process.env.REGION`. 

**Testing:** Local selenium grid.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.* 
Run the transcription integration test against a demo application with GovCloud as the payload region.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

