### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/browser-compatibility-test-previous-major-version.yml
+++ b/.github/workflows/browser-compatibility-test-previous-major-version.yml
@@ -29,7 +29,7 @@ jobs:
         id: get-version
         run: |
           current_version=$(.github/script/get-current-version)
-          echo "::set-output name=version-number::$((${current_version%%.*} - 1))"
+          echo "version-number=$((${current_version%%.*} - 1))" >> $GITHUB_OUTPUT
 
 
   browser-compatibility-audio-previous-major-version:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,7 +45,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -71,7 +71,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -97,7 +97,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -126,7 +126,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -154,7 +154,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -183,7 +183,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -215,7 +215,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -241,7 +241,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test
@@ -267,7 +267,7 @@
           run: |
             source ${GITHUB_WORKSPACE}/integration/js/script/need-integ-test
             check_if_integ_tests_required
-            echo ::set-output name=integ_test_required::$requires_integration_test
+            echo "integ_test_required=$requires_integration_test" >> $GITHUB_OUTPUT
         - name: Setup GitHub Actions Host
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           uses: ./.github/actions/setup-integration-test

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           prev_version=$(.github/script/get-prev-version)
           echo "Previous version:" $prev_version
-          echo ::set-output name=prev_version::$prev_version
+          echo "prev_version=$prev_version" >> $GITHUB_OUTPUT
       - name: Create a Job ID
         id: create-job-id
         uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           npm_publish_tag=$(.github/script/get-npm-tag.js)
           echo "Received NPM publish tag:" $npm_publish_tag
-          echo ::set-output name=npm_tag::$npm_publish_tag
+          echo "npm_tag=$npm_publish_tag" >> $GITHUB_OUTPUT
       - name: Publish to NPM with tag
         run: npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
         env:
@@ -63,7 +63,7 @@ jobs:
             if [[ *$npm_version* = *$current_version* ]]
             then
               echo "Version is published to npm:" $current_version
-              echo ::set-output name=npm_version::$current_version
+              echo "npm_version=$current_version" >> $GITHUB_OUTPUT
               break
             fi
 

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - name: Version check for backward compatibility check
         id: version-check
-        run: echo "::set-output name=run-check::$(node .github/script/backward-compatibility-run-check.js)"
+        run: echo "run-check=$(node .github/script/backward-compatibility-run-check.js)" >> $GITHUB_OUTPUT
 
   release-integ-test:
     name: Run Backwards Compatible Integration Tests with Release Tarball


### PR DESCRIPTION
**Issue #:** #2622 

**Description of changes:**

> For external contributor sending a PR from a fork, currently our workflow cannot run as the GitHub secrets wont be available in the fork. Could you clone the repo and re-send the PR? But the change LGTM.

Reopen #2623 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=version-number::$((${current_version%%.*} - 1))"
```

**TO-BE**

```yml
echo "version-number=$((${current_version%%.*} - 1))" >> $GITHUB_OUTPUT
```

**Testing:**
N/A

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

