### PR TITLE
repro startAudioInput bug

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -2827,9 +2827,22 @@ export class DemoMeetingApp
 
   async selectAudioInputDevice(device: AudioInputDevice): Promise<void> {
     this.currentAudioInputDevice = device;
-    this.log('Selecting audio input', device);
+
+    const audioStream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+    });
+    const audioTrack = await audioStream.getAudioTracks()[0];
+    this.log('Selecting audio input', audioTrack);
     try {
-      await this.audioVideo.startAudioInput(device);
+      if (audioTrack) {
+        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
+        await this.audioVideo?.stopAudioInput();
+        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
+        await this.audioVideo?.stopAudioInput();
+        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
+        await this.audioVideo?.stopAudioInput();
+        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
+      }
     } catch (e) {
       fatal(e);
       this.log(`failed to choose audio input device ${device}`, e);


### PR DESCRIPTION
Bug repro for https://github.com/aws/amazon-chime-sdk-js/issues/2709

When you call `startAudioInput` repeatedly with an audio stream, audio will fail to send (`audioSendingFailed`)

Run the browser demo, the following scenarios will cause `audioSendingFailed`:

1. Calling `startAudioInput` repeatedly with the same audio track but in a new media stream
```
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
```

2. Calling `startAudioInput` repeatedly with the same audio track but making sure to `stopAudioInput` before starting again
```
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(new MediaStream([audioTrack]));
```

3. Putting the track into the same media stream, ie:
```
        const stream = new MediaStream([audioTrack]);
        await this.audioVideo?.startAudioInput(stream);
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(stream);
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(stream);
        await this.audioVideo?.stopAudioInput();
        await this.audioVideo?.startAudioInput(stream);
```