### PR TITLE
Update Sauce Connection Action version

### DIFF
--- a/.github/actions/setup-integration-test/action.yml
+++ b/.github/actions/setup-integration-test/action.yml
@@ -50,7 +50,7 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: us-east-1
     - name: Setup Sauce Connect
-      uses: saucelabs/sauce-connect-action@v1
+      uses: saucelabs/sauce-connect-action@v2
       with:
         username: ${{ inputs.sauce-username }}
         accessKey: ${{ inputs.sauce-access-key }}

--- a/.integration-watchlist
+++ b/.integration-watchlist
@@ -2,6 +2,7 @@
 demos/browser
 src/
 integration/
+.github/
 
 # exceptions
 !.eslintignore
@@ -12,5 +13,4 @@ integration/
 !demos/device/README.md
 !guides/
 !docs/
-!.github/
 !.integration-watchlist


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Update Sauce Connection Action to v2 to use Sauce Connection v4.8.x as v4.6.x is no longer supported.
**Testing:**
Verify from GitHub action log that the Sauce Connect version is 4.8.1
```
Run saucelabs/sauce-connect-action@v2
/usr/bin/docker pull saucelabs/sauce-connect:4.8.1
4.8.1: Pulling from saucelabs/sauce-connect

```

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

