### PR TITLE
Reduce steps in ContentShareOnlyAllowTwoTest to reduce runtime.

### DIFF
--- a/integration/js/ContentShareOnlyAllowTwoTest.js
+++ b/integration/js/ContentShareOnlyAllowTwoTest.js
@@ -37,26 +37,11 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
 
     //Turn on Content Share for first participant
     await test_window_1.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
-    await TestUtils.waitAround(5000);
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
+    await TestUtils.waitAround(3000);
 
     //Turn on Content Share for second participant
     await test_window_2.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
-    await TestUtils.waitAround(5000);
-    await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
-    await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_1.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
-    await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
+    await TestUtils.waitAround(3000);
 
     //Turn on Content Share for third participant
     await test_window_3.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));


### PR DESCRIPTION
**Issue #:**
ContentShareOnlyAllowTwoTest often takes 15m+.
**Description of changes:**
- Remove steps to reduce runtime of the ContentShareOnlyAllowTwoTest steps these steps are tested on other tests.

**Testing:**
- Ran test

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

