### PR TITLE
Fix messagingSession infinite reconnect loop on error and also add backwards compatibility with AWS JS SDK V2 for getMessagingSessionEndpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `MessagingSession` reconnect loop did not break on error past reconnect deadline. Infinite reconnect loop was caused due to `firstConnectionAttemptTimestamp` not being set as `startedConnectionAttempt` was not invoked. Check https://github.com/aws/amazon-chime-sdk-js/issues/2372 for details.
+- `MessagingSession` `getMessagingSessionEndpoint` call is now backwards compatible with AWS JS SDK v2.
 - Use a default "playback" `latencyHint` when creating the `AudioContext` on Windows. Also adds a `setDefaultLatencyHint` API to `DefaultDeviceController` to allow for overriding.
 
 ## [3.7.0] - 2022-07-05


### PR DESCRIPTION
**Issue #:**
 https://github.com/aws/amazon-chime-sdk-js/issues/2372

**Description of changes:**
1. Fix to break infinite reconnect loop in messagingSession on timeout. Reported here https://github.com/aws/amazon-chime-sdk-js/issues/2372
2. Add backwards compatibility with aws-js-sdk 2.x for getMessagingSessionEndpoint call

**Testing:**
* Tested reconnect loop fix by expiring credentials to validate reconnect loop on messagingSession breaks after the timeout
* Tested compatibility with aws sdk v2 by changing the chime client instantiation in the messagingSession demo

* Set aws credentials with in correct aws session token
* Run the messagingSession demo here: https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/browser. npm run start --app=messagingSession
* connect with an app instance user
* Reconnect loop is triggered but breaks after timeout

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
*To Test aws js sdk v2 compatibility run the messagingSession demo with below changes*
 Make the following changes in amazon-chime-sdk-js/demos/browser/app/messagingSession/messagingSession.ts
```
import { ChimeSDKMessagingClient } from '@aws-sdk/client-chime-sdk-messaging'
to
import * as Chime from 'aws-sdk/clients/chime';
```

and change 
```
 const chime = new ChimeSDKMessagingClient({ region: 'us-east-1', credentials: response });
to
const chime = new Chime({ region: 'us-east-1', credentials: response });
```

*To Test aws js sdk v3 with v2 style run the messagingSession demo with below changes*
 Make the following changes in amazon-chime-sdk-js/demos/browser/app/messagingSession/messagingSession.ts
```
import { ChimeSDKMessagingClient } from '@aws-sdk/client-chime-sdk-messaging'
to
import { ChimeSDKMessaging } from '@aws-sdk/client-chime-sdk-messaging';
```
and 
```
 const chime = new ChimeSDKMessagingClient({ region: 'us-east-1', credentials: response });
to
const chime = new ChimeSDKMessaging({ region: 'us-east-1', credentials: response });
```

and then run 
**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
yes
