### PR TITLE
Revert "Add extendedDebugging to content share tests"

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -130,7 +130,8 @@ const getSauceLabsConfig = (capabilities) => {
     seleniumVersion: '3.141.59',
     screenResolution: '1280x960',
     tunnelIdentifier: process.env.JOB_ID,
-    ...(capabilities.platform.toUpperCase() !== 'LINUX' && {
+    ...((capabilities.platform.toUpperCase() !== 'LINUX' &&
+      !((capabilities.name).includes('ContentShare'))) && {
         extendedDebugging: true
       }),
       prerun : prerunScript


### PR DESCRIPTION
This reverts commit 415a986047f8cfcb9391d883b1ad11ff7c86db61.

**Description of changes:**
Remove `extendedDebugging` for content share integration tests.
**Testing:**
 
N/A this is only affect integ tests.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

