### PR TITLE
Update the prerun script hashed id to a process environment for release-2.x

### DIFF
--- a/.github/workflows/audio-video-transform-integration.yml
+++ b/.github/workflows/audio-video-transform-integration.yml
@@ -12,6 +12,7 @@
     TEST_TYPE: Github-Action
     SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
     SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+    PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
 
   jobs:
     integ-background-blur:

--- a/integration/js/README.md
+++ b/integration/js/README.md
@@ -172,3 +172,9 @@ For our use case, a pre-run executable script is a minimal `bash` script that wi
       return capabilities.name.includes('Background Blur Test') ? 'storage:<storage_id>' : '';
     }
     ```
+
+5. Another way is hosting the pre-run-script in any open public domain and export another environment:
+```shell
+export PRE_RUN_SCRIPT_URL=<url_to_pre_run_script>
+```
+Then you can skip other steps and run the test directly on Sauce Labs

--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -104,7 +104,7 @@ const getPrerunScript = (capabilities) =>{
   const name = capabilities.name;
   const blurName = "Background Blur Test";
   const repName = "Background Replacement Test";
-  return (name.includes(blurName) || name.includes(repName)) ?  'storage:696e27c0-061c-4d38-b3f5-0a2636818448' : "";
+  return (name.includes(blurName) || name.includes(repName)) ?  process.env.PRE_RUN_SCRIPT_URL : "";
 }
 const getChromeCapabilities = capabilities => {
   let cap = Capabilities.chrome();


### PR DESCRIPTION
Update the prerun script hashed id to a process environment to avoid updating this every 2 months on release-2.x for PMV tests

**Issue #:**
No

**Description of changes:**
Update the prerun script hashed id to a process environment to avoid updating this every 2 months on release-2.x for PMV tests

**Testing:**
Did on main branch
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

