### PR TITLE
Update the automatic meeting end rule in the FAQ

### DIFF
--- a/docs/modules/faqs.html
+++ b/docs/modules/faqs.html
@@ -163,12 +163,20 @@
 					<a href="#when-does-an-amazon-chime-sdk-meeting-end" id="when-does-an-amazon-chime-sdk-meeting-end" style="color: inherit; text-decoration: none;">
 						<h3>When does an Amazon Chime SDK meeting end?</h3>
 					</a>
-					<p>An Amazon Chime SDK meeting ends when you invoke the <a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html">DeleteMeeting</a> API action. Also, a meeting automatically ends after a period of inactivity, based on the following rules:</p>
+					<p>An Amazon Chime SDK meeting ends when you invoke the <a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html">DeleteMeeting</a> API action.</p>
+					<p>Also, a meeting automatically ends after a period of inactivity, based on the following rules:</p>
+					<p>For <a href="https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime_SDK_Meetings.html">Amazon Chime SDK</a> namespace:</p>
+					<ul>
+						<li>No audio connections are present in the meeting for more than five minutes.</li>
+						<li>24 hours have elapsed since the meeting was created.</li>
+					</ul>
+					<p>For <a href="https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime.html">Amazon Chime</a> namespace:</p>
 					<ul>
 						<li>No audio connections are present in the meeting for more than five minutes.</li>
 						<li>Only one audio connection is present in the meeting for more than 30 minutes.</li>
 						<li>24 hours have elapsed since the meeting was created.</li>
 					</ul>
+					<p>Learn more about <a href="https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime_SDK_Meetings.html">Amazon Chime SDK</a> namespace and <a href="https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime.html">Amazon Chime</a> namespace in <a href="https://docs.aws.amazon.com/chime-sdk/latest/dg/meeting-namespace-migration.html">Migrating to the Amazon Chime SDK Meetings namespace</a>.</p>
 					<a href="#how-many-simultaneous-meetings-can-be-hosted-in-an-account-can-this-limit-be-raised" id="how-many-simultaneous-meetings-can-be-hosted-in-an-account-can-this-limit-be-raised" style="color: inherit; text-decoration: none;">
 						<h3>How many simultaneous meetings can be hosted in an account? Can this limit be raised?</h3>
 					</a>

--- a/guides/07_FAQs.md
+++ b/guides/07_FAQs.md
@@ -104,11 +104,22 @@ The Amazon Chime SDK uses join tokens to control access to meetings. These token
 
 ### When does an Amazon Chime SDK meeting end?
 
-An Amazon Chime SDK meeting ends when you invoke the [DeleteMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html) API action. Also, a meeting automatically ends after a period of inactivity, based on the following rules:
+An Amazon Chime SDK meeting ends when you invoke the [DeleteMeeting](https://docs.aws.amazon.com/chime/latest/APIReference/API_DeleteMeeting.html) API action.
+
+Also, a meeting automatically ends after a period of inactivity, based on the following rules:
+
+For [Amazon Chime SDK](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime_SDK_Meetings.html) namespace:
+
+* No audio connections are present in the meeting for more than five minutes.
+* 24 hours have elapsed since the meeting was created.
+
+For [Amazon Chime](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime.html) namespace:
 
 * No audio connections are present in the meeting for more than five minutes.
 * Only one audio connection is present in the meeting for more than 30 minutes.
 * 24 hours have elapsed since the meeting was created.
+
+Learn more about [Amazon Chime SDK](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime_SDK_Meetings.html) namespace and [Amazon Chime](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_Operations_Amazon_Chime.html) namespace in [Migrating to the Amazon Chime SDK Meetings namespace](https://docs.aws.amazon.com/chime-sdk/latest/dg/meeting-namespace-migration.html).
 
 ### How many simultaneous meetings can be hosted in an account? Can this limit be raised?
 


### PR DESCRIPTION
**Issue #:**
Automatic meeting end rule is out dated in FAQ.

**Description of changes:**
Update the automatic meeting end rule in the FAQ based on Amazon Chime backend namespace.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A, only doc change.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

