### PR TITLE
Add audioUpstreamLevel and audioDownstreamLevel to ClientReportMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added recommendations to use server side network adaptation, and clarified support on all browsers. Removed demo features and information on network adaptation configuration that is not used when server side network adaptation is used.
 - Set `esModuleInterop` to `true` in tsconfig.json, and update several import statements.
 - Update documentation reference to chime-sdk.
+- Add RTC Speak/Mic Audio Level in proto file
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `esModuleInterop` to `true` in tsconfig.json, and update several import statements.
 - Update documentation reference to chime-sdk.
 - Add RTC Speak/Mic Audio Level in proto file
+- Add `audioUpstreamLevel`, `audioDownstreamLevel` to the `ClientMetricReport`
 
 ### Fixed
 

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -284,6 +284,8 @@ message SdkMetric {
         VIDEO_DECODE_WIDTH = 87;
         VIDEO_ENCODER_IS_HARDWARE = 88;
         VIDEO_DECODER_IS_HARDWARE = 89;
+        RTC_SPK_AUDIO_LEVEL = 96;
+        RTC_MIC_AUDIO_LEVEL = 97;
     }
     optional Type type = 1;
     optional double value = 2;

--- a/src/clientmetricreport/ClientMetricReport.ts
+++ b/src/clientmetricreport/ClientMetricReport.ts
@@ -197,6 +197,14 @@ export default class ClientMetricReport {
       transform: this.secondsToMilliseconds,
       type: SdkMetric.Type.STUN_RTT_MS,
     },
+    // Upstream AudioLevel is collected through RTCAudioSourceStats
+    // (https://developer.mozilla.org/en-US/docs/Web/API/RTCAudioSourceStats)
+    // That one doesn't have ssrc field so we must collect it through Global Metric Report
+    audioLevel: {
+      transform: this.identityValue,
+      type: SdkMetric.Type.RTC_MIC_AUDIO_LEVEL,
+      source: "audioLevel"
+    }
   };
 
   readonly audioUpstreamMetricMap: {
@@ -252,6 +260,7 @@ export default class ClientMetricReport {
       type: SdkMetric.Type.RTC_SPK_JITTER_BUFFER_MS,
     },
     bytesReceived: { transform: this.bitsPerSecond, type: SdkMetric.Type.RTC_SPK_BITRATE },
+    audioLevel: { transform: this.identityValue, type: SdkMetric.Type.RTC_SPK_AUDIO_LEVEL },
   };
 
   readonly videoUpstreamMetricMap: {
@@ -554,6 +563,14 @@ export default class ClientMetricReport {
     availableOutgoingBitrate: { source: 'availableOutgoingBitrate' },
     availableIncomingBitrate: { source: 'availableIncomingBitrate' },
     currentRoundTripTimeMs: { source: 'currentRoundTripTime' },
+    audioDownstreamLevel: {
+      source: 'audioLevel',
+      media: MediaType.AUDIO,
+      dir: Direction.DOWNSTREAM,
+    },
+    audioUpstreamLevel: {
+      source: 'audioLevel',
+    },
   };
 
   /**

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -2762,7 +2762,9 @@ export namespace SdkMetric {
         VIDEO_ENCODE_WIDTH = 86,
         VIDEO_DECODE_WIDTH = 87,
         VIDEO_ENCODER_IS_HARDWARE = 88,
-        VIDEO_DECODER_IS_HARDWARE = 89
+        VIDEO_DECODER_IS_HARDWARE = 89,
+        RTC_SPK_AUDIO_LEVEL = 96,
+        RTC_MIC_AUDIO_LEVEL = 97
     }
 }
 

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -7108,6 +7108,8 @@ $root.SdkMetric = (function() {
             case 87:
             case 88:
             case 89:
+            case 96:
+            case 97:
                 break;
             }
         if (message.value != null && message.hasOwnProperty("value"))
@@ -7357,6 +7359,14 @@ $root.SdkMetric = (function() {
         case 89:
             message.type = 89;
             break;
+        case "RTC_SPK_AUDIO_LEVEL":
+        case 96:
+            message.type = 96;
+            break;
+        case "RTC_MIC_AUDIO_LEVEL":
+        case 97:
+            message.type = 97;
+            break;
         }
         if (object.value != null)
             message.value = Number(object.value);
@@ -7459,6 +7469,8 @@ $root.SdkMetric = (function() {
      * @property {number} VIDEO_DECODE_WIDTH=87 VIDEO_DECODE_WIDTH value
      * @property {number} VIDEO_ENCODER_IS_HARDWARE=88 VIDEO_ENCODER_IS_HARDWARE value
      * @property {number} VIDEO_DECODER_IS_HARDWARE=89 VIDEO_DECODER_IS_HARDWARE value
+     * @property {number} RTC_SPK_AUDIO_LEVEL=96 RTC_SPK_AUDIO_LEVEL value
+     * @property {number} RTC_MIC_AUDIO_LEVEL=97 RTC_MIC_AUDIO_LEVEL value
      */
     SdkMetric.Type = (function() {
         var valuesById = {}, values = Object.create(valuesById);
@@ -7519,6 +7531,8 @@ $root.SdkMetric = (function() {
         values[valuesById[87] = "VIDEO_DECODE_WIDTH"] = 87;
         values[valuesById[88] = "VIDEO_ENCODER_IS_HARDWARE"] = 88;
         values[valuesById[89] = "VIDEO_DECODER_IS_HARDWARE"] = 89;
+        values[valuesById[96] = "RTC_SPK_AUDIO_LEVEL"] = 96;
+        values[valuesById[97] = "RTC_MIC_AUDIO_LEVEL"] = 97;
         return values;
     })();
 

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -457,7 +457,8 @@ export default class StatsCollector {
       rawMetricReport.type === 'outbound-rtp' ||
       rawMetricReport.type === 'remote-inbound-rtp' ||
       rawMetricReport.type === 'remote-outbound-rtp' ||
-      (rawMetricReport.type === 'candidate-pair' && rawMetricReport.state === 'succeeded')
+      (rawMetricReport.type === 'candidate-pair' && rawMetricReport.state === 'succeeded') ||
+      (rawMetricReport.type === 'media-source' && rawMetricReport.kind === 'audio')
     );
   }
 

--- a/test/clientmetricreport/ClientMetricReport.test.ts
+++ b/test/clientmetricreport/ClientMetricReport.test.ts
@@ -415,6 +415,7 @@ describe('ClientMetricReport', () => {
       it('returns the transformed metric from the global metric spec', () => {
         const report = new GlobalMetricReport();
         report.currentMetrics['availableIncomingBitrate'] = 10;
+        report.currentMetrics['audioLevel'] = 0.5;
         clientMetricReport.globalMetricReport = report;
 
         // Force setting "source" for the test coverage in case we are adding a new metric spec with "source".
@@ -422,6 +423,12 @@ describe('ClientMetricReport', () => {
           'availableIncomingBitrate';
         expect(clientMetricReport.getObservableMetricValue('availableIncomingBitrate')).to.equal(
           clientMetricReport.identityValue('availableIncomingBitrate')
+        );
+
+        clientMetricReport.globalMetricMap['audioLevel']['source'] =
+          'audioLevel';
+        expect(clientMetricReport.getObservableMetricValue('audioUpstreamLevel')).to.equal(
+          clientMetricReport.identityValue('audioLevel')
         );
       });
     });
@@ -517,7 +524,7 @@ describe('ClientMetricReport', () => {
   describe('getObservableMetrics', () => {
     it('returns the observable metrics as a JS object', () => {
       const metrics = clientMetricReport.getObservableMetrics();
-      expect(Object.keys(metrics).length).to.equal(15);
+      expect(Object.keys(metrics).length).to.equal(17);
     });
   });
 

--- a/test/statscollector/StatsCollector.test.ts
+++ b/test/statscollector/StatsCollector.test.ts
@@ -353,6 +353,12 @@ describe('StatsCollector', () => {
             type: 'remote-outbound-rtp',
           })
         ).to.be.true;
+        expect(
+          statsCollector.isValidStandardRawMetric({
+            type: 'media-source',
+            kind: 'audio',
+          })
+        ).to.be.true;
 
         statsCollector.stop();
       });


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
Add audioUpstreamLevel and audioDownstreamLevel to ClientMetricReport

**Testing:**
npm run build:release

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Add a console.log(metric) after line 630 of `ClientMetricReport.ts` file. Run the demo and see the new metrics has two new fields

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

