### PR TITLE
Fix backward compatibility check to validate preReleaseName if existing

### DIFF
--- a/.github/script/backward-compatibility-run-check.js
+++ b/.github/script/backward-compatibility-run-check.js
@@ -10,9 +10,7 @@
 
  // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionToRelease = require('../../package.json').version;
-console.log('versionToRelease', versionToRelease);
 const preReleaseName = (spawnOrFail('node', ['.github/script/get-pre-release-name'], { skipOutput: true })).trim();
-console.log('preReleaseName', preReleaseName);
 // Check version to release if is a pre-release version or an first major version of a new major version.
 // This satisfies versions like: 3.0.0, 4.0.0, 3.0.0-beta.0, 3.0.0-beta.1
 if (preReleaseName && versionToRelease.includes(preReleaseName)) {

--- a/.github/script/backward-compatibility-run-check.js
+++ b/.github/script/backward-compatibility-run-check.js
@@ -10,11 +10,12 @@
 
  // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionToRelease = require('../../package.json').version;
+console.log('versionToRelease', versionToRelease);
 const preReleaseName = (spawnOrFail('node', ['.github/script/get-pre-release-name'], { skipOutput: true })).trim();
-
+console.log('preReleaseName', preReleaseName);
 // Check version to release if is a pre-release version or an first major version of a new major version.
 // This satisfies versions like: 3.0.0, 4.0.0, 3.0.0-beta.0, 3.0.0-beta.1
-if (versionToRelease.includes(preReleaseName)) {
+if (preReleaseName && versionToRelease.includes(preReleaseName)) {
   console.log(`Skip backward compatibility checks for a pre release ${preReleaseName} version: ${versionToRelease}`);
 } else if ((/^[0-9]+\.0\.0$/g).test(versionToRelease)) {
   console.log(`Skip backward compatibility checks for a new major version: ${versionToRelease}`);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

After we released betas, the backward compatibility checks have not been running correctly. The GitHub action shows success but the test run itself has been skipped due to a bug in the backward compatibility run check script.

Since the `preReleaseName` is empty starting 3.1.0 (no more betas after that) the check did not consider it and always printed "Skip backward compatibility checks". The backward compatibility tests check whether the logged statement includes "Run backward compatibility checks" and then run. Since it was not printed the backward compatibility tests actually did not ran.

![Screen Shot 2022-09-21 at 5 38 03 PM](https://user-images.githubusercontent.com/61809205/191634245-0e62ad76-7e6d-47d6-a64a-daba3f9d68b4.png)


More runs where the backward compatibility checks did not actually ran:
- https://github.com/aws/amazon-chime-sdk-js/actions/runs/2884173393
- https://github.com/aws/amazon-chime-sdk-js/actions/runs/2843403735
- https://github.com/aws/amazon-chime-sdk-js/actions/runs/2558753317

**Testing:**
Did the test locally.

Before:
```
➜  amazon-chime-sdk-js git:(main) ✗ node .github/script/backward-compatibility-run-check.js
versionToRelease 3.8.0
preReleaseName 
Skip backward compatibility checks for a pre release  version: 3.8.0
```

After:
```
➜  amazon-chime-sdk-js git:(main) ✗ node .github/script/backward-compatibility-run-check.js
versionToRelease 3.8.0
preReleaseName 
Run backward compatibility checks to release 3.8.0
```

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA, just a script change.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

