### PR TITLE
Fix codec intersection logic to avoid unnecessary renegotiations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+Fix codec intersection logic to avoid unnecessary renegotiations.
 
 ## [3.9.0] - 2022-09-21
 

--- a/src/task/ReceiveVideoStreamIndexTask.ts
+++ b/src/task/ReceiveVideoStreamIndexTask.ts
@@ -218,16 +218,18 @@ export default class ReceiveVideoStreamIndexTask
     const newMeetingSupportedVideoSendCodecPreferences: VideoCodecCapability[] = [];
     let willNeedUpdate = false;
 
-    // Interesect `this.context.videoSendCodecPreferences` with `index.supportedReceiveCodecIntersection`
+    // Intersect `this.context.videoSendCodecPreferences` with `index.supportedReceiveCodecIntersection`
     for (const capability of this.context.videoSendCodecPreferences) {
+      let codecSupported = false;
       for (const signaledCapability of index.supportedReceiveCodecIntersection) {
         if (capability.equals(VideoCodecCapability.fromSignaled(signaledCapability))) {
+          codecSupported = true;
           newMeetingSupportedVideoSendCodecPreferences.push(capability);
           break;
         }
       }
       // We need to renegotiate if we are currently sending a codec that is no longer supported in the call.
-      if (capability.equals(this.context.currentVideoSendCodec)) {
+      if (!codecSupported && capability.equals(this.context.currentVideoSendCodec)) {
         willNeedUpdate = true;
       }
     }


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Fix codec intersection logic to avoid unnecessary renegotiations.

**Testing:**
Tested locally to verify no unexpected renegotiations are triggered.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Can use instructions in https://github.com/aws/amazon-chime-sdk-js/pull/2292

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

