### PR TITLE
Adds support for selecting a pagination size.

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -161,10 +161,15 @@
             <option value="none">None</option>
             <option value="enable-bandwidth-probing">Enable Bandwidth Probing</option>
           </select>
-          <div class="form-check" id="enable-pagination-checkbox" style="text-align: left; display: none;">
-            <input type="checkbox" id="enable-pagination" class="form-check-input">
-            <label for="enable-pagination" class="form-check-label">Paginate displayed video tiles</label>
-          </div>
+          <label id="pagination-title" for="pagination-page-size" style="display: none; padding-top:5px">Paginate displayed video tiles</label>
+          <select id="pagination-page-size" class="form-select" style="width:100%; display: none;">
+            <option value="2">2</option>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20">20</option>
+            <option value="25" selected>25</option>
+          </select>      
           <div class="form-check" style="text-align: left;">
             <input type="checkbox" checked id="preconnect" class="form-check-input">
             <label for="preconnect" class="form-check-label">Open signaling connection early</label>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1773,7 +1773,7 @@ export class DemoMeetingApp
 
     this.contentShare = new ContentShareManager(this.meetingLogger, this.audioVideo, this.usingStereoMusicAudioProfile);
   }
-   
+
   async setupEventReporter(configuration: MeetingSessionConfiguration): Promise<EventReporter> {
     let eventReporter: EventReporter;
     const ingestionURL = configuration.urls.eventIngestionURL;

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1773,7 +1773,6 @@ export class DemoMeetingApp
 
     this.contentShare = new ContentShareManager(this.meetingLogger, this.audioVideo, this.usingStereoMusicAudioProfile);
   }
-
    
   async setupEventReporter(configuration: MeetingSessionConfiguration): Promise<EventReporter> {
     let eventReporter: EventReporter;

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -237,12 +237,6 @@ export class DemoMeetingApp
   static readonly DATA_MESSAGE_TOPIC: string = 'chat';
   static readonly DATA_MESSAGE_LIFETIME_MS: number = 300_000;
 
-  // Currently this is the same as the maximum number of clients that can enable video (25)
-  // so we id the check box 'enable-pagination' rather then 'reduce-pagionation', but technically pagination is always enabled.
-  static readonly REMOTE_VIDEO_PAGE_SIZE: number = 25;
-  // Enabled on authentication screen by 'enable-pagination' checkbox.
-  static readonly REDUCED_REMOTE_VIDEO_PAGE_SIZE: number = 2;
-
   // Ideally we don't need to change this. Keep this configurable in case users have a super slow network.
   loadingBodyPixDependencyTimeoutMs: number = 10_000;
   loadingBodyPixDependencyPromise: undefined | Promise<void>;
@@ -570,12 +564,15 @@ export class DemoMeetingApp
       const priorityBasedDownlinkPolicyConfigTitle = document.getElementById(
           'priority-downlink-policy-preset-title'
       ) as HTMLElement;
-      const enablePaginationCheckbox = document.getElementById(
-          'enable-pagination-checkbox'
-      ) as HTMLSelectElement;
       const serverSideNetworkAdaption = document.getElementById(
           'server-side-network-adaption'
       ) as HTMLSelectElement;
+      const paginationPageSize = document.getElementById(
+        'pagination-page-size'
+      ) as HTMLElement;
+      const paginationTitle = document.getElementById(
+        'pagination-title'
+      ) as HTMLElement;      
       const serverSideNetworkAdaptionTitle = document.getElementById(
           'server-side-network-adaption-title'
       ) as HTMLElement;
@@ -583,14 +580,16 @@ export class DemoMeetingApp
       if (this.usePriorityBasedDownlinkPolicy) {
         priorityBasedDownlinkPolicyConfigTitle.style.display = 'block';
         priorityBasedDownlinkPolicyConfig.style.display = 'block';
-        enablePaginationCheckbox.style.display = 'block';
         serverSideNetworkAdaption.style.display = 'block';
+        paginationPageSize.style.display = 'block';
+        paginationTitle.style.display = 'block';
         serverSideNetworkAdaptionTitle.style.display = 'block';
       } else {
         priorityBasedDownlinkPolicyConfigTitle.style.display = 'none';
         priorityBasedDownlinkPolicyConfig.style.display = 'none';
-        enablePaginationCheckbox.style.display = 'none';
         serverSideNetworkAdaption.style.display = 'none';
+        paginationTitle.style.display = 'none';
+        paginationPageSize.style.display = 'none';
         serverSideNetworkAdaptionTitle.style.display = 'none';
       }
     });
@@ -1763,15 +1762,19 @@ export class DemoMeetingApp
       this.audioVideo.setVideoCodecSendPreferences(this.videoCodecPreferences);
       this.audioVideo.setContentShareVideoCodecPreferences(this.videoCodecPreferences);
     }
+
+    // The default pagination size is 25.
+    let paginationPageSize = parseInt((document.getElementById('pagination-page-size') as HTMLSelectElement).value)
     this.videoTileCollection = new VideoTileCollection(this.audioVideo,
         this.meetingLogger,
         this.usePriorityBasedDownlinkPolicy ? new VideoPreferenceManager(this.meetingLogger, this.priorityBasedDownlinkPolicy) : undefined,
-        (document.getElementById('enable-pagination') as HTMLInputElement).checked ? DemoMeetingApp.REDUCED_REMOTE_VIDEO_PAGE_SIZE : DemoMeetingApp.REMOTE_VIDEO_PAGE_SIZE)
+        paginationPageSize)
     this.audioVideo.addObserver(this.videoTileCollection);
 
     this.contentShare = new ContentShareManager(this.meetingLogger, this.audioVideo, this.usingStereoMusicAudioProfile);
   }
 
+   
   async setupEventReporter(configuration: MeetingSessionConfiguration): Promise<EventReporter> {
     let eventReporter: EventReporter;
     const ingestionURL = configuration.urls.eventIngestionURL;

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -42,7 +42,7 @@
       }
     },
     "../..": {
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",


### PR DESCRIPTION
**Issue #:**
Adds support for selecting a pagination size. 

**Description of changes:**
Currently, It is not possible to select the pagination size of the video tiles. We have to rely on the default values which is 2 video tiles when pagination is enabled. This adds support for selecting the pagination size of the video tiles to better manage and visualize the video tiles when we have more than 25 video clients publishing their video. 

**Testing:**
* Verified that that we get a dropdown menu using which we can select the pagination size.
![Screen Shot 2023-01-10 at 6 27 46 PM](https://user-images.githubusercontent.com/3948470/211703862-a569eb8b-f453-415c-8971-5d117b3e905e.png)
* Verified that when priority based downlink is selected we can paginate through the videos.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, Demo link: https://drerk6vfrl.execute-api.us-east-1.amazonaws.com/Prod/
1. In the demo app and select "Additional Options" > "Use Priority-Based Downlink Policy"
2. Select the pagination size and start the meeting.
3. Add video streams more than the pagination size to the meeting and you should be able to paginate through the videos.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Y

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Y

