### PR TITLE
Add Client UTC Offset inside join message which is sent over signalling channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.13.0] - 2023-03-28
 
 ### Added
+- Add Client UTC Offset inside join message which is sent over signalling channel.
 
 ### Removed
 
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.12.0] - 2023-02-14
 
-### Added
+### Added 
 
 ### Removed
 

--- a/docs/classes/defaultsignalingclient.html
+++ b/docs/classes/defaultsignalingclient.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L56">src/signalingclient/DefaultSignalingClient.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L57">src/signalingclient/DefaultSignalingClient.ts:57</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#closeconnection">closeConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L228">src/signalingclient/DefaultSignalingClient.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L231">src/signalingclient/DefaultSignalingClient.ts:231</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L492">src/signalingclient/DefaultSignalingClient.ts:492</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L495">src/signalingclient/DefaultSignalingClient.ts:495</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#join">join</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L91">src/signalingclient/DefaultSignalingClient.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L92">src/signalingclient/DefaultSignalingClient.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#leave">leave</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L204">src/signalingclient/DefaultSignalingClient.ts:204</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L207">src/signalingclient/DefaultSignalingClient.ts:207</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#mute">mute</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L274">src/signalingclient/DefaultSignalingClient.ts:274</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L277">src/signalingclient/DefaultSignalingClient.ts:277</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#openconnection">openConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L76">src/signalingclient/DefaultSignalingClient.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L77">src/signalingclient/DefaultSignalingClient.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L283">src/signalingclient/DefaultSignalingClient.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L286">src/signalingclient/DefaultSignalingClient.ts:286</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +356,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pingpong">pingPong</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L82">src/signalingclient/DefaultSignalingClient.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L83">src/signalingclient/DefaultSignalingClient.ts:83</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L477">src/signalingclient/DefaultSignalingClient.ts:477</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L480">src/signalingclient/DefaultSignalingClient.ts:480</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -419,7 +419,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#ready">ready</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L268">src/signalingclient/DefaultSignalingClient.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L271">src/signalingclient/DefaultSignalingClient.ts:271</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -442,7 +442,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L66">src/signalingclient/DefaultSignalingClient.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L67">src/signalingclient/DefaultSignalingClient.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -471,7 +471,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#remotevideoupdate">remoteVideoUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L175">src/signalingclient/DefaultSignalingClient.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L178">src/signalingclient/DefaultSignalingClient.ts:178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -507,7 +507,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L71">src/signalingclient/DefaultSignalingClient.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L72">src/signalingclient/DefaultSignalingClient.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -536,7 +536,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#resume">resume</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L291">src/signalingclient/DefaultSignalingClient.ts:291</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L294">src/signalingclient/DefaultSignalingClient.ts:294</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -565,7 +565,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#sendclientmetrics">sendClientMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L214">src/signalingclient/DefaultSignalingClient.ts:214</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L217">src/signalingclient/DefaultSignalingClient.ts:217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -594,7 +594,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#senddatamessage">sendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L221">src/signalingclient/DefaultSignalingClient.ts:221</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L224">src/signalingclient/DefaultSignalingClient.ts:224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -623,7 +623,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#subscribe">subscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L125">src/signalingclient/DefaultSignalingClient.ts:125</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L128">src/signalingclient/DefaultSignalingClient.ts:128</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@aws-sdk/util-hex-encoding": "^3.47.0",
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
+        "moment-timezone": "^0.5.42",
         "pako": "^2.0.4",
         "protobufjs": "^6.11.3",
         "resize-observer": "^1.0.0",
@@ -4095,6 +4096,25 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
+      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -9059,6 +9079,19 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.42",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
+      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "requires": {
+        "moment": "^2.29.4"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@aws-sdk/util-hex-encoding": "^3.47.0",
     "@types/ua-parser-js": "^0.7.35",
     "detect-browser": "^5.2.0",
+    "moment-timezone": "^0.5.42",
     "pako": "^2.0.4",
     "protobufjs": "^6.11.3",
     "resize-observer": "^1.0.0",

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -72,6 +72,7 @@ message SdkClientDetails {
     optional string platform_version = 6;
     optional string client_source = 7;
     optional string chime_sdk_version = 8;
+    optional string client_utc_offset = 9;
 }
 
 enum SdkServerSideNetworkAdaption {

--- a/script/check-lockfile-version.js
+++ b/script/check-lockfile-version.js
@@ -5,7 +5,7 @@ const lockFileVersion = require('../package-lock.json').lockfileVersion;
 if (lockFileVersion === 2) {
   process.exit(0);
 } else {
-  console.log(`In-correct package-lock verson detected, should be 2, found ${lockFileVersion}`);
+  console.log(`In-correct package-lock version detected, should be 2, found ${lockFileVersion}`);
   console.log('Check if you are using npm v7, if not update to npm v7 and re-run build:release');
   process.exit(1);
 }

--- a/script/generate-signaling-protocol
+++ b/script/generate-signaling-protocol
@@ -14,8 +14,7 @@ end
   verbose "mkdir -p src/#{dir}"
 
   # workaround for https://github.com/hegemonic/requizzle/issues/5
-  verbose "brew install node@10"
-  node = "#{`brew --prefix node@10`.strip}/bin/node"
+  node = "/opt/homebrew/opt/node@14/bin/node"
 
   # workaround for https://github.com/protobufjs/protobuf.js/issues/1217
   verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -28,6 +28,7 @@ import {
   SdkSubscribeFrame,
   SdkVideoSubscriptionConfiguration,
 } from '../signalingprotocol/SignalingProtocol.js';
+import { getUTCOffsetFromTimezoneIdentifier } from '../utils/Utils';
 import Versioning from '../versioning/Versioning';
 import WebSocketAdapter from '../websocketadapter/WebSocketAdapter';
 import WebSocketReadyState from '../websocketadapter/WebSocketReadyState';
@@ -39,7 +40,6 @@ import SignalingClientEventType from './SignalingClientEventType';
 import SignalingClientJoin from './SignalingClientJoin';
 import SignalingClientSubscribe from './SignalingClientSubscribe';
 import SignalingClientVideoSubscriptionConfiguration from './SignalingClientVideoSubscriptionConfiguration';
-import { getUTCOffsetFromTimezoneIdentifier } from '../utils/Utils';
 
 /**
  * [[DefaultSignalingClient]] implements the SignalingClient interface.
@@ -101,7 +101,7 @@ export default class DefaultSignalingClient implements SignalingClient {
       platformVersion: browserBehavior.version(),
       clientSource: Versioning.sdkName,
       chimeSdkVersion: Versioning.sdkVersion,
-      clientUtcOffset: getUTCOffsetFromTimezoneIdentifier(browserTimezone)
+      clientUtcOffset: getUTCOffsetFromTimezoneIdentifier(browserTimezone),
     };
     if (settings.applicationMetadata) {
       const { appName, appVersion } = settings.applicationMetadata;

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -39,6 +39,7 @@ import SignalingClientEventType from './SignalingClientEventType';
 import SignalingClientJoin from './SignalingClientJoin';
 import SignalingClientSubscribe from './SignalingClientSubscribe';
 import SignalingClientVideoSubscriptionConfiguration from './SignalingClientVideoSubscriptionConfiguration';
+import { getUTCOffsetFromTimezoneIdentifier } from '../utils/Utils';
 
 /**
  * [[DefaultSignalingClient]] implements the SignalingClient interface.
@@ -94,11 +95,13 @@ export default class DefaultSignalingClient implements SignalingClient {
     joinFrame.protocolVersion = 2;
     joinFrame.flags = SdkJoinFlags.HAS_STREAM_UPDATE;
     const browserBehavior = new DefaultBrowserBehavior();
+    const browserTimezone: string = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const sdkClientDetails: ISdkClientDetails = {
       platformName: browserBehavior.name(),
       platformVersion: browserBehavior.version(),
       clientSource: Versioning.sdkName,
       chimeSdkVersion: Versioning.sdkVersion,
+      clientUtcOffset: getUTCOffsetFromTimezoneIdentifier(browserTimezone)
     };
     if (settings.applicationMetadata) {
       const { appName, appVersion } = settings.applicationMetadata;

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -379,6 +379,9 @@ export interface ISdkClientDetails {
 
     /** SdkClientDetails chimeSdkVersion */
     chimeSdkVersion?: (string|null);
+
+    /** SdkClientDetails clientUtcOffset */
+    clientUtcOffset?: (string|null);
 }
 
 /** Represents a SdkClientDetails. */
@@ -413,6 +416,9 @@ export class SdkClientDetails implements ISdkClientDetails {
 
     /** SdkClientDetails chimeSdkVersion. */
     public chimeSdkVersion: string;
+
+    /** SdkClientDetails clientUtcOffset. */
+    public clientUtcOffset: string;
 
     /**
      * Creates a new SdkClientDetails instance using the specified properties.

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -1200,6 +1200,7 @@ $root.SdkClientDetails = (function() {
      * @property {string|null} [platformVersion] SdkClientDetails platformVersion
      * @property {string|null} [clientSource] SdkClientDetails clientSource
      * @property {string|null} [chimeSdkVersion] SdkClientDetails chimeSdkVersion
+     * @property {string|null} [clientUtcOffset] SdkClientDetails clientUtcOffset
      */
 
     /**
@@ -1282,6 +1283,14 @@ $root.SdkClientDetails = (function() {
     SdkClientDetails.prototype.chimeSdkVersion = "";
 
     /**
+     * SdkClientDetails clientUtcOffset.
+     * @member {string} clientUtcOffset
+     * @memberof SdkClientDetails
+     * @instance
+     */
+    SdkClientDetails.prototype.clientUtcOffset = "";
+
+    /**
      * Creates a new SdkClientDetails instance using the specified properties.
      * @function create
      * @memberof SdkClientDetails
@@ -1321,6 +1330,8 @@ $root.SdkClientDetails = (function() {
             writer.uint32(/* id 7, wireType 2 =*/58).string(message.clientSource);
         if (message.chimeSdkVersion != null && Object.hasOwnProperty.call(message, "chimeSdkVersion"))
             writer.uint32(/* id 8, wireType 2 =*/66).string(message.chimeSdkVersion);
+        if (message.clientUtcOffset != null && Object.hasOwnProperty.call(message, "clientUtcOffset"))
+            writer.uint32(/* id 9, wireType 2 =*/74).string(message.clientUtcOffset);
         return writer;
     };
 
@@ -1378,6 +1389,9 @@ $root.SdkClientDetails = (function() {
                 break;
             case 8:
                 message.chimeSdkVersion = reader.string();
+                break;
+            case 9:
+                message.clientUtcOffset = reader.string();
                 break;
             default:
                 reader.skipType(tag & 7);
@@ -1438,6 +1452,9 @@ $root.SdkClientDetails = (function() {
         if (message.chimeSdkVersion != null && message.hasOwnProperty("chimeSdkVersion"))
             if (!$util.isString(message.chimeSdkVersion))
                 return "chimeSdkVersion: string expected";
+        if (message.clientUtcOffset != null && message.hasOwnProperty("clientUtcOffset"))
+            if (!$util.isString(message.clientUtcOffset))
+                return "clientUtcOffset: string expected";
         return null;
     };
 
@@ -1469,6 +1486,8 @@ $root.SdkClientDetails = (function() {
             message.clientSource = String(object.clientSource);
         if (object.chimeSdkVersion != null)
             message.chimeSdkVersion = String(object.chimeSdkVersion);
+        if (object.clientUtcOffset != null)
+            message.clientUtcOffset = String(object.clientUtcOffset);
         return message;
     };
 
@@ -1494,6 +1513,7 @@ $root.SdkClientDetails = (function() {
             object.platformVersion = "";
             object.clientSource = "";
             object.chimeSdkVersion = "";
+            object.clientUtcOffset = "";
         }
         if (message.appName != null && message.hasOwnProperty("appName"))
             object.appName = message.appName;
@@ -1511,6 +1531,8 @@ $root.SdkClientDetails = (function() {
             object.clientSource = message.clientSource;
         if (message.chimeSdkVersion != null && message.hasOwnProperty("chimeSdkVersion"))
             object.chimeSdkVersion = message.chimeSdkVersion;
+        if (message.clientUtcOffset != null && message.hasOwnProperty("clientUtcOffset"))
+            object.clientUtcOffset = message.clientUtcOffset;
         return object;
     };
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -40,5 +40,5 @@ export function toLowerCasePropertyNames(input: any): any {
 }
 
 export function getUTCOffsetFromTimezoneIdentifier(timezone: string): string {
-  return moment.tz(timezone).format("Z");
+  return moment.tz(timezone).format('Z');
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import moment = require('moment-timezone');
+
 export function wait(waitTimeMs: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, waitTimeMs));
 }
@@ -35,4 +37,8 @@ export function toLowerCasePropertyNames(input: any): any {
     result[key.toLowerCase()] = newValue;
     return result;
   }, {});
+}
+
+export function getUTCOffsetFromTimezoneIdentifier(timezone: string): string {
+  return moment.tz(timezone).format("Z");
 }

--- a/test/utils/Utils.test.ts
+++ b/test/utils/Utils.test.ts
@@ -3,7 +3,11 @@
 
 import * as chai from 'chai';
 
-import { toLowerCasePropertyNames, wait } from '../../src/utils/Utils';
+import {
+  getUTCOffsetFromTimezoneIdentifier,
+  toLowerCasePropertyNames,
+  wait,
+} from '../../src/utils/Utils';
 
 describe('Utils', () => {
   const expect: Chai.ExpectStatic = chai.expect;
@@ -117,5 +121,13 @@ describe('Utils', () => {
       expect(output.metadata[0]).to.eq('HTTPMetadata1');
       expect(output.metadata[1]).to.eq('HTTPMetadata2');
     });
+
+    it('does not convert any values to lowercase', () => {
+      expect(getUTCOffsetFromTimezoneIdentifier('America/Argentina/Buenos_Aires')).to.eq("-03:00");
+      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Calcutta')).to.eq("+05:30");
+      expect(getUTCOffsetFromTimezoneIdentifier('America/Los_Angeles')).to.eq("-07:00");
+      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Anadyr')).to.eq("+12:00");
+      expect(getUTCOffsetFromTimezoneIdentifier('Etc/GMT-14')).to.eq("+14:00");
+    })
   });
 });

--- a/test/utils/Utils.test.ts
+++ b/test/utils/Utils.test.ts
@@ -122,12 +122,12 @@ describe('Utils', () => {
       expect(output.metadata[1]).to.eq('HTTPMetadata2');
     });
 
-    it('does not convert any values to lowercase', () => {
-      expect(getUTCOffsetFromTimezoneIdentifier('America/Argentina/Buenos_Aires')).to.eq("-03:00");
-      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Calcutta')).to.eq("+05:30");
-      expect(getUTCOffsetFromTimezoneIdentifier('America/Los_Angeles')).to.eq("-07:00");
-      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Anadyr')).to.eq("+12:00");
-      expect(getUTCOffsetFromTimezoneIdentifier('Etc/GMT-14')).to.eq("+14:00");
-    })
+    it('gets correct UTC offset from timezone identifier', () => {
+      expect(getUTCOffsetFromTimezoneIdentifier('America/Argentina/Buenos_Aires')).to.eq('-03:00');
+      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Calcutta')).to.eq('+05:30');
+      expect(getUTCOffsetFromTimezoneIdentifier('America/Los_Angeles')).to.eq('-07:00');
+      expect(getUTCOffsetFromTimezoneIdentifier('Asia/Anadyr')).to.eq('+12:00');
+      expect(getUTCOffsetFromTimezoneIdentifier('Etc/GMT-14')).to.eq('+14:00');
+    });
   });
 });


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
*What?*
Add Client UTC Offset inside join message (which is sent over signalling channel)

*Why?*
With the aim of improving audio quality for customers, we want to map the timezone of attendees to server's AWS region  being connected to by them. 

**Testing:**
- Added unit tests for all modified code with full coverage
- Used demo application to verify that the client UTC offset parameter is being passed inside join message.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, Running MeetingV2 Demo App in the browser should pass the client UTC offset parameter inside join message. You can filter the logs in console of browser by searching for the term `client_utc_offset`

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
 N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
 N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

