### PR TITLE
Fallback to -1 for browser majorVersion when version is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+
 - Update chime sdk messaging client version.
-- Clarify quotas for content-sharing publishing and subscriptions in API Overview. 
+- Clarify quotas for content-sharing publishing and subscriptions in API Overview.
+- Fallback `majorVersion()` to `-1` if `version` is `null` in `DefaultBrowserBehavior`.
 
 ### Fixed
 

--- a/src/browserbehavior/DefaultBrowserBehavior.ts
+++ b/src/browserbehavior/DefaultBrowserBehavior.ts
@@ -65,7 +65,7 @@ export default class DefaultBrowserBehavior implements BrowserBehavior, Extended
   }
 
   majorVersion(): number {
-    return parseInt(this.version().split('.')[0]);
+    return this.version() !== null ? parseInt(this.version().split('.')[0]) : -1;
   }
 
   osMajorVersion(): number {

--- a/test/browserbehavior/DefaultBrowserBehavior.test.ts
+++ b/test/browserbehavior/DefaultBrowserBehavior.test.ts
@@ -252,6 +252,15 @@ describe('DefaultBrowserBehavior', () => {
       expect(new DefaultBrowserBehavior().requiresNoExactMediaStreamConstraints()).to.be.false;
     });
 
+    it('can test ReactNative', () => {
+      domMockBehavior = new DOMMockBehavior();
+      domMockBehavior.navigatorProduct = 'ReactNative';
+      domMockBehavior.undefinedDocument = true;
+      mockBuilder = new DOMMockBuilder(domMockBehavior);
+      expect(new DefaultBrowserBehavior().name()).to.eq('react-native');
+      expect(new DefaultBrowserBehavior().majorVersion()).to.eq(-1);
+    });
+
     it('can handle an unknown user agent', () => {
       setUserAgent(OPERA_USER_AGENT);
       expect(new DefaultBrowserBehavior().isSupported()).to.be.false;

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -22,6 +22,8 @@ export default class DOMMockBehavior {
   iceConnectionStates: string[] = ['completed'];
   setSinkIdSucceeds: boolean = true;
   setSinkIdSupported: boolean = true;
+  navigatorProduct: string = '';
+  undefinedDocument: boolean = false;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   FakeTURNCredentialsBody: Promise<object> = new Promise((resolve, _reject) => {

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -628,6 +628,7 @@ export default class DOMMockBuilder {
     USER_AGENTS.set('samsung', SAMSUNG_INTERNET_USERAGENT);
 
     GlobalAny.navigator = {
+      product: mockBehavior.navigatorProduct,
       mediaDevices: mockBehavior.mediaDevicesSupported ? new mediaDevicesMaker() : undefined,
       userAgent: USER_AGENTS.get(mockBehavior.browserName),
       sendBeacon(
@@ -1065,22 +1066,26 @@ export default class DOMMockBuilder {
       delete GlobalAny.HTMLAudioElement.prototype.setSinkId;
     }
 
-    GlobalAny.document = {
-      createElement(_tagName: string): HTMLElement {
-        switch (_tagName) {
-          case 'video': {
-            return new GlobalAny.HTMLVideoElement();
+    if (mockBehavior.undefinedDocument) {
+      GlobalAny.document = undefined;
+    } else {
+      GlobalAny.document = {
+        createElement(_tagName: string): HTMLElement {
+          switch (_tagName) {
+            case 'video': {
+              return new GlobalAny.HTMLVideoElement();
+            }
+            case 'canvas': {
+              return new GlobalAny.HTMLCanvasElement();
+            }
+            case 'script': {
+              return new GlobalAny.HTMLScriptElement();
+            }
           }
-          case 'canvas': {
-            return new GlobalAny.HTMLCanvasElement();
-          }
-          case 'script': {
-            return new GlobalAny.HTMLScriptElement();
-          }
-        }
-      },
-      visibilityState: mockBehavior.documentVisibilityState,
-    };
+        },
+        visibilityState: mockBehavior.documentVisibilityState,
+      };
+    }
 
     GlobalAny.ImageData = class MockImageData {
       constructor(public data: Uint8ClampedArray, public width: number, public height: number) {}


### PR DESCRIPTION
**Issue #1856, #2674 :**

**Description of changes:**
According to `detect-library` the `detect()` could return browser info with the value of `version` being `null`. 

For example: https://github.com/DamonOehlman/detect-browser/blob/546e6f1348375d8a486f21da07b20717267f6c49/src/index.ts#L59-L65.
```
export class ReactNativeInfo
  implements DetectedInfo<'react-native', 'react-native', null, null> {
  public readonly type = 'react-native';
  public readonly name: 'react-native' = 'react-native';
  public readonly version: null = null;
  public readonly os: null = null;
}
```

In this case our `majorVersion()` will throw an error because it try execute `null.split('.')`. This change add a null check to avoid such case. And give it a fallback value `-1`.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No. The change has been covered by unit test.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

