### PR TITLE
Fix formatted offset logic for UTC timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.13.0] - 2023-03-28
 
 ### Added
-- Send client UTC offset with attendee JOIN frame over signalling channel.
+- Send client utc offset with attendee JOIN frame over signalling channel. 
 
 ### Removed
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -43,7 +43,7 @@ export function toLowerCasePropertyNames(input: any): any {
  */
 export function getFormattedOffset(utcOffset: number): string {
   const offset = Math.abs(utcOffset);
-  const offsetOperator = utcOffset < 0 ? '+' : '-';
+  const offsetOperator = utcOffset <= 0 ? '+' : '-';
   const offsetHours = Math.floor(offset / 60)
     .toString()
     .padStart(2, '0');

--- a/test/utils/Utils.test.ts
+++ b/test/utils/Utils.test.ts
@@ -124,6 +124,7 @@ describe('Utils', () => {
       expect(getFormattedOffset(420)).to.eq('-07:00');
       expect(getFormattedOffset(-720)).to.eq('+12:00');
       expect(getFormattedOffset(-840)).to.eq('+14:00');
+      expect(getFormattedOffset(0)).to.eq('+00:00');
     });
   });
 });


### PR DESCRIPTION
**Issue #:**
None

**Description of changes:**
Fix formatted offset logic in case timezone is UTC timezone

**Testing:**
build succeeded

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, running the demo browser app locally sends +00:00 as utc offset in join message during signalling (filter console logs).

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

