### PR TITLE
simplified media capture demo deployment and added automatic concatenation for media capture demo

### DIFF
--- a/demos/serverless/README.md
+++ b/demos/serverless/README.md
@@ -39,37 +39,29 @@ npm install
 npm run deploy -- -r us-east-1 -b <my-bucket> -s <my-stack-name> -a meeting -u false
 ```
 
-#### Media Capture
-You can use the live connector feature to broadcast the captured artifacts. The default layout is vertical layout and FHD resolution. You can use the playback url that showed up in any M3U8 player, such as `https://www.hlsplayer.net/`.
+#### Media Live Connector
+You can use the live connector feature to livestream the Chime SDK meeting with supported layout. The default layout in this demo is vertical layout and FHD resolution. You can use the playback url that showed up after clicking "livestream to IVS" button. **This feature will not work under "chime" namespace.**
+
 If you want to try differnt layout configuration, please check our [ public document](https://docs.aws.amazon.com/chime-sdk/latest/APIReference/API_media-pipelines-chime_CreateMediaLiveConnectorPipeline.html).
-```
-cd demos/serverless
-npm install
-npm run deploy -- -r us-east-1 -b <deploy-bucekt> -i af-south-1,eu-south-1 -s <my-stack-name> -a meeting
-```
 
-If you want to also use media capture in the same meeting, an S3 bucket needs to be created for each region.
-The S3 bucket will be created with a prefix specified with the -o option.
+No specific deployment parameter is needed for media live connector.
 
 ```
 cd demos/serverless
 npm install
-npm run deploy -- -r us-east-1 -b <deploy-bucket> -o <capture-bucket-prefix> -s <my-stack-name> -a meeting
+npm run deploy -- -r us-east-1 -b <deploy-bucekt> -s <my-stack-name> -a meeting
 ```
 
-When the bucket prefix is provided, an S3 bucket will be created in each AWS region that
-a meeting can be hosted in except for those that require opt-in. If you wish to use
-media capture in one of these regions, you can list them with the -i option, for example
+#### Media Capture
+If you want to use media capture in the same meeting, an S3 bucket needs to be created. The bucket name needs to be unique otherwise it will fail to create. Use `-o <media-capture-bucket>` to pass the name.
+
+The captured artifacts are using composited video configuration, and will be stored in the `media-capture-bucket`.
 
 ```
 cd demos/serverless
 npm install
-npm run deploy -- -r us-east-1 -b <deploy-bucekt> -o <capture-bucket-prefix> -i af-south-1,eu-south-1 -s <my-stack-name> -a meeting
+npm run deploy -- -r us-east-1 -b <deploy-bucket> -o <media-capture-bucket> -s <my-stack-name> -a meeting
 ```
-
-Note that you need to enable these regions if you plan to use media capture. For more information, see [Managing AWS Regions](https://docs.aws.amazon.com/general/latest/gr/rande-manage.html).
-
-
 
 ##### ChimeSDKMediaPipelines Namespace vs Chime Namespace
 The `AWS.Chime` and the `AWS.ChimeSDKMediaPipelines` are both Amazon Chime's AWS clients to help builders create Amazon Chime SDK media pipelines. `AWS.ChimeSDKMediaPipelines` is intended to replace the previous `AWS.Chime` client.

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -20,8 +20,12 @@ Parameters:
     Description: The AWS SDK Chime endpoint
     Default: "https://service.chime.aws.amazon.com"
     Type: String
-  ChimeServicePrincipal:
+  ChimeMediaPipelinesServicePrincipal:
     Description: "The principal that will capture to the S3 bucket"
+    Default: "chime.amazonaws.com"
+    Type: String
+  ChimeMeetingsServicePrincipal:
+    Description: "The principal for meeting notification"
     Default: "chime.amazonaws.com"
     Type: String
   ChimeSDKMeetingsEndpoint:
@@ -81,6 +85,7 @@ Resources:
   MediaCapturePipelineCaptureBucket:
     Type: AWS::S3::Bucket
     Condition: ShouldCreateS3BucketForMediaCapture
+    DeletionPolicy: Retain
     Properties:
       BucketName: !Ref ChimeMediaCaptureS3Bucket
       LifecycleConfiguration:
@@ -119,7 +124,7 @@ Resources:
                   - '/*'
             Principal: 
               Service: 
-                - 'mediapipelines.chime.amazonaws.com'
+                - !Ref ChimeMediaPipelinesServicePrincipal
             Condition:
               StringEquals:
                 'aws:SourceAccount': !Ref AWS::AccountId
@@ -240,7 +245,7 @@ Resources:
           - Sid: Allow access for Chime Service
             Effect: Allow
             Principal:
-              Service: !Ref ChimeServicePrincipal
+              Service: !Ref ChimeMediaPipelinesServicePrincipal
             Action:
               - kms:GenerateDataKey
               - kms:Decrypt
@@ -556,7 +561,7 @@ Resources:
               - sqs:GetQueueUrl
             Principal:
               Service:
-                - !Ref ChimeServicePrincipal
+                - !Ref ChimeMeetingsServicePrincipal
             Resource: !GetAtt MeetingNotificationsQueue.Arn
       Queues:
         - Ref: MeetingNotificationsQueue

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -28,7 +28,7 @@ Parameters:
     Description: The AWS Chime SDK Meetings endpoint
     Default: "https://service.chime.aws.amazon.com"
     Type: String
-  ChimeMediaCaptureS3BucketPrefix:
+  ChimeMediaCaptureS3Bucket:
     Description: Prefix of S3 bucket to write capture artifacts.  The bucket name will be suffixed with the region.
     Default: ""
     Type: String
@@ -55,6 +55,7 @@ Parameters:
 Conditions:
   ShouldUseEventBridge: !Equals [true, !Ref UseEventBridge]
   ShouldDeployFetchCredentialLambda: !Equals [true, !Ref UseFetchCredentialLambda]
+  ShouldCreateS3BucketForMediaCapture: !Not [!Equals ["", !Ref ChimeMediaCaptureS3Bucket]]
 Globals:
   Function:
     Runtime: nodejs14.x
@@ -74,10 +75,60 @@ Globals:
         USE_CHIME_SDK_MEDIA_PIPELINES: !Ref UseChimeSDKMediaPipelines
         CHIME_SDK_MEDIA_PIPELINES_ENDPOINT: !Ref ChimeSDKMediaPipelinesEndpoint
         BROWSER_EVENT_INGESTION_LOG_GROUP_NAME: !Ref ChimeBrowserEventIngestionLogs
-        CAPTURE_S3_DESTINATION_PREFIX: !Ref ChimeMediaCaptureS3BucketPrefix
+        CAPTURE_S3_DESTINATION: !Ref ChimeMediaCaptureS3Bucket
         AWS_ACCOUNT_ID: !Sub "${AWS::AccountId}"
 Resources:
-
+  MediaCapturePipelineCaptureBucket:
+    Type: AWS::S3::Bucket
+    Condition: ShouldCreateS3BucketForMediaCapture
+    Properties:
+      BucketName: !Ref ChimeMediaCaptureS3Bucket
+      LifecycleConfiguration:
+        Rules:
+          - Id: "Delete artifacts after 1 day"
+            ExpirationInDays: 1
+            Status: Enabled
+            Prefix: ""
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+  MediaCaptureBucketPolicy:
+    Condition: ShouldCreateS3BucketForMediaCapture
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket: !Ref ChimeMediaCaptureS3Bucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: 'Policy1625687208360'
+        Statement:
+          - Action:
+              - 's3:PutObject'
+              - 's3:PutObjectAcl'
+              - 's3:GetObject'
+              - 's3:ListBucket'
+            Effect: Allow
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::'
+                  - !Ref ChimeMediaCaptureS3Bucket
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::'
+                  - !Ref ChimeMediaCaptureS3Bucket
+                  - '/*'
+            Principal: 
+              Service: 
+                - 'mediapipelines.chime.amazonaws.com'
+            Condition:
+              StringEquals:
+                'aws:SourceAccount': !Ref AWS::AccountId
+              ArnLike:
+                'aws:SourceArn': !Join
+                  - ''
+                  - - 'arn:aws:chime:*:'
+                    - !Ref AWS::AccountId
+                    - ':*'
   ChimeMeetingsAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -103,6 +154,7 @@ Resources:
               - 'chime:CreateMediaCapturePipeline'
               - 'chime:DeleteMediaCapturePipeline'
               - 'chime:CreateMediaLiveConnectorPipeline'
+              - 'chime:CreateMediaConcatenationPipeline'
               - 'chime:DeleteMediaPipeline'
               - 'ivs:CreateChannel'
               - 'ivs:DeleteChannel'

--- a/script/deploy-canary-demo
+++ b/script/deploy-canary-demo
@@ -13,7 +13,7 @@ ChimeAlpha)
     echo "Deploying to alpha stage for canary"
 
     # Uses Chime Client
-    npm run deploy -- -b chime-sdk-demo-canary$canarySuffix -s chime-sdk-demo-canary$canarySuffix -o chime-sdk-demo-canary$canarySuffix -u false -i eu-south-1 -t -l --use-chime-sdk-media-pipelines false
+    npm run deploy -- -b chime-sdk-demo-canary$canarySuffix -s chime-sdk-demo-canary$canarySuffix -o chime-sdk-demo-canary$canarySuffix -u false -t -l --use-chime-sdk-media-pipelines false
     npm run deploy -- -b chime-sdk-meeting-readiness-checker-dev-canary$canarySuffix -s chime-sdk-meeting-readiness-checker-dev-canary$canarySuffix -a meetingReadinessChecker -u false -t -l
     ;;
 
@@ -21,7 +21,7 @@ ChimeBeta)
     echo "Deploying to beta stage for canary that talks to gamma Chime client for meetings and gamma Chime client for media pipelines"
 
     # Uses Chime Client for meetings and Chime client for media pipelines
-    npm run deploy -- -b chime-sdk-demo-beta-canary$canarySuffix -s chime-sdk-demo-beta-canary$canarySuffix -o chime-sdk-demo-beta-canary$canarySuffix -i eu-south-1 -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT -u false -t -l --use-chime-sdk-media-pipelines false
+    npm run deploy -- -b chime-sdk-demo-beta-canary$canarySuffix -s chime-sdk-demo-beta-canary$canarySuffix -o chime-sdk-demo-beta-canary$canarySuffix -p $GAMMA_CHIME_SERVICE_PRINCIPAL -c $GAMMA_CHIME_ENDPOINT -u false -t -l --use-chime-sdk-media-pipelines false
     npm run deploy -- -b chime-sdk-meeting-readiness-checker-beta-canary$canarySuffix -s chime-sdk-meeting-readiness-checker-beta-canary$canarySuffix -a meetingReadinessChecker -c $GAMMA_CHIME_ENDPOINT -u false -t -l
     ;;
 
@@ -54,7 +54,7 @@ ChimeGamma)
     echo "Deploying to gamma stage for canary that talks to prod Chime client for meetings and prod Chime client for media pipelines"
 
     # Uses Chime Client
-    npm run deploy -- -b chime-sdk-demo-gamma-canary$canarySuffix -s chime-sdk-demo-gamma-canary$canarySuffix -o chime-sdk-demo-gamma-canary$canarySuffix -u false -i eu-south-1 -t -l --use-chime-sdk-media-pipelines false -p chime.amazonaws.com
+    npm run deploy -- -b chime-sdk-demo-gamma-canary$canarySuffix -s chime-sdk-demo-gamma-canary$canarySuffix -o chime-sdk-demo-gamma-canary$canarySuffix -u false -t -l --use-chime-sdk-media-pipelines false -p chime.amazonaws.com
     npm run deploy -- -b chime-sdk-meeting-readiness-checker-gamma-canary$canarySuffix -s chime-sdk-meeting-readiness-checker-gamma-canary$canarySuffix -a meetingReadinessChecker -u false -t -l
     ;;
 


### PR DESCRIPTION
**Description of changes:**
1. Some of the default boolean parameter like `useChimeSdkMeetings` or `useChimeSdkMediaPipelines` didn't work because they were set as boolean and compared as string in the `ensureRegion()`. Fixed.
2. Rewrote the media live connector and media capture section in Readme.
3. Enabled media capture video compositing for the demo.
4. Added concatenation for media capture.
5. Removed the complicated media capture s3 bucket regional parameter, as media capture no longer requires a specific bucket region, and this simplifies the deployment workflow.
6. Moved the media capture bucket creation to cloudformation, so that we don't need to create a new stack every time. Just updating the previous stack. The resource creation depends on the condition that a bucket name is passed in.
7. Decoupled media pipeline service principal and meetings SP. 

**Testing:**
Deployed and worked fine.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

Have you successfully run `npm run build:release` locally?
Yes

Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes
