### PR TITLE
Fix backward compatibility script to validate the empty `preReleaseName`

### DIFF
--- a/.github/script/backward-compatibility-run-check.js
+++ b/.github/script/backward-compatibility-run-check.js
@@ -10,11 +10,12 @@
 
  // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionToRelease = require('../../package.json').version;
+console.log('versionToRelease', versionToRelease);
 const preReleaseName = (spawnOrFail('node', ['.github/script/get-pre-release-name'], { skipOutput: true })).trim();
-
+console.log('preReleaseName', preReleaseName);
 // Check version to release if is a pre-release version or an first major version of a new major version.
 // This satisfies versions like: 3.0.0, 4.0.0, 3.0.0-beta.0, 3.0.0-beta.1
-if (versionToRelease.includes(preReleaseName)) {
+if (preReleaseName && versionToRelease.includes(preReleaseName)) {
   console.log(`Skip backward compatibility checks for a pre release ${preReleaseName} version: ${versionToRelease}`);
 } else if ((/^[0-9]+\.0\.0$/g).test(versionToRelease)) {
   console.log(`Skip backward compatibility checks for a new major version: ${versionToRelease}`);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
- Check https://github.com/aws/amazon-chime-sdk-js/pull/2449 for all details.
- Creating this PR to trigger the backward compatibility run check.
- This does not affect any existing changes going as part of the `3.8.0` release rather help catch any breaking/backward in-compatible changes.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

