### PR TITLE
Add fallback value for detect() when it can not parse UserAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [3.14.0] - 2023-04-11
 
 ### Added
+
 * Add new guide for `VideoFXProcessor`.
 
 ### Removed
 
 ### Changed
 
+* Add fallback value for `DefaultBrowserBehavior.browser` when `detect()` can not parse browser UserAgent.
+
 ### Fixed
 
 ## [3.13.0] - 2023-03-28
 
 ### Added
-- Send client utc offset with attendee JOIN frame over signalling channel. 
+
+- Send client utc offset with attendee JOIN frame over signalling channel.
 - Add an unified interface (videofx processor) with new implementation for ML features, namely background blur 2.0 and background replacement 2.0. This includes improvement to the underlying model for better segmentation, better image processing algorithms to blur the background, and other miscellanies bug-fixes/features.
 
 ### Removed

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -42,7 +42,7 @@
       }
     },
     "../..": {
-      "version": "3.13.0",
+      "version": "3.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/docs/classes/defaultbrowserbehavior.html
+++ b/docs/classes/defaultbrowserbehavior.html
@@ -158,7 +158,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#disable480presolutionscaledown">disable480pResolutionScaleDown</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L226">src/browserbehavior/DefaultBrowserBehavior.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L232">src/browserbehavior/DefaultBrowserBehavior.ts:232</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#disableresolutionscaledown">disableResolutionScaleDown</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L222">src/browserbehavior/DefaultBrowserBehavior.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L228">src/browserbehavior/DefaultBrowserBehavior.ts:228</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L163">src/browserbehavior/DefaultBrowserBehavior.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L169">src/browserbehavior/DefaultBrowserBehavior.ts:169</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L157">src/browserbehavior/DefaultBrowserBehavior.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L163">src/browserbehavior/DefaultBrowserBehavior.ts:163</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#haschromiumwebrtc">hasChromiumWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L73">src/browserbehavior/DefaultBrowserBehavior.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L79">src/browserbehavior/DefaultBrowserBehavior.ts:79</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#hasfirefoxwebrtc">hasFirefoxWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L91">src/browserbehavior/DefaultBrowserBehavior.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L97">src/browserbehavior/DefaultBrowserBehavior.ts:97</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L82">src/browserbehavior/DefaultBrowserBehavior.ts:82</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L88">src/browserbehavior/DefaultBrowserBehavior.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#issimulcastsupported">isSimulcastSupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L180">src/browserbehavior/DefaultBrowserBehavior.ts:180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L186">src/browserbehavior/DefaultBrowserBehavior.ts:186</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#issupported">isSupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L167">src/browserbehavior/DefaultBrowserBehavior.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L173">src/browserbehavior/DefaultBrowserBehavior.ts:173</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L248">src/browserbehavior/DefaultBrowserBehavior.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L254">src/browserbehavior/DefaultBrowserBehavior.ts:254</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -356,7 +356,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#majorversion">majorVersion</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L61">src/browserbehavior/DefaultBrowserBehavior.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L67">src/browserbehavior/DefaultBrowserBehavior.ts:67</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -379,7 +379,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L69">src/browserbehavior/DefaultBrowserBehavior.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L75">src/browserbehavior/DefaultBrowserBehavior.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -401,7 +401,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L65">src/browserbehavior/DefaultBrowserBehavior.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L71">src/browserbehavior/DefaultBrowserBehavior.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -419,7 +419,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresbundlepolicy">requiresBundlePolicy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L145">src/browserbehavior/DefaultBrowserBehavior.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L151">src/browserbehavior/DefaultBrowserBehavior.ts:151</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -442,7 +442,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requirescheckforsdpconnectionattributes">requiresCheckForSdpConnectionAttributes</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L137">src/browserbehavior/DefaultBrowserBehavior.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L143">src/browserbehavior/DefaultBrowserBehavior.ts:143</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresdisablingh264encoding">requiresDisablingH264Encoding</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L230">src/browserbehavior/DefaultBrowserBehavior.ts:230</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L236">src/browserbehavior/DefaultBrowserBehavior.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -483,7 +483,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresgroupidmediastreamconstraints">requiresGroupIdMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L153">src/browserbehavior/DefaultBrowserBehavior.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L159">src/browserbehavior/DefaultBrowserBehavior.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -501,7 +501,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresicecandidategatheringtimeoutworkaround">requiresIceCandidateGatheringTimeoutWorkaround</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L141">src/browserbehavior/DefaultBrowserBehavior.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L147">src/browserbehavior/DefaultBrowserBehavior.ts:147</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -524,7 +524,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresnoexactmediastreamconstraints">requiresNoExactMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L149">src/browserbehavior/DefaultBrowserBehavior.ts:149</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L155">src/browserbehavior/DefaultBrowserBehavior.ts:155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -547,7 +547,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresplaybacklatencyhintforaudiocontext">requiresPlaybackLatencyHintForAudioContext</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L95">src/browserbehavior/DefaultBrowserBehavior.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L101">src/browserbehavior/DefaultBrowserBehavior.ts:101</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -570,7 +570,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresresolutionalignment">requiresResolutionAlignment</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L130">src/browserbehavior/DefaultBrowserBehavior.ts:130</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L136">src/browserbehavior/DefaultBrowserBehavior.ts:136</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -596,7 +596,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L239">src/browserbehavior/DefaultBrowserBehavior.ts:239</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L245">src/browserbehavior/DefaultBrowserBehavior.ts:245</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -614,7 +614,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportdownlinkbandwidthestimation">supportDownlinkBandwidthEstimation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L184">src/browserbehavior/DefaultBrowserBehavior.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L190">src/browserbehavior/DefaultBrowserBehavior.ts:190</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -632,7 +632,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportstring">supportString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L188">src/browserbehavior/DefaultBrowserBehavior.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L194">src/browserbehavior/DefaultBrowserBehavior.ts:194</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -655,7 +655,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportedvideocodecs">supportedVideoCodecs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L199">src/browserbehavior/DefaultBrowserBehavior.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L205">src/browserbehavior/DefaultBrowserBehavior.ts:205</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -678,7 +678,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportsbackgroundfilter">supportsBackgroundFilter</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L112">src/browserbehavior/DefaultBrowserBehavior.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L118">src/browserbehavior/DefaultBrowserBehavior.ts:118</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -696,7 +696,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportscanvascapturedstreamplayback">supportsCanvasCapturedStreamPlayback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L99">src/browserbehavior/DefaultBrowserBehavior.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L105">src/browserbehavior/DefaultBrowserBehavior.ts:105</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -719,7 +719,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportssetsinkid">supportsSetSinkId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L218">src/browserbehavior/DefaultBrowserBehavior.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L224">src/browserbehavior/DefaultBrowserBehavior.ts:224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -742,7 +742,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportsvideolayersallocationrtpheaderextension">supportsVideoLayersAllocationRtpHeaderExtension</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L126">src/browserbehavior/DefaultBrowserBehavior.ts:126</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L132">src/browserbehavior/DefaultBrowserBehavior.ts:132</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -760,7 +760,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#version">version</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L57">src/browserbehavior/DefaultBrowserBehavior.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L63">src/browserbehavior/DefaultBrowserBehavior.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -8,7 +8,13 @@ import BrowserBehavior from './BrowserBehavior';
 import ExtendedBrowserBehavior from './ExtendedBrowserBehavior';
 
 export default class DefaultBrowserBehavior implements BrowserBehavior, ExtendedBrowserBehavior {
-  private readonly browser = detect();
+  private readonly FALLBACK_BROWSER = {
+    type: 'browser',
+    name: 'unknown',
+    version: 'unknown',
+    os: 'unknown',
+  };
+  private readonly browser = detect() || this.FALLBACK_BROWSER;
   private readonly uaParserResult =
     navigator && navigator.userAgent ? new UAParser(navigator.userAgent).getResult() : null;
 


### PR DESCRIPTION
**Issue #2636 :**

**Description of changes:**
We're using `detect-browser` library's `detect()` method to parse the UserAgent.

https://github.com/aws/amazon-chime-sdk-js/blob/26327a523539cd0b0b0538d12d9d9df42263ce6e/src/browserbehavior/DefaultBrowserBehavior.ts#L11
And later we're accessing the `name`, `os`, `version` property, and maybe even `type` property in the future of this `browser` in `DefaultBrowserBehavior`.

https://github.com/aws/amazon-chime-sdk-js/blob/26327a523539cd0b0b0538d12d9d9df42263ce6e/src/browserbehavior/DefaultBrowserBehavior.ts#L57-L59
https://github.com/aws/amazon-chime-sdk-js/blob/26327a523539cd0b0b0538d12d9d9df42263ce6e/src/browserbehavior/DefaultBrowserBehavior.ts#L69-L71
https://github.com/aws/amazon-chime-sdk-js/blob/26327a523539cd0b0b0538d12d9d9df42263ce6e/src/browserbehavior/DefaultBrowserBehavior.ts#L226-L228

However if the UserAgent is not supported, `detect()` returns `null`. When `browser` is `null` it will throw error and stop page from rendering.
>TypeError: Cannot read properties of null (reading 'name')

This change adds a fallback value to avoid such errors.
https://github.com/aws/amazon-chime-sdk-js/blob/c1660fe8671c0df7adfd0339b728c03ed619acc8/src/browserbehavior/DefaultBrowserBehavior.ts#L11-L17

And we already log a warning when browser is not supported. So no need to add an extra warning message.
https://github.com/aws/amazon-chime-sdk-js/blob/26327a523539cd0b0b0538d12d9d9df42263ce6e/src/meetingsession/DefaultMeetingSession.ts#L157-L163

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, in meetingV2 demo. 
1. In Chrome browser, follow this [guide](https://www.searchenginejournal.com/change-user-agent/368448/#close) to custom UserAgent. Use `FakeBrowser/26.7.2.100 (Android/13/sdk_gphone64_arm64)` as the value.
2. Refresh the page and load the meeting demo.
3. Verify the meeting demo is rendered correctly.
4. In debugger console, enter `this.navigator.userAgent` and verify the printed value is `FakeBrowser/26.7.2.100 (Android/13/sdk_gphone64_arm64)`


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

5. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

6. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

