### PR TITLE
Fixed usage of `this` in `VideoCodecCapability` constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed usage of `this` in `VideoCodecCapability` constructors.
+
 ## [3.15.0] - 2023-05-01
 
 ### Added

--- a/src/sdp/VideoCodecCapability.ts
+++ b/src/sdp/VideoCodecCapability.ts
@@ -52,7 +52,7 @@ export default class VideoCodecCapability implements Eq {
    * Returns the configuration of H.264 recommended by the SDK
    */
   static h264(): VideoCodecCapability {
-    return this.h264ConstrainedBaselineProfile();
+    return VideoCodecCapability.h264ConstrainedBaselineProfile();
   }
 
   /**
@@ -61,9 +61,9 @@ export default class VideoCodecCapability implements Eq {
   static fromSignaled(capability: SdkVideoCodecCapability): VideoCodecCapability | undefined {
     switch (capability) {
       case SdkVideoCodecCapability.VP8:
-        return this.vp8();
+        return VideoCodecCapability.vp8();
       case SdkVideoCodecCapability.H264_CONSTRAINED_BASELINE_PROFILE:
-        return this.h264ConstrainedBaselineProfile();
+        return VideoCodecCapability.h264ConstrainedBaselineProfile();
       default:
         return undefined;
     }


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** Fixing incorrect usage of `this` that can break mildly exotic use cases.

**Testing:** No longer breaks usage.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No testing needed.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n
3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

