### PR TITLE
Fix protobuf script and add join flag for layers alloc header extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix protobuf generate script.
+
 ## [3.13.0] - 2023-03-28
 
 ### Added

--- a/docs/classes/defaultsignalingclient.html
+++ b/docs/classes/defaultsignalingclient.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L57">src/signalingclient/DefaultSignalingClient.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L58">src/signalingclient/DefaultSignalingClient.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#closeconnection">closeConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L230">src/signalingclient/DefaultSignalingClient.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L233">src/signalingclient/DefaultSignalingClient.ts:233</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,7 +189,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L494">src/signalingclient/DefaultSignalingClient.ts:494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L497">src/signalingclient/DefaultSignalingClient.ts:497</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -212,7 +212,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#join">join</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L92">src/signalingclient/DefaultSignalingClient.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L93">src/signalingclient/DefaultSignalingClient.ts:93</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#leave">leave</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L206">src/signalingclient/DefaultSignalingClient.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L209">src/signalingclient/DefaultSignalingClient.ts:209</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#mute">mute</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L276">src/signalingclient/DefaultSignalingClient.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L279">src/signalingclient/DefaultSignalingClient.ts:279</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#openconnection">openConnection</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L77">src/signalingclient/DefaultSignalingClient.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L78">src/signalingclient/DefaultSignalingClient.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -327,7 +327,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pause">pause</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L285">src/signalingclient/DefaultSignalingClient.ts:285</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L288">src/signalingclient/DefaultSignalingClient.ts:288</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +356,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#pingpong">pingPong</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L83">src/signalingclient/DefaultSignalingClient.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L84">src/signalingclient/DefaultSignalingClient.ts:84</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -385,7 +385,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L479">src/signalingclient/DefaultSignalingClient.ts:479</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L482">src/signalingclient/DefaultSignalingClient.ts:482</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -419,7 +419,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#ready">ready</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L270">src/signalingclient/DefaultSignalingClient.ts:270</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L273">src/signalingclient/DefaultSignalingClient.ts:273</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -442,7 +442,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#registerobserver">registerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L67">src/signalingclient/DefaultSignalingClient.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L68">src/signalingclient/DefaultSignalingClient.ts:68</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -471,7 +471,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#remotevideoupdate">remoteVideoUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L177">src/signalingclient/DefaultSignalingClient.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L180">src/signalingclient/DefaultSignalingClient.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -507,7 +507,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L72">src/signalingclient/DefaultSignalingClient.ts:72</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L73">src/signalingclient/DefaultSignalingClient.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -536,7 +536,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#resume">resume</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L293">src/signalingclient/DefaultSignalingClient.ts:293</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L296">src/signalingclient/DefaultSignalingClient.ts:296</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -565,7 +565,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#sendclientmetrics">sendClientMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L216">src/signalingclient/DefaultSignalingClient.ts:216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L219">src/signalingclient/DefaultSignalingClient.ts:219</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -594,7 +594,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#senddatamessage">sendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L223">src/signalingclient/DefaultSignalingClient.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L226">src/signalingclient/DefaultSignalingClient.ts:226</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -623,7 +623,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclient.html">SignalingClient</a>.<a href="../interfaces/signalingclient.html#subscribe">subscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L127">src/signalingclient/DefaultSignalingClient.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/signalingclient/DefaultSignalingClient.ts#L130">src/signalingclient/DefaultSignalingClient.ts:130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -89,6 +89,7 @@ message SdkJoinFrame {
     optional SdkClientDetails client_details = 4;
     optional uint64 audio_session_id = 6;
     optional bool wants_compressed_sdp = 7;
+    optional bool use_layers_allocation_header_extension = 9;
     optional SdkServerSideNetworkAdaption server_side_network_adaption = 10;
     repeated SdkServerSideNetworkAdaption supported_server_side_network_adaptions = 11;
     optional bool disable_periodic_keyframe_request_on_content_sender = 13;

--- a/script/generate-signaling-protocol
+++ b/script/generate-signaling-protocol
@@ -10,21 +10,23 @@ end
 ['SignalingProtocol'].each do |protocol|
   dir = protocol.downcase
 
+  # please change the protobuf dependency in package.json to the following:
+  # "protobufjs": "git://github.com/VitalyName/protobuf.js.git#236a7c757a5eada7926fdff149d0b49ada838275"
+  # This is a walkaround for https://github.com/protobufjs/protobuf.js/issues/1414
+
   verbose "rm -rf src/#{dir}"
   verbose "mkdir -p src/#{dir}"
 
   # workaround for https://github.com/hegemonic/requizzle/issues/5
-  verbose "brew install node@10"
-  node = "#{`brew --prefix node@10`.strip}/bin/node"
+  # node@14 will work with libicu4c 72
+  # verbose "brew install node@14"
+  node = "#{`brew --prefix node@14`.strip}/bin/node"
 
   # workaround for https://github.com/protobufjs/protobuf.js/issues/1217
+  # brew upgrade icu4c if library not loaded
   verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
   File.write('node_modules/protobufjs/package.json', File.read('node_modules/protobufjs/package.json').gsub('"jsdoc": "^3.6.3",', '"jsdoc": "~3.5.5",'))
 
   verbose "#{node} node_modules/.bin/pbjs -t static-module -w commonjs -o src/#{dir}/#{protocol}.js ./protocol/#{protocol}.proto"
   verbose "#{node} node_modules/.bin/pbts -o src/#{dir}/#{protocol}.d.ts src/#{dir}/#{protocol}.js"
-
-  # workaround for the Long type import issue. Remove when https://github.com/protobufjs/protobuf.js/pull/1166/files is released.
-  File.write("src/#{dir}/#{protocol}.d.ts", "import * as Long from \"long\";\n" + File.read("src/#{dir}/#{protocol}.d.ts"))
-  File.write("src/#{dir}/#{protocol}.js", "$util.Long = undefined;\n$protobuf.configure();", mode:"a")
 end

--- a/src/signalingclient/DefaultSignalingClient.ts
+++ b/src/signalingclient/DefaultSignalingClient.ts
@@ -48,6 +48,7 @@ export default class DefaultSignalingClient implements SignalingClient {
   private static FRAME_TYPE_RTC: number = 0x5;
   private static CLOSE_EVENT_TIMEOUT_MS: number = 2000;
   private static CLIENT_SUPPORTS_COMPRESSION: boolean = true;
+  private static USE_LAYERS_ALLOCATION_HEADER_EXTENSION = true;
 
   private observerQueue: Set<SignalingClientObserver>;
   private wasOpened: boolean;
@@ -110,6 +111,8 @@ export default class DefaultSignalingClient implements SignalingClient {
     joinFrame.clientDetails = SdkClientDetails.create(sdkClientDetails);
     joinFrame.audioSessionId = this.audioSessionId;
     joinFrame.wantsCompressedSdp = DefaultSignalingClient.CLIENT_SUPPORTS_COMPRESSION;
+    joinFrame.useLayersAllocationHeaderExtension =
+      DefaultSignalingClient.USE_LAYERS_ALLOCATION_HEADER_EXTENSION;
     joinFrame.disablePeriodicKeyframeRequestOnContentSender =
       settings.disablePeriodicKeyframeRequestOnContentSender;
     joinFrame.serverSideNetworkAdaption = convertServerSideNetworkAdaptionEnumToSignaled(

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -1,4 +1,3 @@
-import * as Long from "long";
 import * as $protobuf from "protobufjs";
 /** Properties of a SdkSignalFrame. */
 export interface ISdkSignalFrame {
@@ -519,6 +518,9 @@ export interface ISdkJoinFrame {
     /** SdkJoinFrame wantsCompressedSdp */
     wantsCompressedSdp?: (boolean|null);
 
+    /** SdkJoinFrame useLayersAllocationHeaderExtension */
+    useLayersAllocationHeaderExtension?: (boolean|null);
+
     /** SdkJoinFrame serverSideNetworkAdaption */
     serverSideNetworkAdaption?: (SdkServerSideNetworkAdaption|null);
 
@@ -555,6 +557,9 @@ export class SdkJoinFrame implements ISdkJoinFrame {
 
     /** SdkJoinFrame wantsCompressedSdp. */
     public wantsCompressedSdp: boolean;
+
+    /** SdkJoinFrame useLayersAllocationHeaderExtension. */
+    public useLayersAllocationHeaderExtension: boolean;
 
     /** SdkJoinFrame serverSideNetworkAdaption. */
     public serverSideNetworkAdaption: SdkServerSideNetworkAdaption;

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -1578,6 +1578,7 @@ $root.SdkJoinFrame = (function() {
      * @property {ISdkClientDetails|null} [clientDetails] SdkJoinFrame clientDetails
      * @property {number|Long|null} [audioSessionId] SdkJoinFrame audioSessionId
      * @property {boolean|null} [wantsCompressedSdp] SdkJoinFrame wantsCompressedSdp
+     * @property {boolean|null} [useLayersAllocationHeaderExtension] SdkJoinFrame useLayersAllocationHeaderExtension
      * @property {SdkServerSideNetworkAdaption|null} [serverSideNetworkAdaption] SdkJoinFrame serverSideNetworkAdaption
      * @property {Array.<SdkServerSideNetworkAdaption>|null} [supportedServerSideNetworkAdaptions] SdkJoinFrame supportedServerSideNetworkAdaptions
      * @property {boolean|null} [disablePeriodicKeyframeRequestOnContentSender] SdkJoinFrame disablePeriodicKeyframeRequestOnContentSender
@@ -1648,6 +1649,14 @@ $root.SdkJoinFrame = (function() {
     SdkJoinFrame.prototype.wantsCompressedSdp = false;
 
     /**
+     * SdkJoinFrame useLayersAllocationHeaderExtension.
+     * @member {boolean} useLayersAllocationHeaderExtension
+     * @memberof SdkJoinFrame
+     * @instance
+     */
+    SdkJoinFrame.prototype.useLayersAllocationHeaderExtension = false;
+
+    /**
      * SdkJoinFrame serverSideNetworkAdaption.
      * @member {SdkServerSideNetworkAdaption} serverSideNetworkAdaption
      * @memberof SdkJoinFrame
@@ -1707,6 +1716,8 @@ $root.SdkJoinFrame = (function() {
             writer.uint32(/* id 6, wireType 0 =*/48).uint64(message.audioSessionId);
         if (message.wantsCompressedSdp != null && Object.hasOwnProperty.call(message, "wantsCompressedSdp"))
             writer.uint32(/* id 7, wireType 0 =*/56).bool(message.wantsCompressedSdp);
+        if (message.useLayersAllocationHeaderExtension != null && Object.hasOwnProperty.call(message, "useLayersAllocationHeaderExtension"))
+            writer.uint32(/* id 9, wireType 0 =*/72).bool(message.useLayersAllocationHeaderExtension);
         if (message.serverSideNetworkAdaption != null && Object.hasOwnProperty.call(message, "serverSideNetworkAdaption"))
             writer.uint32(/* id 10, wireType 0 =*/80).int32(message.serverSideNetworkAdaption);
         if (message.supportedServerSideNetworkAdaptions != null && message.supportedServerSideNetworkAdaptions.length)
@@ -1765,6 +1776,9 @@ $root.SdkJoinFrame = (function() {
                 break;
             case 7:
                 message.wantsCompressedSdp = reader.bool();
+                break;
+            case 9:
+                message.useLayersAllocationHeaderExtension = reader.bool();
                 break;
             case 10:
                 message.serverSideNetworkAdaption = reader.int32();
@@ -1837,6 +1851,9 @@ $root.SdkJoinFrame = (function() {
         if (message.wantsCompressedSdp != null && message.hasOwnProperty("wantsCompressedSdp"))
             if (typeof message.wantsCompressedSdp !== "boolean")
                 return "wantsCompressedSdp: boolean expected";
+        if (message.useLayersAllocationHeaderExtension != null && message.hasOwnProperty("useLayersAllocationHeaderExtension"))
+            if (typeof message.useLayersAllocationHeaderExtension !== "boolean")
+                return "useLayersAllocationHeaderExtension: boolean expected";
         if (message.serverSideNetworkAdaption != null && message.hasOwnProperty("serverSideNetworkAdaption"))
             switch (message.serverSideNetworkAdaption) {
             default:
@@ -1899,6 +1916,8 @@ $root.SdkJoinFrame = (function() {
                 message.audioSessionId = new $util.LongBits(object.audioSessionId.low >>> 0, object.audioSessionId.high >>> 0).toNumber(true);
         if (object.wantsCompressedSdp != null)
             message.wantsCompressedSdp = Boolean(object.wantsCompressedSdp);
+        if (object.useLayersAllocationHeaderExtension != null)
+            message.useLayersAllocationHeaderExtension = Boolean(object.useLayersAllocationHeaderExtension);
         switch (object.serverSideNetworkAdaption) {
         case "DEFAULT":
         case 1:
@@ -1965,6 +1984,7 @@ $root.SdkJoinFrame = (function() {
             } else
                 object.audioSessionId = options.longs === String ? "0" : 0;
             object.wantsCompressedSdp = false;
+            object.useLayersAllocationHeaderExtension = false;
             object.serverSideNetworkAdaption = options.enums === String ? "DEFAULT" : 1;
             object.disablePeriodicKeyframeRequestOnContentSender = false;
         }
@@ -1983,6 +2003,8 @@ $root.SdkJoinFrame = (function() {
                 object.audioSessionId = options.longs === String ? $util.Long.prototype.toString.call(message.audioSessionId) : options.longs === Number ? new $util.LongBits(message.audioSessionId.low >>> 0, message.audioSessionId.high >>> 0).toNumber(true) : message.audioSessionId;
         if (message.wantsCompressedSdp != null && message.hasOwnProperty("wantsCompressedSdp"))
             object.wantsCompressedSdp = message.wantsCompressedSdp;
+        if (message.useLayersAllocationHeaderExtension != null && message.hasOwnProperty("useLayersAllocationHeaderExtension"))
+            object.useLayersAllocationHeaderExtension = message.useLayersAllocationHeaderExtension;
         if (message.serverSideNetworkAdaption != null && message.hasOwnProperty("serverSideNetworkAdaption"))
             object.serverSideNetworkAdaption = options.enums === String ? $root.SdkServerSideNetworkAdaption[message.serverSideNetworkAdaption] : message.serverSideNetworkAdaption;
         if (message.supportedServerSideNetworkAdaptions && message.supportedServerSideNetworkAdaptions.length) {
@@ -13270,5 +13292,3 @@ $root.SdkVideoCodecCapability = (function() {
 })();
 
 module.exports = $root;
-$util.Long = undefined;
-$protobuf.configure();


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Protobuf generate script fails because of the jsdoc issue. Also add a join flag for layers allocation header extension with default value of true. The header extension was added in https://github.com/aws/amazon-chime-sdk-js/pull/2195.

**Testing:**

Unit test and smoke test with the demo app.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

no

**Checklist:**

1. Have you successfully run `npm run build:release` locally?

y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

