### PR TITLE
Fix content share local file testing using label + input file type

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -651,9 +651,8 @@
               Audio Speech</a>
             <a id="dropdown-item-content-share-test-stereo-audio-tone" class="dropdown-item content-share-source-option" href="#">Test Stereo
               Tone (L-500Hz R-1000Hz)</a>
-            <a id="dropdown-item-content-share-file-item" class="dropdown-item content-share-source-option" onclick="document.getElementById('content-share-item').click();" href="#">
-              Local File<input id="content-share-item" type="file" style="display: none;">
-            </a> 
+            <label id="dropdown-item-content-share-file-item" class="dropdown-item content-share-source-option" for="content-share-item">Local file</label>
+            <input id="content-share-item" type="file">
           </div>
         </div>
         <div class="btn-group mx-1 mx-xl-2 my-2" role="group" aria-label="Toggle speaker">

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1067,3 +1067,13 @@ a.markdown:active {
     right: 20px;
     position: absolute;
 }
+
+input[type="file"] { 
+  opacity: 0;
+  z-index: -1;
+  position: absolute;
+}
+
+input[type="file"]:focus + label {
+  outline: 2px solid;
+}


### PR DESCRIPTION
**Issue #:**

File clicking does not work when the display of the input tag is set to none.

**Description of changes:**
change the `display: none` to use `label` to fix local file content share upload .

Will port the change to `release-3.9.0`.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
browser meeting demo

1. Run the demo
2. Click the content share drop down.
3. Select "Local file", this opens the file browser and select a file.
4. Then click on the content share button to start the screen share.

Tested in Chrome and Firefox desktop. Not tested in mobile phones.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Not needed as this is a demo change

6. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

7. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

