### PR TITLE
Add null check for DefaultBrowserBehavior.majorVersion()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+
 - Update chime sdk messaging client version.
-- Clarify quotas for content-sharing publishing and subscriptions in API Overview. 
+- Clarify quotas for content-sharing publishing and subscriptions in API Overview.
+- Add null check for `DefaultBrowserBehavior.majorVersion()`.
 
 ### Fixed
 

--- a/docs/classes/defaultbrowserbehavior.html
+++ b/docs/classes/defaultbrowserbehavior.html
@@ -158,7 +158,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#disable480presolutionscaledown">disable480pResolutionScaleDown</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L232">src/browserbehavior/DefaultBrowserBehavior.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L235">src/browserbehavior/DefaultBrowserBehavior.ts:235</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -176,7 +176,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#disableresolutionscaledown">disableResolutionScaleDown</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L228">src/browserbehavior/DefaultBrowserBehavior.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L231">src/browserbehavior/DefaultBrowserBehavior.ts:231</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -193,7 +193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L169">src/browserbehavior/DefaultBrowserBehavior.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L172">src/browserbehavior/DefaultBrowserBehavior.ts:172</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L163">src/browserbehavior/DefaultBrowserBehavior.ts:163</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L166">src/browserbehavior/DefaultBrowserBehavior.ts:166</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -228,7 +228,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#haschromiumwebrtc">hasChromiumWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L79">src/browserbehavior/DefaultBrowserBehavior.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L82">src/browserbehavior/DefaultBrowserBehavior.ts:82</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -251,7 +251,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#hasfirefoxwebrtc">hasFirefoxWebRTC</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L97">src/browserbehavior/DefaultBrowserBehavior.ts:97</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L100">src/browserbehavior/DefaultBrowserBehavior.ts:100</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L88">src/browserbehavior/DefaultBrowserBehavior.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L91">src/browserbehavior/DefaultBrowserBehavior.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#issimulcastsupported">isSimulcastSupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L186">src/browserbehavior/DefaultBrowserBehavior.ts:186</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L189">src/browserbehavior/DefaultBrowserBehavior.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -309,7 +309,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#issupported">isSupported</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L173">src/browserbehavior/DefaultBrowserBehavior.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L176">src/browserbehavior/DefaultBrowserBehavior.ts:176</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L253">src/browserbehavior/DefaultBrowserBehavior.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L256">src/browserbehavior/DefaultBrowserBehavior.ts:256</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -378,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#name">name</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L75">src/browserbehavior/DefaultBrowserBehavior.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L78">src/browserbehavior/DefaultBrowserBehavior.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -400,7 +400,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L71">src/browserbehavior/DefaultBrowserBehavior.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L74">src/browserbehavior/DefaultBrowserBehavior.ts:74</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -418,7 +418,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresbundlepolicy">requiresBundlePolicy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L151">src/browserbehavior/DefaultBrowserBehavior.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L154">src/browserbehavior/DefaultBrowserBehavior.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -441,7 +441,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requirescheckforsdpconnectionattributes">requiresCheckForSdpConnectionAttributes</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L143">src/browserbehavior/DefaultBrowserBehavior.ts:143</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L146">src/browserbehavior/DefaultBrowserBehavior.ts:146</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -464,7 +464,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresdisablingh264encoding">requiresDisablingH264Encoding</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L236">src/browserbehavior/DefaultBrowserBehavior.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L239">src/browserbehavior/DefaultBrowserBehavior.ts:239</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -482,7 +482,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresgroupidmediastreamconstraints">requiresGroupIdMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L159">src/browserbehavior/DefaultBrowserBehavior.ts:159</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L162">src/browserbehavior/DefaultBrowserBehavior.ts:162</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -500,7 +500,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresicecandidategatheringtimeoutworkaround">requiresIceCandidateGatheringTimeoutWorkaround</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L147">src/browserbehavior/DefaultBrowserBehavior.ts:147</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L150">src/browserbehavior/DefaultBrowserBehavior.ts:150</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -523,7 +523,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresnoexactmediastreamconstraints">requiresNoExactMediaStreamConstraints</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L155">src/browserbehavior/DefaultBrowserBehavior.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L158">src/browserbehavior/DefaultBrowserBehavior.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -546,7 +546,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresplaybacklatencyhintforaudiocontext">requiresPlaybackLatencyHintForAudioContext</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L101">src/browserbehavior/DefaultBrowserBehavior.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L104">src/browserbehavior/DefaultBrowserBehavior.ts:104</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -569,7 +569,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#requiresresolutionalignment">requiresResolutionAlignment</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L136">src/browserbehavior/DefaultBrowserBehavior.ts:136</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L139">src/browserbehavior/DefaultBrowserBehavior.ts:139</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -595,7 +595,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L245">src/browserbehavior/DefaultBrowserBehavior.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L248">src/browserbehavior/DefaultBrowserBehavior.ts:248</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportdownlinkbandwidthestimation">supportDownlinkBandwidthEstimation</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L190">src/browserbehavior/DefaultBrowserBehavior.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L193">src/browserbehavior/DefaultBrowserBehavior.ts:193</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -631,7 +631,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportstring">supportString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L194">src/browserbehavior/DefaultBrowserBehavior.ts:194</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L197">src/browserbehavior/DefaultBrowserBehavior.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -654,7 +654,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportedvideocodecs">supportedVideoCodecs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L205">src/browserbehavior/DefaultBrowserBehavior.ts:205</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L208">src/browserbehavior/DefaultBrowserBehavior.ts:208</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -677,7 +677,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportsbackgroundfilter">supportsBackgroundFilter</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L118">src/browserbehavior/DefaultBrowserBehavior.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L121">src/browserbehavior/DefaultBrowserBehavior.ts:121</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -695,7 +695,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportscanvascapturedstreamplayback">supportsCanvasCapturedStreamPlayback</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L105">src/browserbehavior/DefaultBrowserBehavior.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L108">src/browserbehavior/DefaultBrowserBehavior.ts:108</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -718,7 +718,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportssetsinkid">supportsSetSinkId</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L224">src/browserbehavior/DefaultBrowserBehavior.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L227">src/browserbehavior/DefaultBrowserBehavior.ts:227</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -741,7 +741,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/extendedbrowserbehavior.html">ExtendedBrowserBehavior</a>.<a href="../interfaces/extendedbrowserbehavior.html#supportsvideolayersallocationrtpheaderextension">supportsVideoLayersAllocationRtpHeaderExtension</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L132">src/browserbehavior/DefaultBrowserBehavior.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/browserbehavior/DefaultBrowserBehavior.ts#L135">src/browserbehavior/DefaultBrowserBehavior.ts:135</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -64,7 +64,10 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
     return this.browser.version;
   }
 
-  majorVersion(): number {
+  majorVersion(): number | null {
+    if (!this.browser.version) {
+      return null;
+    }
     return parseInt(this.version().split('.')[0]);
   }
 

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -90,6 +90,18 @@ describe('DefaultBrowserBehavior', () => {
   });
 
   describe('platforms', () => {
+    it('can detect ReactNative', () => {
+      // Set ReactNative Environment. https://github.com/DamonOehlman/detect-browser/blob/546e6f1348375d8a486f21da07b20717267f6c49/src/index.ts#L216-L222
+      // @ts-ignore
+      navigator.product = 'ReactNative';
+      document = undefined;
+
+      expect(new DefaultBrowserBehavior().name()).to.eq('react-native');
+      expect(new DefaultBrowserBehavior().version()).to.eq(null);
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(null);
+      expect(new DefaultBrowserBehavior().isSupported()).to.be.false;
+    });
+
     it('can detect Firefox', () => {
       setUserAgent(FIREFOX_MAC_USER_AGENT);
       expect(new DefaultBrowserBehavior().name()).to.eq('firefox');


### PR DESCRIPTION
**Issue #1856, #2674 :**

**Description of changes:**
According to `detect-library` the `detect()` could return browser info with the value of `version` being `null`. 

For example: https://github.com/DamonOehlman/detect-browser/blob/546e6f1348375d8a486f21da07b20717267f6c49/src/index.ts#L59-L65.
```
export class ReactNativeInfo
  implements DetectedInfo<'react-native', 'react-native', null, null> {
  public readonly type = 'react-native';
  public readonly name: 'react-native' = 'react-native';
  public readonly version: null = null;
  public readonly os: null = null;
}
```

In this case our `majorVersion()` will throw an error because it try execute `null.split('.')`. This change add a null check to avoid such case.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No. The change has been covered by unit test.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

