### PR TITLE
Update Chrome options per SauceLabs suggestion to fix private connect…

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -83,6 +83,26 @@ const getChromeOptions = capabilities => {
       chromeOptions['args'].push('--use-file-for-fake-audio-capture=' + fetchMediaPath(capabilities.audio, capabilities.browserName));
     }
   }
+  
+  /**
+   * Recently, SauceLabs loads the web page in test and runs into "Your connection is not private" error.
+   * Content share test is also failing with WebSocket connection failed issues which SauceLabs says may
+   * be related.
+   * 
+   * Per SauceLabs suggestion add '--ignore-certificate-errors' to all tests and
+   * few explicit ones for content share test as most errors are on MAC platform.
+   */
+  chromeOptions.args.push('--ignore-certificate-errors');
+  if (capabilities.platform.toUpperCase() === 'MAC' && capabilities.name.includes('ContentShare')) {
+    const args = [
+      "start-maximized",
+      "disable-infobars",
+      "ignore-gpu-blacklist",
+      "test-type",
+      "disable-gpu"
+    ];
+    chromeOptions.args = [...chromeOptions.args, ...args];
+  }
   return chromeOptions;
 }
 
@@ -106,6 +126,7 @@ const getPrerunScript = (capabilities) =>{
   const repName = "Background Replacement Test";
   return (name.includes(blurName) || name.includes(repName)) ?  process.env.PRE_RUN_SCRIPT_URL : "";
 }
+
 const getChromeCapabilities = capabilities => {
   let cap = Capabilities.chrome();
   var prefs = new logging.Preferences();


### PR DESCRIPTION
Update Chrome options per SauceLabs suggestion to fix private connection error

**Issue #:**

Currently tests are failing with below two reasons:
1. Web page loads with "your connection is private" error and thus test never progresses this failing.
2.  Content share test is failing with Websocket connection failed issue. In content share, I saw no attendee joining in roster, thus, checked meeting from browser logs and got to know the meeting session never succeeds due to Websocket failure. This is not happening with other tests. The difference is that we do not enable extendedDebugging for content share test and for rest we do.

**Description of changes:**

Checked with SauceLabs on the issues and per suggestion update some Chrome options.
1. Add `--ignore-certificate-errors` for all tests under Chrome options.
2. Add below config for content share. I restricted this to only MAC as most failures are actually on MAC.
```
[
  "start-maximized",
  "disable-infobars",
  "ignore-gpu-blacklist",
  "test-type",
  "disable-gpu"
]
```

**Testing:**

This is only integration test change.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
NA

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

