### PR TITLE
Add metrics derived from string metrics in metric report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add metric derived from string metric in metric report.
+
 ### Fixed
 
 ## [3.8.0] - 2022-08-18

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -390,6 +390,10 @@ export default class StatsCollector {
       for (const metricName in streamMetricReport.currentMetrics) {
         this.addMetricFrame(metricName, clientMetricFrame, metricMap[metricName], Number(ssrc));
       }
+
+      for (const metricName in streamMetricReport.currentStringMetrics) {
+        this.addMetricFrame(metricName, clientMetricFrame, metricMap[metricName], Number(ssrc));
+      }
     }
   }
 


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Add metric derived from string metric in metric report

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Join a meeting with Chrome and select log level as `DEBUG`, turn on video on one user. Use the following string to filter console logs `[DEBUG] SDK - sending:`. Verify the log contains the following fields on sender and receiver side, respectively.

Sender side message has `VIDEO_ENCODER_IS_HARDWARE` metric field. Example: `{"type":"VIDEO_ENCODER_IS_HARDWARE","value":0}`

Receiver side message has `VIDEO_DECODER_IS_HARDWARE` metric field. Example: `{"type":"VIDEO_DECODER_IS_HARDWARE","value":1}`

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

