### PR TITLE
Filter empty speakers in medical transcribe integ test

### DIFF
--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -518,7 +518,7 @@ class AppPage {
 
     // Temporarily filtering empty speakers for medical transcribe test. Empty speaker issue - P68074811
     if (isMedicalTranscribe) {
-      console.log(`Filtering empty speaker in medical transcribe. isMedicalTranscribe: ${isMedicalTranscribe}"`);
+      console.log(`Filtering empty speaker in medical transcribe.`);
       actualSpeakers = actualSpeakers.filter(speaker => speaker !== "")
     }
 

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -516,6 +516,12 @@ class AppPage {
     let actualSpeakers = Object.getOwnPropertyNames(actualTranscriptContentBySpeaker);
     let expectedSpeaker = Object.getOwnPropertyNames(expectedTranscriptContentBySpeaker);
 
+    // Temporarily filtering empty speakers for medical transcribe test. Empty speaker issue - P68074811
+    if (isMedicalTranscribe) {
+      console.log(`Filtering empty speaker in medical transcribe. isMedicalTranscribe: ${isMedicalTranscribe}"`);
+      actualSpeakers = actualSpeakers.filter(speaker => speaker !== "")
+    }
+
     if (actualSpeakers.length !== expectedSpeaker.length) {
       console.error(`Expected speaker length ${expectedSpeaker.length} but got ${actualSpeakers.length}`);
       return false;


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
Temporarily filtering empty speakers in medical transcribe integration tests. In some cases, we can observe no speaker attributed to a transcripts in medical transcription at the beginning of the transcription. While service team fixes the issue on server-side, temporarily filtering the speakers lists by ignoring unattributed speakers for transcripts. Tracked in P68074811.

**Testing:**
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Run the transcription integration tests and verified successful tests.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

