### PR TITLE
Re-disable extendedDebugging for content sharing in Sauce Labs

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -130,7 +130,8 @@ const getSauceLabsConfig = (capabilities) => {
     seleniumVersion: '3.141.59',
     screenResolution: '1280x960',
     tunnelIdentifier: process.env.JOB_ID,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
+    ...((capabilities.platform.toUpperCase() !== 'LINUX' &&
+      !((capabilities.name).includes('ContentShare'))) && {
         extendedDebugging: true
       }),
       prerun : prerunScript


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Disable the "extendedDebugging" flag for content sharing. Content share tests fail intermittently after we enabled this flag on 2022-07-07 (https://github.com/aws/amazon-chime-sdk-js/pull/2337).

**Testing:**
- N/A. Just reverting the commit.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

