### PR TITLE
Use frames received value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- export of `videoDownstreamFramesReceived` in `observableVideoMetricSpec`
+
 ### Removed
 
 ### Changed

--- a/src/clientmetricreport/ClientMetricReport.ts
+++ b/src/clientmetricreport/ClientMetricReport.ts
@@ -455,6 +455,11 @@ export default class ClientMetricReport {
       media: MediaType.VIDEO,
       dir: Direction.DOWNSTREAM,
     },
+    videoDownstreamFramesReceived: {
+      source: 'framesReceived',
+      media: MediaType.VIDEO,
+      dir: Direction.DOWNSTREAM,
+    },
     videoDownstreamFramesDecodedPerSecond: {
       source: 'framesDecoded',
       media: MediaType.VIDEO,


### PR DESCRIPTION
**Issue #:**
`framesReceived` is defined but never used

**Description of changes:**
Modifies the `observableVideoMetricSpec` function for it to export one more value

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Output in the console `getObservableVideoMetrics`, and there will be no information about frames received (only frames decoded)

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
Yes, I assume such PR is for reviewing

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

