### PR TITLE
Changed the token for PR to a PAT

### DIFF
--- a/.github/workflows/update-prerun-script.yml
+++ b/.github/workflows/update-prerun-script.yml
@@ -51,7 +51,7 @@ jobs:
         id: create-pull-request
         uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JS_SDK_BOT_ACCESS_KEY }}
           commit-message: Update integration tests pre-run script ID
           title: Update integration tests pre-run script ID
           branch: update-pre-run-script-id
@@ -84,7 +84,7 @@ jobs:
         id: pmv-create-pull-request
         uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.JS_SDK_BOT_ACCESS_KEY }}
           commit-message: Update integration tests pre-run script ID
           title: Update integration tests pre-run script ID for previous release
           branch: update-pre-run-script-id-previous-release


### PR DESCRIPTION
**Issue #:**
The automated tests were not running for the PRs created by the update-prerun-script workflow

**Description of changes:**
Changed the token being used to create the PRs from the `GITHUB_TOKEN` to `JS_SDK_BOT_ACCESS_KEY`

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

