### PR TITLE
[Integ test] Change Linux integration tests to SauceLab Linux beta (#2656)

### DIFF
--- a/integration/js/utils/WebdriverSauceLabs.js
+++ b/integration/js/utils/WebdriverSauceLabs.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const Base64 = require('js-base64').Base64;
 const { AppPage, MeetingReadinessCheckerPage, MessagingSessionPage, TestAppPage } = require('../pages');
 
+const SAUCE_LAB_DOMAIN = 'us-west-1.saucelabs.com';
 const getPlatformName = capabilities => {
   const { browserName, version, platform } = capabilities;
   switch (platform) {
@@ -15,7 +16,7 @@ const getPlatformName = capabilities => {
     case 'WINDOWS':
       return 'Windows 10';
     case 'LINUX':
-      return 'Linux';
+      return 'Linux Beta';
     case 'IOS':
       return 'iOS';
     case 'ANDROID':
@@ -83,12 +84,12 @@ const getChromeOptions = capabilities => {
       chromeOptions['args'].push('--use-file-for-fake-audio-capture=' + fetchMediaPath(capabilities.audio, capabilities.browserName));
     }
   }
-  
+
   /**
    * Recently, SauceLabs loads the web page in test and runs into "Your connection is not private" error.
    * Content share test is also failing with WebSocket connection failed issues which SauceLabs says may
    * be related.
-   * 
+   *
    * Per SauceLabs suggestion add '--ignore-certificate-errors' to all tests and
    * few explicit ones for content share test as most errors are on MAC platform.
    */
@@ -160,14 +161,6 @@ const getSauceLabsConfig = (capabilities) => {
   }
 };
 
-const getSauceLabsDomain = (platform)  => {
-  const platformUpperCase = platform.toUpperCase();
-  if (platformUpperCase === 'LINUX') {
-    return 'us-east-1.saucelabs.com';
-  }
-  return 'us-west-1.saucelabs.com';
-};
-
 const getSafariIOSConfig = (capabilities) => {
   return {
     platformName: capabilities.platform,
@@ -220,7 +213,7 @@ class SaucelabsSession {
         cap = getSafariCapabilities(capabilities);
       }
     }
-    const domain = getSauceLabsDomain(capabilities.platform);
+    const domain = SAUCE_LAB_DOMAIN;
     const driver = await new Builder()
       .usingServer(getSauceLabsUrl(domain))
       .withCapabilities(cap)


### PR DESCRIPTION
**Issue #:**
Cherry pick this PR https://github.com/aws/amazon-chime-sdk-js/pull/2656 to v2 integration test

**Testing:**
N/A


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

