### PR TITLE
Fallback to -1 for browser majorVersion when version is null

### DIFF
--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -65,7 +65,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   }
 
   majorVersion(): number {
-    return parseInt(this.version().split('.')[0]);
+    return this.version() !== null ? parseInt(this.version().split('.')[0]) : -1;
   }
 
   osMajorVersion(): number {

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -252,6 +252,15 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
     });
 
+    it('can test ReactNative', () => {
+      domMockBehavior = new DOMMockBehavior();
+      domMockBehavior.navigatorProduct = 'ReactNative';
+      domMockBehavior.undefinedDocument = true;
+      mockBuilder = new DOMMockBuilder(domMockBehavior);
+      expect(new DefaultBrowserBehavior().name()).to.eq('react-native');
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(-1);
+    });
+
     it('can handle an unknown user agent', () => {
       setUserAgent(OPERA_USER_AGENT);
       expect(new DefaultBrowserBehavior().isSupported()).to.be.false;

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -22,6 +22,8 @@ export default class DOMMockBehavior {
   iceConnectionStates: string[] = ['completed'];
   setSinkIdSucceeds: boolean = true;
   setSinkIdSupported: boolean = true;
+  navigatorProduct: string = '';
+  undefinedDocument: boolean = false;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   FakeTURNCredentialsBody: Promise<object> = new Promise((resolve, _reject) => {

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -628,6 +628,7 @@ export default class DOMMockBuilder {
     USER_AGENTS.set('samsung', SAMSUNG_INTERNET_USERAGENT);
 
     GlobalAny.navigator = {
+      product: mockBehavior.navigatorProduct,
       mediaDevices: mockBehavior.mediaDevicesSupported ? new mediaDevicesMaker() : undefined,
       userAgent: USER_AGENTS.get(mockBehavior.browserName),
       sendBeacon(
@@ -1065,22 +1066,26 @@ export default class DOMMockBuilder {
       delete GlobalAny.HTMLAudioElement.prototype.setSinkId;
     }
 
-    GlobalAny.document = {
-      createElement(_tagName: string): HTMLElement {
-        switch (_tagName) {
-          case 'video': {
-            return new GlobalAny.HTMLVideoElement();
+    if (mockBehavior.undefinedDocument) {
+      GlobalAny.document = undefined;
+    } else {
+      GlobalAny.document = {
+        createElement(_tagName: string): HTMLElement {
+          switch (_tagName) {
+            case 'video': {
+              return new GlobalAny.HTMLVideoElement();
+            }
+            case 'canvas': {
+              return new GlobalAny.HTMLCanvasElement();
+            }
+            case 'script': {
+              return new GlobalAny.HTMLScriptElement();
+            }
           }
-          case 'canvas': {
-            return new GlobalAny.HTMLCanvasElement();
-          }
-          case 'script': {
-            return new GlobalAny.HTMLScriptElement();
-          }
-        }
-      },
-      visibilityState: mockBehavior.documentVisibilityState,
-    };
+        },
+        visibilityState: mockBehavior.documentVisibilityState,
+      };
+    }
 
     GlobalAny.ImageData = class MockImageData {
       constructor(public data: Uint8ClampedArray, public width: number, public height: number) {}


### PR DESCRIPTION
**Issue #: [1856](https://github.com/aws/amazon-chime-sdk-js/issues/1856)**

**Description of changes:**
In ReactNative `detect`  from [detect-browser library returns null for version](https://github.com/DamonOehlman/detect-browser/blob/546e6f1348375d8a486f21da07b20717267f6c49/src/index.ts#L63). When [DefaultMessagingSession](https://github.com/aws/amazon-chime-sdk-js/blob/fb3dfb57f86e12cc9d46d3de943832a6c77f79d5/src/messagingsession/DefaultMessagingSession.ts#L200) signs the websocket url, the [sigv4 class calls Versioning.sdkUserAgentLowResolution](https://github.com/aws/amazon-chime-sdk-js/blob/fb3dfb57f86e12cc9d46d3de943832a6c77f79d5/src/sigv4/DefaultSigV4.ts#LL108C37-L108C62) which in turns [calls DefaultBrowserBehavior.majorVersion](https://github.com/aws/amazon-chime-sdk-js/blob/fb3dfb57f86e12cc9d46d3de943832a6c77f79d5/src/versioning/Versioning.ts#LL78C1-L78C1). This should provide a default major version of -1 whenever detect returns null for version.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Unit test + validated could start messaging session in our react native app.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

```
=============================== Coverage summary ===============================
Statements   : 100% ( 10854/10854 )
Branches     : 100% ( 4803/4803 )
Functions    : 100% ( 2062/2062 )
Lines        : 100% ( 10727/10727 )
================================================================================
```

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

