### PR TITLE
Fix a race condition when start and stop content share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed usage of `this` in `VideoCodecCapability` constructors.
+- Fixed a race condition error if calling `startContentShare` then `stopContentShare` right after. 
 
 ## [3.15.0] - 2023-05-01
 

--- a/src/contentsharecontroller/DefaultContentShareController.ts
+++ b/src/contentsharecontroller/DefaultContentShareController.ts
@@ -157,7 +157,7 @@ export default class DefaultContentShareController
   }
 
   audioVideoDidStart(): void {
-    if (this.mediaStreamBroker.mediaStream.getVideoTracks().length > 0) {
+    if (this.mediaStreamBroker.mediaStream?.getVideoTracks().length > 0) {
       this.contentAudioVideo.videoTileController.startLocalVideoTile();
     }
   }

--- a/test/contentsharecontroller/DefaultContentShareController.test.ts
+++ b/test/contentsharecontroller/DefaultContentShareController.test.ts
@@ -86,7 +86,8 @@ describe('DefaultContentShareController', () => {
       this.audioProfile = audioProfile;
     }
 
-    start(): void {
+    async start(): Promise<void> {
+      await delay(1);
       this.forEachObserver(observer => {
         Maybe.of(observer.audioVideoDidStart).map(f => f.bind(observer)());
       });
@@ -260,6 +261,28 @@ describe('DefaultContentShareController', () => {
       expect(audioVideoSpy.calledOnce).to.be.true;
       expect(videoTileSpy.notCalled).to.be.true;
       await delay(defaultDelay);
+      expect(contentShareObserverSpy.calledOnce).to.be.true;
+      expect(selfVideoTileSpy.notCalled).to.be.true;
+    });
+
+    it('startContentShare does not error out if media stream is deleted', async () => {
+      // @ts-ignore
+      mediaStream.addTrack(new MediaStreamTrack('video-track-id', 'video'));
+      const audioVideoSpy = sinon.spy(contentAudioVideoController, 'start');
+      const videoTileSpy = sinon.spy(
+        contentAudioVideoController.videoTileController,
+        'startLocalVideoTile'
+      );
+      const selfVideoTileSpy = sinon.spy(
+        attendeeAudioVideoController.videoTileController,
+        'addVideoTile'
+      );
+      const contentShareObserverSpy = sinon.spy(contentShareObserver, 'contentShareDidStart');
+      contentShareController.startContentShare(mediaStream);
+      contentShareMediaStreamBroker.mediaStream = null;
+      await delay(defaultDelay);
+      expect(audioVideoSpy.calledOnce).to.be.true;
+      expect(videoTileSpy.notCalled).to.be.true;
       expect(contentShareObserverSpy.calledOnce).to.be.true;
       expect(selfVideoTileSpy.notCalled).to.be.true;
     });


### PR DESCRIPTION
**Issue #2659 and #2535:**
If calling `startContentShare` and then call `stopContentShare` or delete the media stream before the content attendee join the meeting, there will be an error logged in `audioVideoDidStart` event when the content attendee joins the meeting.
```
Cannot read properties of null (reading 'getVideoTracks')
```
**Description of changes:**
Add an optional chaining to make sure the media stream still exists.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes,
1. Log in to the meeting demo
2. Type in the developer console
```
await app.meetingSession.audioVideo.startContentShareFromScreenCapture(); app.meetingSession.audioVideo.stopContentShare();
```
3. Verify that there is no error in the console.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

