### PR TITLE
Remove video and content share enable/disable steps from media-capture integration tests

### DIFF
--- a/integration/js/MediaCaptureTest.js
+++ b/integration/js/MediaCaptureTest.js
@@ -1,4 +1,4 @@
-const { AuthenticateUserStep, JoinMeetingStep, OpenAppStep, ClickContentShareButton, ClickVideoButton, ClickMediaCaptureButton, EndMeetingStep } = require('./steps');
+const { AuthenticateUserStep, JoinMeetingStep, OpenAppStep, ClickMediaCaptureButton, EndMeetingStep } = require('./steps');
 const { RosterCheck, UserAuthenticationCheck, UserJoinedMeetingCheck } = require('./checks');
 const { AppPage } = require('./pages/AppPage');
 const { TestUtils } = require('./node_modules/kite-common');
@@ -17,45 +17,26 @@ class MediaCaptureTest extends SdkBaseTest {
 
     // Join a meeting from two browser sessions with video on
     const testAttendeeId = uuidv4();
-    const monitorAttendeeId = uuidv4();
 
     const testWindow = await Window.existing(session.driver, 'TEST');
-    const monitorWindow = await Window.openNew(session.driver, 'MONITOR');
 
     const meetingId = uuidv4();
     console.log(`testing region: ${this.region}, meetingId: ${meetingId}`);
 
     await testWindow.runCommands(async () => await this.addUserToMeeting(testAttendeeId, session, this.region));
-    await testWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await testWindow.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
-    await TestUtils.waitAround(5000);
-
-    await monitorWindow.runCommands(async () => await this.addUserToMeeting(monitorAttendeeId, session, this.region));
-    await monitorWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-
     // Start media capture session
     await testWindow.runCommands(async () => await ClickMediaCaptureButton.executeStep(this, session));
-    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await monitorWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-
-    await TestUtils.waitAround(15000);
-
-    // One at a time, have the browser sessions turn OFF and ON video & content share
-    await testWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await testWindow.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "OFF"));
-
     await TestUtils.waitAround(5000);
 
-    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
-    await monitorWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 3));
+    // Check if media capture started successfully.
+    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 2));
 
-    await testWindow.runCommands(async () => await ClickVideoButton.executeStep(this, session));
-    await testWindow.runCommands(async () => await ClickContentShareButton.executeStep(this, session, "ON"));
-
+    // Stop media capture session
+    await testWindow.runCommands(async () => await ClickMediaCaptureButton.executeStep(this, session));
     await TestUtils.waitAround(5000);
 
-    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
-    await monitorWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 4));
+    // // Check if media capture stopped successfully.
+    await testWindow.runCommands(async () => await RosterCheck.executeStep(this, session, 1));
 
     await testWindow.runCommands(async () => await EndMeetingStep.executeStep(this, session));
     await this.waitAllSteps();


### PR DESCRIPTION
**Issue #:** NA

**Description of changes:**
Remove video and content share enable/disable steps from media-capture integration tests

**Testing:**
Ran `npm run build:release` locally

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
This is a change in the integration test. 

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
NA

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes
