### PR TITLE
Update sauce connect to v2 in prev integ and release backwards workflow

### DIFF
--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -47,7 +47,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Setup Sauce Connect
-        uses: saucelabs/sauce-connect-action@v1
+        uses: saucelabs/sauce-connect-action@v2
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -65,7 +65,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - name: Setup Sauce Connect
-        uses: saucelabs/sauce-connect-action@v1
+        uses: saucelabs/sauce-connect-action@v2
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
**Issue #:**

Sauce Connect v4.6 is getting deprecated. Sauce Connect proxy v1 uses v4.6.4

**Description of changes:**

Upgrade Sauce Connect Github action version to 2. Sauce Connect v2 uses 4.8.1
This PR is similar to past PR: #2426 

**Testing:**
Temporarily updated the workflow run condition for previous version integration test and backwards compatibility test to run the actions for verification. Verified from GitHub action log that the Sauce Connect version is 4.8.1

```
Run saucelabs/sauce-connect-action@v2
/usr/bin/docker pull saucelabs/sauce-connect:4.8.1
```

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

