### PR TITLE
Allow stubbing join info to enable easy cross account joining from browser demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -116,7 +116,11 @@
             </select>
             <label for="videoCodec"  style="text-align: left;">Preferred Video Send Codec:</label>
           </div>
-          <div class="form-check" style="text-align: left;">
+          <button type="button" class="btn btn-outline-secondary h-50 d-sm-block mb-3" style="width: 100%" data-bs-toggle="modal" id="create-attendee-override-button"
+        data-bs-target="#join-info-override-modal">
+            Override Join Info
+        </button>
+        <div class="form-check" style="text-align: left;">
             <input type="checkbox" id="webaudio" class="form-check-input">
             <label for="webaudio" class="form-check-label">Use WebAudio</label>
           </div>
@@ -198,6 +202,69 @@
         </fieldset>
       </div>
       <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="additional-options-save-button">Save</button>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="join-info-override-modal" tabindex="-1" aria-labelledby="join-info-override-modal-label"
+  aria-hidden="true">
+  <div class="modal-dialog modal-lg" style="width: 90%">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="join-info-override-modal-label">Join Info Override</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Use the following overrides to enable joining meetings created from services that do not utilize the
+          serverless demo, for example, meetings created for your application, or meetings created in
+          different accounts. To get these response you can use the following CLI commands with appropriate
+          credentials</p>
+        <ul>
+          <li>
+            <code>aws chime-sdk-meetings create-attendee --meeting-id &lt;value&gt; --external-user-id &lt;value&gt; --region &lt;region&gt;</code>
+          </li>
+          <li><code>aws chime-sdk-meetings get-meeting --meeting-id &lt;value&gt; --region &lt;region&gt;</code></li>
+        </ul>
+        <div class="form-group">
+          <label for="create-attendee-override-input" class="mb-2">
+            <h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">
+                CreateAttendee</a> Override</h6>
+          </label>
+          <textarea class="form-control" id="create-attendee-override-input" rows="7" placeholder='{
+  "Attendee": {
+      "ExternalUserId": "John",
+      "AttendeeId": "18ba3ce2-9d76-722f-6b58-2c2fe0db5c94",
+      "JoinToken": "..."
+  }
+}
+'></textarea>
+          <div class="form-group">
+            <label for="get-meeting-override-input" class="mb-2 mt-3">
+              <h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_GetMeeting.html">
+                  GetMeeting</a> Override</h6>
+            </label>
+            <textarea class="form-control" id="get-meeting-override-input" rows="17" placeholder='{
+  "Meeting": {
+      "MeetingId": "35f23a2b-c4d7-413f-a299-2b1dc3f63314",
+      "ExternalMeetingId": "f7f76d4a-08ba-4001-8900-2b3fba4b6b3f",
+      "MediaRegion": "us-east-1",
+      "MediaPlacement": {
+          "AudioHostUrl": "...",
+          "AudioFallbackUrl": "...",
+          "SignalingUrl": "...",
+          "TurnControlUrl": "...",
+          "ScreenDataUrl": "...",
+          "ScreenViewingUrl": "...",
+          "ScreenSharingUrl": "...",
+          "EventIngestionUrl": "..."
+      }
+  }
+}'></textarea>
+          </div>
+        </div>
+      </div>
+      <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="join-info-override-join-button">Join
+        Meeting</button>
     </div>
   </div>
 </div>

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1016,6 +1016,10 @@ a.markdown:active {
   max-width: 480px;
 }
 
+#join-info-override-modal .modal-content {
+  max-width: 600px;
+}
+
 .modal-content-header {
   display: flex;
   flex-direction: row;

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -31,7 +31,7 @@ function findAllElements() {
     dataMessageSendInput: By.id('send-message'),
     sipAuthenticateButton: By.id('button-sip-authenticate'),
     roster: By.id('roster'),
-    participants: By.css('li'),
+    participants: By.css('#roster>li'),
     switchToSipFlow: By.id('to-sip-flow'),
 
     authenticationFlow: By.id('flow-authenticate'),


### PR DESCRIPTION
Dusting off https://github.com/aws/amazon-chime-sdk-js/pull/2389 which we would like to use internally but also can be useful to external builders just the same.
**Issue #:** None. 

**Description of changes:** Often we (and possibly builders would find this useful) would like to join SDK meetings in different accounts using the browser demo that may not be using the serverless demo (or have a public endpoint). Previously we had the following workarounds:

* Deploy a serverless demo in every account and keep it updated. Use Meeting ID to join non-serverless created meetings.
* Hard code credentials into browser demo and recompile.

This change basically adds hidden (at least in additional options, where it is easily removed) logic to allow stubbing the join info. Also formatted demo.

![Screen Shot 2022-08-04 at 10 34 34 AM](https://user-images.githubusercontent.com/36210679/182914922-040cce06-3fba-4c89-9747-70875e2a7b99.png)

![Screen Shot 2022-08-04 at 10 33 35 AM](https://user-images.githubusercontent.com/36210679/182914939-bdee66d2-ebfa-468f-a595-4be975491d22.png)


**Testing:**

Joined a test meeting created in one account with a serverless demo in another account.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not relevant, just demo changes.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


