### PR TITLE
Remove entry from meetingsTable when meeting ends

### DIFF
--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -199,6 +199,8 @@ function serve(host = '127.0.0.1:8080') {
         await client.deleteMeeting({
           MeetingId: meetingTable[requestUrl.query.title].Meeting.MeetingId,
         }).promise();
+        //Remove the meeting from table(so that a new meeting can be created with the same name with in a session)
+        delete meetingTable[requestUrl.query.title];
         respond(response, 200, 'application/json', JSON.stringify({}));
       } else if (request.method === 'POST' && requestUrl.pathname === '/startCapture') {
         if (captureS3Destination) {

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -202,6 +202,7 @@ exports.end = async (event, context) => {
 
   // End the meeting. All attendee connections will hang up.
   await client.deleteMeeting({ MeetingId: meeting.Meeting.MeetingId }).promise();
+  await deleteMeeting(event.queryStringParameters.title);
   return response(200, 'application/json', JSON.stringify({}));
 };
 
@@ -543,6 +544,16 @@ async function putMeeting(title, meeting) {
       'TTL': {
         N: `${Math.floor(Date.now() / 1000) + 60 * 60 * 24}` // clean up meeting record one day from now
       }
+    }
+  }).promise();
+}
+
+// Deletes the meeting in the table using the meeting title as the key
+async function deleteMeeting(title, meeting) {
+  await ddb.deleteItem({
+    TableName: MEETINGS_TABLE_NAME,
+    Key: {
+      'Title': { S: title }
     }
   }).promise();
 }


### PR DESCRIPTION
**Issue #:**
Unable to create a meeting with the same name with in a browser session. I either have to use a new name every time I need to run a test or restart the app to use the same name.

**Description of changes:**
Deleting the entry from the temporary cache(meetingsTable) when the meeting is ended.

**Testing:**
Tested by creating the meeting with same name with in a browser session.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- Create a meeting with title "Test"
- End meeting and recreate with the same title. The meeting would be created without complaining about the meeting not being found.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

