### PR TITLE
Fix content share issue with ssna change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set max bitrate to 1500kbps.
 - Add resolution constraint to content share (1080p@30fps).
 - Added opt-in server side network adaption enablement flag `ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption`. See [this section in the guide](https://aws.github.io/amazon-chime-sdk-js/modules/prioritybased_downlink_policy.html#server-side-network-adaption) for more details.
+- Content share issue with above change
 
 ### Removed
 

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -45,7 +45,7 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
     180,
   ];
 
-  private numberOfPublishedVideoSources: number | undefined = 0;
+  private numberOfPublishedVideoSources: number | undefined = undefined;
   private optimalParameters: DefaultVideoAndEncodeParameter;
   private parametersInEffect: DefaultVideoAndEncodeParameter;
   private idealMaxBandwidthKbps = 1500;
@@ -64,7 +64,7 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
 
   reset(): void {
     // Don't reset `idealMaxBandwidthKbps` or `hasBandwidthPriority` which are set via builder API paths
-    this.numberOfPublishedVideoSources = 0;
+    this.numberOfPublishedVideoSources = undefined;
     this.optimalParameters = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
     this.parametersInEffect = new DefaultVideoAndEncodeParameter(0, 0, 0, 0, false);
     this.encodingParamMap.set(NScaleVideoUplinkBandwidthPolicy.encodingMapKey, {


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** Followup to previous CR, which avoided an unnecessary resubscribe on camera enable, but requires this change so the bitrate is non-zero (on browsers without video layers allocation extension support).

**Testing:** Issue no longer reproduces.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
* Enable content share on FF
* Confirm it can be received.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
y

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
y

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

