### PR TITLE
Add average bitrate as a second criterion for stream selection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add metric derived from string metric in metric report.
+- Add average bitrate as a second criterion for stream selection in priority based downlink policy
 
 ### Fixed
 * Fixed missing videos, or unnecessarily long freezes when switching simulcast streams.

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -316,7 +316,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L391">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L394">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:394</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -452,7 +452,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getcurrentvideopreferences">getCurrentVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1064">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1064</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1069">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1069</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videopreferences.html" class="tsd-signature-type" data-tsd-kind="Class">VideoPreferences</a></h4>
@@ -470,7 +470,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getserversidenetworkadaption">getServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1068">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1068</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1073">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1073</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -494,7 +494,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getvideopreferences">getVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1081">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1081</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1086">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1086</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -570,7 +570,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setserversidenetworkadaption">setServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1072">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1072</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1077">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1077</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -624,7 +624,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#supportedserversidenetworkadaptions">supportedServerSideNetworkAdaptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1077">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1077</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1082">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1082</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -315,7 +315,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L391">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L394">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:394</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -440,7 +440,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1064">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1064</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1069">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1069</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videopreferences.html" class="tsd-signature-type" data-tsd-kind="Class">VideoPreferences</a></h4>
@@ -458,7 +458,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#getserversidenetworkadaption">getServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1068">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1068</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1073">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1073</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -482,7 +482,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#getvideopreferences">getVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1081">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1081</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1086">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1086</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -558,7 +558,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#setserversidenetworkadaption">setServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1072">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1072</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1077">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1077</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -611,7 +611,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#supportedserversidenetworkadaptions">supportedServerSideNetworkAdaptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1077">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1077</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1082">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1082</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -286,7 +286,10 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     // Sort streams by bitrate ascending.
     remoteInfos.sort((a, b) => {
       if (a.maxBitrateKbps === b.maxBitrateKbps) {
-        return a.streamId - b.streamId;
+        if (a.avgBitrateKbps === b.avgBitrateKbps) {
+          return a.streamId - b.streamId;
+        }
+        return a.avgBitrateKbps - b.avgBitrateKbps;
       }
       return a.maxBitrateKbps - b.maxBitrateKbps;
     });
@@ -868,7 +871,9 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
             if (info.attendeeId === preference.attendeeId) {
               const index = chosenStreams.findIndex(
                 stream =>
-                  stream.groupId === info.groupId && stream.maxBitrateKbps < info.maxBitrateKbps
+                  stream.groupId === info.groupId &&
+                  stream.maxBitrateKbps <= info.maxBitrateKbps &&
+                  stream.avgBitrateKbps < info.avgBitrateKbps
               );
               if (index !== -1) {
                 const increaseKbps = info.avgBitrateKbps - chosenStreams[index].avgBitrateKbps;


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
This is useful for the SVC stream selection usecase where the maximum bitrate advertised is the same.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
This change is not testable at the time as VP9 SVC is not supported. Will add QA test cases prior to SVC rollout.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

