### PR TITLE
Update engines 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "NOTICE"
   ],
   "engines": {
-    "node": "^12 || ^14 || ^15 || ^16",
-    "npm": "^6 || ^7 || ^8"
+    "node": "^12 || ^14 || ^15 || ^16 || ^18 || ^19",
+    "npm": "^6 || ^7 || ^8 || ^9"
   },
   "scripts": {
     "clean": "rimraf .nyc_output build node_modules",


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- After pushing https://github.com/aws/amazon-chime-sdk-js/pull/2596, the **Run deployment** job has been failing with this error:
  https://github.com/aws/amazon-chime-sdk-js/actions/runs/4297453422/jobs/7490544556

    ```
    npm WARN EBADENGINE Unsupported engine {
    npm WARN EBADENGINE   package: 'amazon-chime-sdk-js@2.32.0',
    npm WARN EBADENGINE   required: { node: '^12 || ^14 || ^15 || ^16', npm: '^6 || ^7 || ^8' },
    npm WARN EBADENGINE   current: { node: 'v18.14.1', npm: '9.3.1' }
    npm WARN EBADENGINE }
    npm WARN deprecated uuid@3.3.3: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
    npm WARN deprecated core-js@2.6.11: core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
    npm WARN EBADENGINE Unsupported engine {
    npm WARN EBADENGINE   package: 'amazon-chime-sdk-js@2.32.0',
    npm WARN EBADENGINE   required: { node: '^12 || ^14 || ^15 || ^16', npm: '^6 || ^7 || ^8' },
    npm WARN EBADENGINE   current: { node: 'v18.14.1', npm: '9.3.1' }
    npm WARN EBADENGINE }
    npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
    npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
    npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
    npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
    npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
    npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
    npm WARN deprecated popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
    Error: error:0308010C:digital envelope routines::unsupported
        at new Hash (node:internal/crypto/hash:71:19)
        at Object.createHash (node:crypto:133:10)
        at BulkUpdateDecorator.hashFactory (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/util/createHash.js:145:18)
        at BulkUpdateDecorator.update (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/util/createHash.js:46:50)
        at RawSource.updateHash (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack-sources/lib/RawSource.js:70:8)
        at NormalModule._initBuildHash (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/NormalModule.js:888:17)
        at handleParseResult (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/NormalModule.js:954:10)
        at /home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/NormalModule.js:1048:4
        at processResult (/home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/NormalModule.js:763:11)
        at /home/runner/work/amazon-chime-sdk-js/amazon-chime-sdk-js/demos/browser/node_modules/webpack/lib/NormalModule.js:827:5
    ```


**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

