### PR TITLE
Set max bitrate to 1500kbps and add resolution constraint to content …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Set max bitrate to 1500kbps
+* Add resolution constraint to content share (1080p@30fps)
+
 ### Removed
 
 ### Changed

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -333,7 +333,7 @@
           <select id="video-input-quality" class="form-select" style="width:100%">
             <option value="360p">360p (nHD) @ 15 fps (600 Kbps max)</option>
             <option value="540p" selected>540p (qHD) @ 15 fps (1.4 Mbps max)</option>
-            <option value="720p">720p (HD) @ 15 fps (1.4 Mbps max)</option>
+            <option value="720p">720p (HD) @ 15 fps (1.5 Mbps max)</option>
           </select>
         </div>
       </div>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -832,7 +832,7 @@ export class DemoMeetingApp
           break;
         case '720p':
           this.audioVideo.chooseVideoInputQuality(1280, 720, 15);
-          this.audioVideo.setVideoMaxBandwidthKbps(1400);
+          this.audioVideo.setVideoMaxBandwidthKbps(1500);
           break;
       }
       try {

--- a/src/task/ReceiveVideoInputTask.ts
+++ b/src/task/ReceiveVideoInputTask.ts
@@ -74,6 +74,28 @@ export default class ReceiveVideoInputTask extends BaseTask {
         DefaultModality.MODALITY_CONTENT
       );
       const trackSettings = videoTracks[0].getSettings();
+
+      // apply video track constraints for content share
+      if (isContentAttendee) {
+        const constraint = {
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+          frameRate: { ideal: 30 },
+        };
+        this.context.logger.info(
+          `Video track (content = ${isContentAttendee}) with constraint: ${JSON.stringify(
+            constraint
+          )}, trackSettings: ${JSON.stringify(trackSettings)}`
+        );
+        try {
+          await videoTracks[0].applyConstraints(constraint);
+        } catch (error) {
+          this.context.logger.info(
+            'Could not apply constraint for video track (content = ${isContentAttendee})'
+          );
+        }
+      }
+
       // For video, we currently enforce 720p for simulcast. This logic should be removed in the future.
       if (this.context.enableSimulcast && !isContentAttendee) {
         const constraint = this.context.videoUplinkBandwidthPolicy.chooseMediaTrackConstraints();

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -48,7 +48,7 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
   private numberOfPublishedVideoSources: number | undefined = 0;
   private optimalParameters: DefaultVideoAndEncodeParameter;
   private parametersInEffect: DefaultVideoAndEncodeParameter;
-  private idealMaxBandwidthKbps = 1400;
+  private idealMaxBandwidthKbps = 1500;
   private hasBandwidthPriority: boolean = false;
   private encodingParamMap = new Map<string, RTCRtpEncodingParameters>();
   private transceiverController: TransceiverController;

--- a/test/task/ReceiveVideoInputTask.test.ts
+++ b/test/task/ReceiveVideoInputTask.test.ts
@@ -96,6 +96,43 @@ describe('ReceiveVideoInputTask', () => {
       assert.exists(context.activeVideoInput);
     });
 
+    it('will acquire the video input and query constraint (unicast - content with video track constraint)', async () => {
+      context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
+      context.enableSimulcast = false;
+      context.meetingSessionConfiguration.credentials.attendeeId = 'foo-attendee#content';
+      context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy(
+        'attendee',
+        new NoOpLogger()
+      );
+      context.videoTileController.startLocalVideoTile();
+      context.mediaStreamBroker = new MockMediaStreamBroker({
+        acquireVideoInputDeviceSucceeds: true,
+      });
+
+      const task = new ReceiveVideoInputTask(context);
+      await task.run();
+      assert.exists(context.activeVideoInput);
+    });
+
+    it('will acquire the video input and query constraint (unicast - content without video track constraint)', async () => {
+      domMockBehavior.applyConstraintSucceeds = false;
+      context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
+      context.enableSimulcast = false;
+      context.meetingSessionConfiguration.credentials.attendeeId = 'foo-attendee#content';
+      context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy(
+        'attendee',
+        new NoOpLogger()
+      );
+      context.videoTileController.startLocalVideoTile();
+      context.mediaStreamBroker = new MockMediaStreamBroker({
+        acquireVideoInputDeviceSucceeds: true,
+      });
+
+      const task = new ReceiveVideoInputTask(context);
+      await task.run();
+      assert.exists(context.activeVideoInput);
+    });
+
     it('will acquire the video input and query constraint', async () => {
       context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
       context.enableSimulcast = true;
@@ -112,7 +149,7 @@ describe('ReceiveVideoInputTask', () => {
       assert.exists(context.activeVideoInput);
     });
 
-    it('will acquire the video input and query constraint', async () => {
+    it('will acquire the video input and query constraint with applyConstraintSucceeds set to false', async () => {
       domMockBehavior.applyConstraintSucceeds = false;
       context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
       context.enableSimulcast = true;


### PR DESCRIPTION
**Issue #:**
Set max bitrate to 1500kbps (to sync with simulcast max bitrate setting)
Add resolution constraint for content share (currently missing)

**Description of changes:**
Bitrate constraint: max bitrate set to 1500kbps
Resolution constraint: content share 1080p@30fps

**Testing:**
MeetingV2 demo app, check target bitrate is not above 1500kbps and content share resolution is not above 1080p.
 
Check chrome://webrtc-internals to confirm that.
-------------------------------------------------------------------------------------
Webrtc stats from chrome:

**targetBitrate | 1500000**
framesEncoded | 2468
[framesEncoded/s] | 19.029208670955565
keyFramesEncoded | 15
totalEncodeTime | 97.938
[totalEncodeTime/framesEncoded_in_ms] | 33.578947368421325
totalEncodedBytesTarget | 0
[totalEncodedBytesTarget_in_bits/s] | 0
**frameWidth | 1666
frameHeight | 1080**
framesPerSecond | 20
framesSent | 2468
[framesSent/s] | 19.029208670955565
hugeFramesSent | 14
totalPacketSendDelay | 101.149647
[totalPacketSendDelay/packetsSent_in_ms] | 22.769783333333393
qualityLimitationReason | cpu
qualityLimitationDurations | {bandwidth:0,cpu:110.571,none:20.231,other:0}
qualityLimitationResolutionChanges | 0
**contentType | screenshare**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
MeetingV2 demo app

Steps:
1. Start MeetingV2 demo app using Chrome browser
2. Start content share with higher than 1080p tab or window
3. Check chrome://webrtc-internals for encoding details (shown above)
4. targetBitrate should not be above 1500000 
5. frameWidth should not be above 1920
6. frameHeight should not be above 1080

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

7. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

8. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

