### PR TITLE
Optional chain on the mediaStream in case is null (DefaultContentShareController)

### DIFF
--- a/src/contentsharecontroller/DefaultContentShareController.ts
+++ b/src/contentsharecontroller/DefaultContentShareController.ts
@@ -157,7 +157,7 @@ export default class DefaultContentShareController
   }
 
   audioVideoDidStart(): void {
-    if (this.mediaStreamBroker.mediaStream.getVideoTracks().length > 0) {
+    if (this.mediaStreamBroker.mediaStream?.getVideoTracks().length > 0) {
       this.contentAudioVideo.videoTileController.startLocalVideoTile();
     }
   }


### PR DESCRIPTION
**Issue #2659 and #2535**

**Description of changes:**
- Optional Check `mediaStream` on the `audioVideoDidStart` event inside `DefaultContentShareController`

**Testing:**
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes!
```
=============================== Coverage summary ===============================
Statements   : 100% ( 10707/10707 )
Branches     : 100% ( 4719/4719 )
Functions    : 100% ( 2039/2039 )
Lines        : 100% ( 10580/10580 )
================================================================================
```

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
