### PR TITLE
Fix AbortError in safari when video is turned ON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `AbortError` when turning video ON in Safari.
+
 ## [3.6.0] - 2022-06-23
 
 ### Added

--- a/docs/classes/defaultvideotile.html
+++ b/docs/classes/defaultvideotile.html
@@ -125,7 +125,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L105">src/videotile/DefaultVideoTile.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L118">src/videotile/DefaultVideoTile.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideoelement">bindVideoElement</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L195">src/videotile/DefaultVideoTile.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L208">src/videotile/DefaultVideoTile.ts:208</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#bindvideostream">bindVideoStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L149">src/videotile/DefaultVideoTile.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L162">src/videotile/DefaultVideoTile.ts:162</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#capture">capture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L251">src/videotile/DefaultVideoTile.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L264">src/videotile/DefaultVideoTile.ts:264</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -266,7 +266,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L118">src/videotile/DefaultVideoTile.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L131">src/videotile/DefaultVideoTile.ts:131</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicepixelratioobserver.html">DevicePixelRatioObserver</a>.<a href="../interfaces/devicepixelratioobserver.html#devicepixelratiochanged">devicePixelRatioChanged</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L132">src/videotile/DefaultVideoTile.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L145">src/videotile/DefaultVideoTile.ts:145</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#id">id</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L137">src/videotile/DefaultVideoTile.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L150">src/videotile/DefaultVideoTile.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#markpoorconnection">markPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L233">src/videotile/DefaultVideoTile.ts:233</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L246">src/videotile/DefaultVideoTile.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -369,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L219">src/videotile/DefaultVideoTile.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L232">src/videotile/DefaultVideoTile.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -396,7 +396,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#setstreamid">setStreamId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L264">src/videotile/DefaultVideoTile.ts:264</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L277">src/videotile/DefaultVideoTile.ts:277</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -426,7 +426,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#state">state</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L141">src/videotile/DefaultVideoTile.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L154">src/videotile/DefaultVideoTile.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -449,7 +449,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#stateref">stateRef</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L145">src/videotile/DefaultVideoTile.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L158">src/videotile/DefaultVideoTile.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -472,7 +472,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unmarkpoorconnection">unmarkPoorConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L242">src/videotile/DefaultVideoTile.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L255">src/videotile/DefaultVideoTile.ts:255</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -497,7 +497,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videotile.html">VideoTile</a>.<a href="../interfaces/videotile.html#unpause">unpause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L226">src/videotile/DefaultVideoTile.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L239">src/videotile/DefaultVideoTile.ts:239</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L79">src/videotile/DefaultVideoTile.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videotile/DefaultVideoTile.ts#L92">src/videotile/DefaultVideoTile.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/videotile/DefaultVideoTile.ts
+++ b/src/videotile/DefaultVideoTile.ts
@@ -63,7 +63,20 @@ export default class DefaultVideoTile implements DevicePixelRatioObserver, Video
       // In Safari, a hidden video element can show a black screen.
       // See https://bugs.webkit.org/show_bug.cgi?id=241152 for more information.
       if (new DefaultBrowserBehavior().requiresVideoPlayWorkaround() && videoElement.paused) {
-        videoElement.play();
+        const promise = videoElement.play();
+        // See https://bugs.webkit.org/show_bug.cgi?id=243519 for more information.
+        // https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/
+        /* istanbul ignore else */
+        if (promise !== undefined) {
+          promise
+            .catch(error => {
+              console.warn('Error playing video in Safari', error);
+            })
+            .then(() => {
+              // `then` block is needed, without it we run into black tile issue even though we catch the error.
+              console.debug('Video played successfully in Safari');
+            });
+        }
       }
     }
   }

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -230,13 +230,13 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
     });
 
-    it('can test Safari version 11', () => {
+    it('can test Safari version 15', () => {
       domMockBehavior = new DOMMockBehavior();
-      domMockBehavior.browserName = 'safari11';
+      domMockBehavior.browserName = 'safari15';
       mockBuilder = new DOMMockBuilder(domMockBehavior);
       expect(new DefaultBrowserBehavior().name()).to.eq('safari');
-      expect(new DefaultBrowserBehavior().isSupported()).to.be.false;
-      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(11);
+      expect(new DefaultBrowserBehavior().isSupported()).to.be.true;
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(15);
       expect(new DefaultBrowserBehavior().requiresBundlePolicy()).to.eq('max-bundle');
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
     });

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -605,8 +605,8 @@ export default class DOMMockBuilder {
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.2 Safari/605.1.15';
     const SAFARI12_USERAGENT =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15';
-    const SAFARI11_USERAGENT =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Safari/605.1.15';
+    const SAFARI15_USERAGENT =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15';
     const IOS_SAFARI12_0_USERAGENT =
       'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1';
     const IOS_SAFARI12_1_USERAGENT =
@@ -621,7 +621,7 @@ export default class DOMMockBuilder {
     USER_AGENTS.set('firefox', FIREFOX_USERAGENT);
     USER_AGENTS.set('safari', SAFARI_USERAGENT);
     USER_AGENTS.set('safari12', SAFARI12_USERAGENT);
-    USER_AGENTS.set('safari11', SAFARI11_USERAGENT);
+    USER_AGENTS.set('safari15', SAFARI15_USERAGENT);
     USER_AGENTS.set('ios12.0', IOS_SAFARI12_0_USERAGENT);
     USER_AGENTS.set('ios12.1', IOS_SAFARI12_1_USERAGENT);
     USER_AGENTS.set('ios15.1', IOS_SAFARI15_1_USERAGENT);
@@ -1330,6 +1330,7 @@ export default class DOMMockBuilder {
       style: { [key: string]: string } = {
         transform: '',
       };
+      paused: boolean;
 
       private clearAttribute(): void {
         this.videoHeight = 0;
@@ -1356,11 +1357,18 @@ export default class DOMMockBuilder {
         this.listeners[type].push(listener);
       }
 
-      pause(): void {}
+      pause(): void {
+        this.paused = true;
+      }
 
       play(): Promise<void> {
+        this.paused = false;
         if (mockBehavior.videoElementShouldFail) {
-          return Promise.reject();
+          if (['ios15.1', 'safari15'].includes(mockBehavior.browserName)) {
+            return Promise.reject(new MockError('AbortError', 'The operation was aborted'));
+          } else {
+            return Promise.reject();
+          }
         }
         if (this.refSrcObject) {
           new TimeoutScheduler(mockBehavior.videoElementStartPlayDelay).start(() => {

--- a/test/videotile/DefaultVideoTile.test.ts
+++ b/test/videotile/DefaultVideoTile.test.ts
@@ -198,7 +198,7 @@ describe('DefaultVideoTile', () => {
     });
 
     it('unbinds a video stream in Safari', done => {
-      domMockBehavior.browserName = 'safari12';
+      domMockBehavior.browserName = 'safari15';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
       tile = new DefaultVideoTile(tileId, true, tileController, monitor);
       const videoElement = videoElementFactory.create();
@@ -249,6 +249,25 @@ describe('DefaultVideoTile', () => {
       expect(tileControllerSpy.called).to.be.true;
       new TimeoutScheduler(10).start(() => {
         expect(videoElementSpy.called).to.be.true;
+        expect(videoElement.srcObject).to.equal(mockVideoStream);
+        done();
+      });
+    });
+
+    it('catches AbortError and plays the paused video element in Safari after setting srcObject to a new video stream', done => {
+      domMockBehavior.browserName = 'safari15';
+      domMockBehavior.videoElementShouldFail = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+
+      tile = new DefaultVideoTile(tileId, true, tileController, monitor);
+      const sinonSpy = sinon.spy(console, 'warn');
+      const videoElement = document.createElement('video');
+      videoElement.pause();
+      tile.bindVideoElement(videoElement);
+      tile.bindVideoStream('attendee', true, mockVideoStream, 1, 1, 1);
+
+      new TimeoutScheduler(10).start(() => {
+        expect(sinonSpy.calledWithMatch('Error playing video')).to.be.true;
         expect(videoElement.srcObject).to.equal(mockVideoStream);
         done();
       });


### PR DESCRIPTION
**Issue #:**
From browser compatibility test failures we came to know that video test is failing in Safari (15.5 as well as 15.6 on iOS and macOS safari). Turning the video ON results into below fatal error.
```
[Error] Fatal error: this was going to be caught, but should not have been thrown. – AbortError: The operation was aborted.
AbortError: The operation was aborted.
    fatal (Prod:2:986193)
    fatal
    (anonymous function) (Prod:2:985999)
[Log] [DEMO] AbortError: The operation was aborted. (Prod, line 2)
[Error] Unhandled Promise Rejection: AbortError: The operation was aborted.
    (anonymous function)
    rejectPromise
```

Browser compatibility test failure:
```
Generating failure report
=========================================
Run configuration:
 Client 1 : MAC  latest
Failure details:
 [Safari] Check the local video to be: video
=========================================
```

Failed test runs:
- https://github.com/aws/amazon-chime-sdk-js/actions/runs/2769578869
- https://github.com/aws/amazon-chime-sdk-js/runs/7591695192?check_suite_focus=true
- https://github.com/aws/amazon-chime-sdk-js/actions/runs/2760845837

**Root cause**
For a WebKit bug we had added a workaround to play a video element which is out of viewport.
PR: https://github.com/aws/amazon-chime-sdk-js/pull/2276
WebKit Bug: https://bugs.webkit.org/show_bug.cgi?id=241152
```
// In Safari, a hidden video element can show a black screen.
// See https://bugs.webkit.org/show_bug.cgi?id=241152 for more information.
if (new DefaultBrowserBehavior().requiresVideoPlayWorkaround() && videoElement.paused) {
  videoElement.play();
}
```

The `videoElement.play()` returns a promise hence, we have to catch any error if thrown. **The video playing does not affect local and remote videos over the peerconnection even if `AbortError` is thrown.**
Ref: https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/

Filed a Webkit bug for this: https://bugs.webkit.org/show_bug.cgi?id=243519 as the earlier https://bugs.webkit.org/show_bug.cgi?id=241152 is resolved fix.

**Description of changes:**
- Catch the error when thrown in Safari so that it does not result into fatal error.
- Add corresponding unit tests.
- Remove Safari 11 and add safari 15 based on current browser support.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Testing using the JS SDK browser demo app.
- Join a meeting with fatal error checked under additional options.
- Turn ON the video.
- There should be no fatal error.

Also tested the test steps in #2276 and see that the video is coming up fine after zooming in so that the video element when turned ON, it is out of the viewport. When scrolled down to get the video in viewport, I can see the video element fine.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

