### PR TITLE
Revert "Allow stubbing join info to enable easy cross account joining…

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -116,11 +116,7 @@
             </select>
             <label for="videoCodec"  style="text-align: left;">Preferred Video Send Codec:</label>
           </div>
-          <button type="button" class="btn btn-outline-secondary h-50 d-sm-block mb-3" style="width: 100%" data-bs-toggle="modal" id="create-attendee-override-button"
-        data-bs-target="#join-info-override-modal">
-            Override Join Info
-        </button>
-        <div class="form-check" style="text-align: left;">
+          <div class="form-check" style="text-align: left;">
             <input type="checkbox" id="webaudio" class="form-check-input">
             <label for="webaudio" class="form-check-label">Use WebAudio</label>
           </div>
@@ -202,69 +198,6 @@
         </fieldset>
       </div>
       <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="additional-options-save-button">Save</button>
-    </div>
-  </div>
-</div>
-
-<div class="modal fade" id="join-info-override-modal" tabindex="-1" aria-labelledby="join-info-override-modal-label"
-  aria-hidden="true">
-  <div class="modal-dialog modal-lg" style="width: 90%">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="join-info-override-modal-label">Join Info Override</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p>Use the following overrides to enable joining meetings created from services that do not utilize the
-          serverless demo, for example, meetings created for your application, or meetings created in
-          different accounts. To get these response you can use the following CLI commands with appropriate
-          credentials</p>
-        <ul>
-          <li>
-            <code>aws chime-sdk-meetings create-attendee --meeting-id &lt;value&gt; --external-user-id &lt;value&gt; --region &lt;region&gt;</code>
-          </li>
-          <li><code>aws chime-sdk-meetings get-meeting --meeting-id &lt;value&gt; --region &lt;region&gt;</code></li>
-        </ul>
-        <div class="form-group">
-          <label for="create-attendee-override-input" class="mb-2">
-            <h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_CreateAttendee.html">
-                CreateAttendee</a> Override</h6>
-          </label>
-          <textarea class="form-control" id="create-attendee-override-input" rows="7" placeholder='{
-  "Attendee": {
-      "ExternalUserId": "John",
-      "AttendeeId": "18ba3ce2-9d76-722f-6b58-2c2fe0db5c94",
-      "JoinToken": "..."
-  }
-}
-'></textarea>
-          <div class="form-group">
-            <label for="get-meeting-override-input" class="mb-2 mt-3">
-              <h6><a href="https://docs.aws.amazon.com/chime/latest/APIReference/API_GetMeeting.html">
-                  GetMeeting</a> Override</h6>
-            </label>
-            <textarea class="form-control" id="get-meeting-override-input" rows="17" placeholder='{
-  "Meeting": {
-      "MeetingId": "35f23a2b-c4d7-413f-a299-2b1dc3f63314",
-      "ExternalMeetingId": "f7f76d4a-08ba-4001-8900-2b3fba4b6b3f",
-      "MediaRegion": "us-east-1",
-      "MediaPlacement": {
-          "AudioHostUrl": "...",
-          "AudioFallbackUrl": "...",
-          "SignalingUrl": "...",
-          "TurnControlUrl": "...",
-          "ScreenDataUrl": "...",
-          "ScreenViewingUrl": "...",
-          "ScreenSharingUrl": "...",
-          "EventIngestionUrl": "..."
-      }
-  }
-}'></textarea>
-          </div>
-        </div>
-      </div>
-      <button type="button" class="btn btn-primary" data-bs-dismiss="modal" id="join-info-override-join-button">Join
-        Meeting</button>
     </div>
   </div>
 </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -97,8 +97,6 @@ import Roster from './component/Roster';
 import ContentShareManager from './component/ContentShareManager';
 import { AudioBufferMediaStreamProvider, SynthesizedStereoMediaStreamProvider } from './util/mediastreamprovider/DemoMediaStreamProviders';
 
-import { Modal } from 'bootstrap';
-
 let SHOULD_EARLY_CONNECT = (() => {
   return document.location.search.includes('earlyConnect=1');
 })();
@@ -251,7 +249,7 @@ export class DemoMeetingApp
 
   attendeeIdPresenceHandler: (undefined | ((attendeeId: string, present: boolean, externalUserId: string, dropped: boolean) => void)) = undefined;
   activeSpeakerHandler: (undefined | ((attendeeIds: string[]) => void)) = undefined;
-  volumeIndicatorHandler: (undefined | ((attendeeId: string, volume: number, muted: boolean, signalStrength: number) => void)) = undefined;
+  volumeIndicatorHandler:  (undefined | ((attendeeId: string, volume: number, muted: boolean, signalStrength: number) => void)) = undefined;
   canUnmuteLocalAudioHandler: (undefined | ((canUnmute: boolean) => void)) = undefined;
   muteAndUnmuteLocalAudioHandler: (undefined | ((muted: boolean) => void)) = undefined;
   blurObserver: (undefined | BackgroundBlurVideoFrameProcessorObserver) = undefined;
@@ -335,7 +333,6 @@ export class DemoMeetingApp
   voiceFocusTransformer: VoiceFocusDeviceTransformer | undefined;
   voiceFocusDevice: VoiceFocusTransformDevice | undefined;
   joinInfo: any | undefined;
-  joinInfoOverride: any | undefined = undefined;
   deleteOwnAttendeeToLeave = false;
 
   blurProcessor: BackgroundBlurProcessor | undefined;
@@ -460,17 +457,6 @@ export class DemoMeetingApp
       (document.getElementById('inputName') as HTMLInputElement).focus();
     } else {
       (document.getElementById('inputMeeting') as HTMLInputElement).focus();
-    }
-
-    if (new URL(window.location.href).searchParams.has('join-info-override')) {
-      const joinInfoOverride = JSON.parse(new URL(window.location.href).searchParams.get('join-info-override'));
-      (document.getElementById('create-attendee-override-input') as HTMLTextAreaElement).value = JSON.stringify(joinInfoOverride.JoinInfo.Attendee, null, 4);
-      (document.getElementById('get-meeting-override-input') as HTMLTextAreaElement).value = JSON.stringify(joinInfoOverride.JoinInfo.Meeting, null, 4);
-      new Modal(document.getElementById('join-info-override-modal'), {}).show();
-
-      document.getElementById('join-info-override-join-button').addEventListener('click', () => {
-        this.isViewOnly = (document.getElementById('join-view-only') as HTMLInputElement).checked;
-      });
     }
   }
 
@@ -641,11 +627,6 @@ export class DemoMeetingApp
     });
 
     document.getElementById('quick-join').addEventListener('click', e => {
-      e.preventDefault();
-      this.redirectFromAuthentication(true);
-    });
-
-    document.getElementById('join-info-override-join-button').addEventListener('click', e => {
       e.preventDefault();
       this.redirectFromAuthentication(true);
     });
@@ -1903,7 +1884,7 @@ export class DemoMeetingApp
       ) {
         this.contentShare.stop();
       }
-      const attendeeName = externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '');
+      const attendeeName =  externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '');
       this.roster.addAttendee(attendeeId, attendeeName);
 
       this.volumeIndicatorHandler = async (
@@ -3184,7 +3165,7 @@ export class DemoMeetingApp
   }
 
   async authenticate(): Promise<string> {
-    this.joinInfo = this.joinInfoOverride ? this.joinInfoOverride.JoinInfo : (await this.sendJoinRequest(this.meeting, this.name, this.region, this.primaryExternalMeetingId)).JoinInfo;
+    this.joinInfo = (await this.sendJoinRequest(this.meeting, this.name, this.region, this.primaryExternalMeetingId)).JoinInfo;
     this.region = this.joinInfo.Meeting.Meeting.MediaRegion;
     const configuration = new MeetingSessionConfiguration(this.joinInfo.Meeting, this.joinInfo.Attendee);
     await this.initializeMeetingSession(configuration);
@@ -3213,7 +3194,7 @@ export class DemoMeetingApp
 
   audioVideoDidStop(sessionStatus: MeetingSessionStatus): void {
     this.log(`session stopped from ${JSON.stringify(sessionStatus)}`);
-    if (this.behaviorAfterLeave === 'nothing') {
+    if(this.behaviorAfterLeave === 'nothing') {
       return;
     }
     this.log(`resetting stats`);
@@ -3414,20 +3395,6 @@ export class DemoMeetingApp
         break;
     }
 
-    const createAttendeeOverride = (document.getElementById('create-attendee-override-input') as HTMLTextAreaElement).value;
-    const getMeetingOverride = (document.getElementById('get-meeting-override-input') as HTMLTextAreaElement).value;
-    if (createAttendeeOverride.length !== 0 && getMeetingOverride.length !== 0) {
-      this.joinInfoOverride = {
-        JoinInfo: {
-          Meeting: JSON.parse(getMeetingOverride),
-          Attendee: JSON.parse(createAttendeeOverride),
-        }
-      };
-      this.meeting = this.joinInfoOverride.JoinInfo.Meeting.Meeting.ExternalMeetingId;
-      this.name = this.joinInfoOverride.JoinInfo.Attendee.Attendee.ExternalUserId;
-      this.region = this.joinInfoOverride.JoinInfo.Meeting.Meeting.MediaRegion;
-    }
-
     AsyncScheduler.nextTick(
         async (): Promise<void> => {
           let chimeMeetingId: string = '';
@@ -3484,9 +3451,9 @@ export class DemoMeetingApp
             videoInputQuality.disabled = true;
           }
 
-          // `this.primaryExternalMeetingId` may by set by the join request. Not relevant with overriden info.
+          // `this.primaryExternalMeetingId` may by the join request
           const buttonPromoteToPrimary = document.getElementById('button-promote-to-primary');
-          if (!this.primaryExternalMeetingId || this.joinInfoOverride !== undefined) {
+          if (!this.primaryExternalMeetingId) {
             buttonPromoteToPrimary.style.display = 'none';
           } else {
             this.setButtonVisibility('button-record-cloud', false);

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1015,10 +1015,6 @@ a.markdown:active {
   max-width: 480px;
 }
 
-#join-info-override-modal .modal-content {
-  max-width: 600px;
-}
-
 .modal-content-header {
   display: flex;
   flex-direction: row;

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -31,7 +31,7 @@ function findAllElements() {
     dataMessageSendInput: By.id('send-message'),
     sipAuthenticateButton: By.id('button-sip-authenticate'),
     roster: By.id('roster'),
-    participants: By.css('#roster>li'),
+    participants: By.css('li'),
     switchToSipFlow: By.id('to-sip-flow'),
 
     authenticationFlow: By.id('flow-authenticate'),


### PR DESCRIPTION
… from browser demo (#2511)"

This reverts commit 9f49efe2a17bffa620362c2b56fbbc1b53066698.

This is to unblock media pipeline canary alarms. Their canary is failing as they use the gamma SDK canary demo URL in prod canaries. This change is good but changing the URL on canary side will need a deployment and with limited resource availablity, I wanted to avoid it.

Media capture will follow-up with correct URL update and we can re-apply this commit then.

**Issue #:**

This is to unblock media pipeline canary alarms. Their canary is failing as they use the gamma SDK canary demo URL in prod canaries. This change is good but changing the URL on canary side will need a deployment and with limited resource availablity, I wanted to avoid it.

Media capture will follow-up with correct URL update and we can re-apply this commit then.

**Description of changes:**

Revert #2511 .

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA as it is a revert

**Checklist:**

1. Have you successfully run `npm run build:release` locally?

Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

