### PR TITLE
[Integ test] Skip waiting meeting flow check for content share only two tests

### DIFF
--- a/integration/js/ContentShareOnlyAllowTwoTest.js
+++ b/integration/js/ContentShareOnlyAllowTwoTest.js
@@ -28,7 +28,7 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await OpenAppStep.executeStep(this, sessionInfo);
     await AuthenticateUserStep.executeStep(this, sessionInfo, attendee_id);
     await UserAuthenticationCheck.executeStep(this, sessionInfo);
-    await JoinMeetingStep.executeStep(this, sessionInfo);
+    await JoinMeetingStep.executeStep(this, sessionInfo, true);
     // await UserJoinedMeetingCheck.executeStep(this, sessionInfo, attendee_id);
   }
 
@@ -77,21 +77,6 @@ class ContentShareOnlyAllowTwoTest extends SdkBaseTest {
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
     await test_window_3.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_3));
     await test_window_3.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    
-    // await test_window_1.runCommands(
-    //   async () => await ContentShareVideoCheck.executeStep(this, session, 'ON', test_attendee_id_1)
-    // );
-    // await test_window_1.runCommands(
-    //   async () => await ContentShareVideoCheck.executeStep(this, session, 'ON', test_attendee_id_2)
-    // );
-    // await test_window_1.runCommands(
-    //   async () => await ContentShareVideoCheck.executeStep(this, session, 'OFF', test_attendee_id_3)
-    // );
-    // await test_window_1.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
-    // await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_1));
-    // await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "ON", test_attendee_id_2));
-    // await test_window_2.runCommands(async () => await ContentShareVideoCheck.executeStep(this, session, "OFF", test_attendee_id_3));
-    // await test_window_2.runCommands(async () => await RosterCheck.executeStep(this, session, 5));
   }
 }
 

--- a/integration/js/pages/AppPage.js
+++ b/integration/js/pages/AppPage.js
@@ -27,7 +27,7 @@ function findAllElements() {
     contentSharePauseButton: By.id('dropdown-item-content-share-pause-resume'),
 
     videoFilterDropButton: By.id('button-video-filter-drop'),
-  
+
     dataMessageSendInput: By.id('send-message'),
     sipAuthenticateButton: By.id('button-sip-authenticate'),
     roster: By.id('roster'),
@@ -151,7 +151,7 @@ class AppPage {
     }
   }
 
-  // selects echo reduction capability at the meeting level 
+  // selects echo reduction capability at the meeting level
   async chooseEchoReduction() {
     const echoReductionFeature = await this.driver.findElement(elements.echoReductionFeature);
     const echoReductionFeatureLabel = await this.driver.findElement(elements.echoReductionFeatureLabel);
@@ -179,7 +179,7 @@ class AppPage {
   async chooseEnableEventReporting() {
     const eventReportingCheck = await this.driver.findElement(elements.eventReportingCheckBox);
     const eventReportingCheckLabel = await this.driver.findElement(elements.eventReportingCheckBoxLabel);
-    
+
     // Click the label because it's on top.
     if (await eventReportingCheck.isSelected()) {
       this.logger('event reporting is enabled');
@@ -191,7 +191,7 @@ class AppPage {
   async chooseStereoMusicAudioProfile() {
     const stereoMusicProfileCheck = await this.driver.findElement(elements.stereoMusicProfileCheckBox);
     const stereoMusicProfileCheckLabel = await this.driver.findElement(elements.stereoMusicProfileCheckBoxLabel);
-    
+
     // Click the label because it's on top.
     if (await stereoMusicProfileCheck.isSelected()) {
       this.logger('stereo music audio profile is selected');
@@ -298,7 +298,7 @@ class AppPage {
 
   async clickStartAmazonVoiceFocus() {
     const startAmazonVoiceFocus = await this.driver.findElement(elements.microphoneDropDownVoiceFocusButton);
-    await startAmazonVoiceFocus.click();    
+    await startAmazonVoiceFocus.click();
   }
 
   async getNumberOfParticipantsOnRoster() {
@@ -355,7 +355,7 @@ class AppPage {
     }
     return 'failed'
   }
-  
+
   async waitForElement(element, timeout = 10000) {
     try {
       await this.driver.wait(until.elementLocated(element), timeout);
@@ -404,7 +404,11 @@ class AppPage {
   }
 
   async waitToJoinTheMeeting() {
-    return await this.waitForElement(elements.meetingFlow, 20000)
+    return await this.waitForElement(elements.meetingFlow, 20000);
+  }
+
+  async waitForContentShareButton() {
+    return await this.waitForElement(elements.contentShareButton, 20000);
   }
 
   async isLiveTranscriptionPresentInDeviceMenu() {
@@ -922,7 +926,7 @@ class AppPage {
     }
     return expectedStateFound;
   }
-  
+
   async echoAudioCheck(stepInfo, expectedState){
     let res = undefined;
     try {

--- a/integration/js/steps/ClickContentShareButton.js
+++ b/integration/js/steps/ClickContentShareButton.js
@@ -1,4 +1,5 @@
 const AppTestStep = require('../utils/AppTestStep');
+const {KiteTestError, Status} = require('kite-common');
 
 class ClickContentShareButton extends AppTestStep {
   constructor(kiteBaseTest, sessionInfo, testType) {
@@ -16,6 +17,10 @@ class ClickContentShareButton extends AppTestStep {
   }
 
   async run() {
+    let isButtonClickable = await this.page.waitForContentShareButton();
+    if (isButtonClickable === 'failed') {
+      throw new KiteTestError(Status.BROKEN, 'Content share button is not clickable');
+    }
     await this.page.clickContentShareButton();
     const message = this.testType === "ON" ? 'content_share_start' : 'content_share_stop';
     this.finished(message)

--- a/integration/js/steps/JoinMeetingStep.js
+++ b/integration/js/steps/JoinMeetingStep.js
@@ -3,12 +3,13 @@ const { v4: uuidv4 } = require('uuid');
 const AppTestStep = require('../utils/AppTestStep');
 
 class JoinMeetingStep extends AppTestStep {
-  constructor(kiteBaseTest, sessionInfo) {
+  constructor(kiteBaseTest, sessionInfo, skipWait) {
     super(kiteBaseTest, sessionInfo);
+    this.skipWait = skipWait;
   }
 
-  static async executeStep(KiteBaseTest, sessionInfo) {
-    const step = new JoinMeetingStep(KiteBaseTest, sessionInfo);
+  static async executeStep(KiteBaseTest, sessionInfo, skipWait = false) {
+    const step = new JoinMeetingStep(KiteBaseTest, sessionInfo, skipWait);
     await step.execute(KiteBaseTest);
   }
 
@@ -26,6 +27,9 @@ class JoinMeetingStep extends AppTestStep {
 
   async run() {
     await this.page.joinMeeting();
+    if (this.skipWait) {
+      return;
+    }
     let joinState = await this.page.waitToJoinTheMeeting();
     if (joinState === 'failed') {
       throw new KiteTestError(Status.BROKEN, 'Timeout while joining the meeting');


### PR DESCRIPTION
**Description of changes:**
Skip the wait for `flow-meeting` div to be visible which seems to cause Selenium timeout for `ContentShareOnlyAllowTwoTests` and replace with a check for content share visible.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
 No just a test change.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

