### PR TITLE
Add media capture documentation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ In addition to the below, here is a list of [all blog posts about the Amazon Chi
 - [Real-time Collaboration Using Amazon Chime SDK messaging](https://aws.amazon.com/blogs/business-productivity/real-time-collaboration-using-amazon-chime-sdk-messaging/)
 - [Building a Live Streaming Chat Application](https://aws.amazon.com/blogs/business-productivity/build-a-live-streaming-chat-application-using-amazon-ivs-and-amazon-chime-sdk)
 
+### Media Pipelines
+
+- [Capture Amazon Chime SDK Meetings Using Media Capture Pipelines](https://aws.amazon.com/blogs/business-productivity/capture-amazon-chime-sdk-meetings-using-media-capture-pipelines/)
+- [Amazon Chime SDK launches live connector for streaming](https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-launches-live-connector-for-streaming/)
+
 ### Webinars and videos
 
 - [Webinar: Creating Classroom Experiences Using the Amazon Chime SDK](https://www.youtube.com/watch?v=S8T-0xfvXJ8)
@@ -109,6 +114,7 @@ The following developer guides cover the Amazon Chime SDK more broadly.
 
 - [PSTN Audio developer guide](https://docs.aws.amazon.com/chime/latest/dg/build-lambdas-for-sip-sdk.html)
 - [Messaging developer guide](https://docs.aws.amazon.com/chime/latest/dg/using-the-messaging-sdk.html)
+- [Media Pipelines developer guide](https://docs.aws.amazon.com/chime-sdk/latest/dg/media-pipelines.html)
 
 ## Examples
 
@@ -117,7 +123,7 @@ The following developer guides cover the Amazon Chime SDK more broadly.
   meeting application with a local server
 - [Serverless Meeting Demo](https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/serverless) — A self-contained serverless meeting application
 - [Single JS](https://github.com/aws-samples/amazon-chime-sdk/tree/main/utils/singlejs) — A script to bundle the SDK into a single `.js` file
-- [Recording Demo](https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/) — Recording the meeting's audio, video and screen share in high definition
+- [Transcription and Media Capture Demo](https://github.com/aws-samples/amazon-chime-media-capture-pipeline-demo) - A demo to demonstrate transcription and media capture capabilities
 - [Virtual Classroom](https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/) — An online classroom built with Electron and React
 - [Live Events](https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/) — Interactive live events solution
 - [Amazon Chime SDK Smart Video Sending Demo](https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/) — Demo showcasing how to dynamically display up to 25 video tiles from a pool of up to 250 meeting attendees

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,6 +140,13 @@
 					<li><a href="https://aws.amazon.com/blogs/business-productivity/real-time-collaboration-using-amazon-chime-sdk-messaging/">Real-time Collaboration Using Amazon Chime SDK messaging</a></li>
 					<li><a href="https://aws.amazon.com/blogs/business-productivity/build-a-live-streaming-chat-application-using-amazon-ivs-and-amazon-chime-sdk">Building a Live Streaming Chat Application</a></li>
 				</ul>
+				<a href="#media-pipelines" id="media-pipelines" style="color: inherit; text-decoration: none;">
+					<h3>Media Pipelines</h3>
+				</a>
+				<ul>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/capture-amazon-chime-sdk-meetings-using-media-capture-pipelines/">Capture Amazon Chime SDK Meetings Using Media Capture Pipelines</a></li>
+					<li><a href="https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-launches-live-connector-for-streaming/">Amazon Chime SDK launches live connector for streaming</a></li>
+				</ul>
 				<a href="#webinars-and-videos" id="webinars-and-videos" style="color: inherit; text-decoration: none;">
 					<h3>Webinars and videos</h3>
 				</a>
@@ -179,6 +186,7 @@
 				<ul>
 					<li><a href="https://docs.aws.amazon.com/chime/latest/dg/build-lambdas-for-sip-sdk.html">PSTN Audio developer guide</a></li>
 					<li><a href="https://docs.aws.amazon.com/chime/latest/dg/using-the-messaging-sdk.html">Messaging developer guide</a></li>
+					<li><a href="https://docs.aws.amazon.com/chime-sdk/latest/dg/media-pipelines.html">Media Pipelines developer guide</a></li>
 				</ul>
 				<a href="#examples" id="examples" style="color: inherit; text-decoration: none;">
 					<h2>Examples</h2>
@@ -189,7 +197,7 @@
 					meeting application with a local server</li>
 					<li><a href="https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/serverless">Serverless Meeting Demo</a> — A self-contained serverless meeting application</li>
 					<li><a href="https://github.com/aws-samples/amazon-chime-sdk/tree/main/utils/singlejs">Single JS</a> — A script to bundle the SDK into a single <code>.js</code> file</li>
-					<li><a href="https://aws.amazon.com/blogs/business-productivity/how-to-enable-client-side-recording-using-the-amazon-chime-sdk/">Recording Demo</a> — Recording the meeting&#39;s audio, video and screen share in high definition</li>
+					<li><a href="https://github.com/aws-samples/amazon-chime-media-capture-pipeline-demo">Transcription and Media Capture Demo</a> - A demo to demonstrate transcription and media capture capabilities</li>
 					<li><a href="https://aws.amazon.com/blogs/business-productivity/building-a-virtual-classroom-application-using-the-amazon-chime-sdk/">Virtual Classroom</a> — An online classroom built with Electron and React</li>
 					<li><a href="https://aws.amazon.com/blogs/opensource/how-to-deploy-a-live-events-solution-built-with-the-amazon-chime-sdk/">Live Events</a> — Interactive live events solution</li>
 					<li><a href="https://aws.amazon.com/blogs/business-productivity/amazon-chime-sdk-smart-video-sending-demo/">Amazon Chime SDK Smart Video Sending Demo</a> — Demo showcasing how to dynamically display up to 25 video tiles from a pool of up to 250 meeting attendees</li>


### PR DESCRIPTION
**Issue #:**
Currently, we do not have any documentation on media pipelines in JS SDK readme. This can cause the customers to ignore this awesome feature.

**Description of changes:**
Adding links to blog post and developer documentation in the README

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

