### PR TITLE
Allow stubbing join info to enable easy cross account joining from browser demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -116,6 +116,10 @@ aria-labelledby="additional-options-modal-label" aria-hidden="true">
           </select>
           <label for="videoCodec"  style="text-align: left;">Preferred Video Send Codec:</label>
         </div>
+        <button type="button" class="btn btn-outline-secondary h-50 d-sm-block mb-3" style="width: 100%" data-bs-toggle="modal" id="create-attendee-override-button"
+        data-bs-target="#join-info-override-modal">
+            Override Join Info
+        </button>
         <div class="form-check" style="text-align: left;">
           <input type="checkbox" id="webaudio" class="form-check-input">
           <label for="webaudio" class="form-check-label">Use WebAudio</label>
@@ -200,6 +204,61 @@ aria-labelledby="additional-options-modal-label" aria-hidden="true">
     <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="additional-options-save-button">Save</button>
   </div>
 </div>
+</div>
+
+<div class="modal fade" id="join-info-override-modal" tabindex="-1"
+aria-labelledby="join-info-override-modal-label" aria-hidden="true">
+  <div class="modal-dialog modal-lg" style="width: 90%">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="join-info-override-modal-label">Join Info Override</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Use the following overrides to enable joining meetings created from services that do not utilize the serverless demo, for example, meetings created for your application, or meetings created in different accounts. To get these response you can use the following CLI commands with appropriate credentials</p>
+        <ul>
+          <li><code>aws aws chime-sdk-meetings create-attendee --meeting-id &lt;value&gt; --external-user-id &lt;value&gt;</code></li>
+          <li><code>aws aws chime-sdk-meetings get-meeting --meeting-id &lt;value&gt;</code></li>
+        </ul> 
+        <div class="form-group">
+          <label for="create-attendee-override-input" class="mb-2"><h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">
+            CreateAttendee</a> Override
+          </h5></label>
+          <textarea class="form-control" id="create-attendee-override-input" rows="7" placeholder='{
+  "Attendee": {
+      "ExternalUserId": "John",
+      "AttendeeId": "18ba3ce2-9d76-722f-6b58-2c2fe0db5c94",
+      "JoinToken": "XXX"
+  }
+}
+'></textarea>
+          <div class="form-group">
+            <label for="get-meeting-override-input" class="mb-2 mt-3"><h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_GetMeeting.html">
+              GetMeeting</a> Override
+            </h5></label>
+            <textarea class="form-control" id="get-meeting-override-input" rows="17" placeholder='{
+  "Meeting": {
+      "MeetingId": "35f23a2b-c4d7-413f-a299-2b1dc3f63314",
+      "ExternalMeetingId": "f7f76d4a-08ba-4001-8900-2b3fba4b6b3f",
+      "MediaRegion": "us-east-1",
+      "MediaPlacement": {
+          "AudioHostUrl": "...",
+          "AudioFallbackUrl": "...",
+          "SignalingUrl": "...",
+          "TurnControlUrl": "...",
+          "ScreenDataUrl": "...",
+          "ScreenViewingUrl": "...",
+          "ScreenSharingUrl": "...",
+          "EventIngestionUrl": "..."
+      }
+  }
+}'></textarea>
+          </div>
+        </div>
+      </div>
+      <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="join-info-override-join-button">Join Meeting</button>
+    </div>
+  </div>
 </div>
 
 <!-- Authenticate for SIP with meeting and voice connector ID -->

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -95,6 +95,8 @@ import SyntheticVideoDeviceFactory from './video/SyntheticVideoDeviceFactory';
 import { getPOSTLogger } from './util/MeetingLogger';
 import Roster from './component/Roster';
 
+import { Modal } from 'bootstrap';
+
 let SHOULD_EARLY_CONNECT = (() => {
   return document.location.search.includes('earlyConnect=1');
 })();
@@ -252,7 +254,7 @@ export class DemoMeetingApp
 
   attendeeIdPresenceHandler: (undefined | ((attendeeId: string, present: boolean, externalUserId: string, dropped: boolean) => void)) = undefined;
   activeSpeakerHandler: (undefined | ((attendeeIds: string[]) => void)) = undefined;
-  volumeIndicatorHandler:  (undefined | ((attendeeId: string, volume: number, muted: boolean, signalStrength: number) => void)) = undefined;
+  volumeIndicatorHandler: (undefined | ((attendeeId: string, volume: number, muted: boolean, signalStrength: number) => void)) = undefined;
   canUnmuteLocalAudioHandler: (undefined | ((canUnmute: boolean) => void)) = undefined;
   muteAndUnmuteLocalAudioHandler: (undefined | ((muted: boolean) => void)) = undefined;
   blurObserver: (undefined | BackgroundBlurVideoFrameProcessorObserver) = undefined;
@@ -335,6 +337,7 @@ export class DemoMeetingApp
   voiceFocusTransformer: VoiceFocusDeviceTransformer | undefined;
   voiceFocusDevice: VoiceFocusTransformDevice | undefined;
   joinInfo: any | undefined;
+  joinInfoOverride: any | undefined = undefined;
   deleteOwnAttendeeToLeave = false;
 
   blurProcessor: BackgroundBlurProcessor | undefined;
@@ -459,6 +462,17 @@ export class DemoMeetingApp
       (document.getElementById('inputName') as HTMLInputElement).focus();
     } else {
       (document.getElementById('inputMeeting') as HTMLInputElement).focus();
+    }
+
+    if (new URL(window.location.href).searchParams.has('join-info-override')) {
+      const joinInfoOverride = JSON.parse(new URL(window.location.href).searchParams.get('join-info-override'));
+      (document.getElementById('create-attendee-override-input') as HTMLTextAreaElement).value = JSON.stringify(joinInfoOverride.JoinInfo.Attendee, null, 4);
+      (document.getElementById('get-meeting-override-input') as HTMLTextAreaElement).value = JSON.stringify(joinInfoOverride.JoinInfo.Meeting, null, 4);
+      new Modal(document.getElementById('join-info-override-modal'), {}).show();
+
+      document.getElementById('join-info-override-join-button').addEventListener('click', () => {
+        this.isViewOnly = (document.getElementById('join-view-only') as HTMLInputElement).checked;
+      });
     }
   }
 
@@ -629,6 +643,11 @@ export class DemoMeetingApp
     });
 
     document.getElementById('quick-join').addEventListener('click', e => {
+      e.preventDefault();
+      this.redirectFromAuthentication(true);
+    });
+
+    document.getElementById('join-info-override-join-button').addEventListener('click', e => {
       e.preventDefault();
       this.redirectFromAuthentication(true);
     });
@@ -1758,8 +1777,8 @@ export class DemoMeetingApp
     this.meetingSession.eventController.addObserver(this);
     this.audioVideo.addContentShareObserver(this);
     if (this.videoCodecPreferences !== undefined && this.videoCodecPreferences.length > 0) {
-        this.audioVideo.setVideoCodecSendPreferences(this.videoCodecPreferences);
-        this.audioVideo.setContentShareVideoCodecPreferences(this.videoCodecPreferences);
+      this.audioVideo.setVideoCodecSendPreferences(this.videoCodecPreferences);
+      this.audioVideo.setContentShareVideoCodecPreferences(this.videoCodecPreferences);
     }
     this.videoTileCollection = new VideoTileCollection(this.audioVideo,
       this.meetingLogger,
@@ -1882,7 +1901,7 @@ export class DemoMeetingApp
       ) {
         this.contentShareStop();
       }
-      const attendeeName =  externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '');
+      const attendeeName = externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '');
       this.roster.addAttendee(attendeeId, attendeeName);
 
       this.volumeIndicatorHandler = async (
@@ -1924,7 +1943,7 @@ export class DemoMeetingApp
       }
     };
 
-    const scoreHandler = (scores: { [attendeeId: string]: number }) => {};
+    const scoreHandler = (scores: { [attendeeId: string]: number }) => { };
 
     this.audioVideo.subscribeToActiveSpeakerDetector(
       new DefaultActiveSpeakerPolicy(),
@@ -3354,7 +3373,7 @@ export class DemoMeetingApp
   }
 
   async authenticate(): Promise<string> {
-    this.joinInfo = (await this.sendJoinRequest(this.meeting, this.name, this.region, this.primaryExternalMeetingId)).JoinInfo;
+    this.joinInfo = this.joinInfoOverride ? this.joinInfoOverride.JoinInfo : (await this.sendJoinRequest(this.meeting, this.name, this.region, this.primaryExternalMeetingId)).JoinInfo;
     this.region = this.joinInfo.Meeting.Meeting.MediaRegion;
     const configuration = new MeetingSessionConfiguration(this.joinInfo.Meeting, this.joinInfo.Attendee);
     await this.initializeMeetingSession(configuration);
@@ -3383,7 +3402,7 @@ export class DemoMeetingApp
 
   audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
     this.log(`session stopped from ${JSON.stringify(sessionStatus)}`);
-    if(this.behaviorAfterLeave === 'nothing') {
+    if (this.behaviorAfterLeave === 'nothing') {
       return;
     }
     this.log(`resetting stats`);
@@ -3585,6 +3604,20 @@ export class DemoMeetingApp
         break;
     }
 
+    const createAttendeeOverride = (document.getElementById('create-attendee-override-input') as HTMLTextAreaElement).value;
+    const getMeetingOverride = (document.getElementById('get-meeting-override-input') as HTMLTextAreaElement).value;
+    if (createAttendeeOverride.length !== 0 && getMeetingOverride.length !== 0) {
+      this.joinInfoOverride = {
+        JoinInfo: {
+          Meeting: JSON.parse(getMeetingOverride),
+          Attendee: JSON.parse(createAttendeeOverride),
+        }
+      };
+      this.meeting = this.joinInfoOverride.JoinInfo.Meeting.ExternalMeetingId;
+      this.name = this.joinInfoOverride.JoinInfo.Attendee.ExternalUserId;
+      this.region = this.joinInfoOverride.JoinInfo.Meeting.MediaRegion;
+    }
+
     AsyncScheduler.nextTick(
       async (): Promise<void> => {
         let chimeMeetingId: string = '';
@@ -3641,9 +3674,9 @@ export class DemoMeetingApp
           videoInputQuality.disabled = true;
         }
 
-        // `this.primaryExternalMeetingId` may by the join request
+        // `this.primaryExternalMeetingId` may by set by the join request. Not relevant with overriden info.
         const buttonPromoteToPrimary = document.getElementById('button-promote-to-primary');
-        if (!this.primaryExternalMeetingId) {
+        if (!this.primaryExternalMeetingId || this.joinInfoOverride !== undefined) {
           buttonPromoteToPrimary.style.display = 'none';
         } else {
           this.setButtonVisibility('button-record-cloud', false);

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1014,6 +1014,10 @@ a.markdown:active {
   max-width: 480px;
 }
 
+#join-info-override-modal .modal-content {
+  max-width: 600px;
+}
+
 .modal-content-header {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
**Issue #:** None. 

**Description of changes:** Often we (and possibly builders would find this useful) would like to join SDK meetings in different accounts using the browser demo that may not be using the serverless demo (or have a public endpoint). Previously we had the following workarounds:

* Deploy a serverless demo in every account and keep it updated. Use Meeting ID to join non-serverless created meetings.
* Hard code credentials into browser demo and recompile.

This change basically adds hidden (at least in additional options, where it is easily removed) logic to allow stubbing the join info. Also formatted demo.

![Screen Shot 2022-08-04 at 10 34 34 AM](https://user-images.githubusercontent.com/36210679/182914922-040cce06-3fba-4c89-9747-70875e2a7b99.png)

![Screen Shot 2022-08-04 at 10 33 35 AM](https://user-images.githubusercontent.com/36210679/182914939-bdee66d2-ebfa-468f-a595-4be975491d22.png)


**Testing:**

Joined a test meeting created in one account with a serverless demo in another account.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not relevant, just demo changes.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

