### PR TITLE
Invoke MediaStreamBrokerObservers in the next event loop tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump protobufjs from 6.11.3 to 7.2.4.
 - Fixed usage of `this` in `VideoCodecCapability` constructors.
 - Fixed a race condition error if calling `startContentShare` then `stopContentShare` right after.
+- Invoke MediaStreamBrokerObservers in the next event loop tick to prevent race conditions with the browser's `RTCRtpSender.replaceTrack` API call.
 
 ## [3.15.0] - 2023-05-01
 

--- a/docs/classes/defaultdevicecontroller.html
+++ b/docs/classes/defaultdevicecontroller.html
@@ -315,7 +315,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#addmediastreambrokerobserver">addMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1525">src/devicecontroller/DefaultDeviceController.ts:1525</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1530">src/devicecontroller/DefaultDeviceController.ts:1530</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -504,7 +504,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1383">src/devicecontroller/DefaultDeviceController.ts:1383</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1388">src/devicecontroller/DefaultDeviceController.ts:1388</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -690,7 +690,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/devicecontrollerbasedmediastreambroker.html">DeviceControllerBasedMediaStreamBroker</a>.<a href="../interfaces/devicecontrollerbasedmediastreambroker.html#removemediastreambrokerobserver">removeMediaStreamBrokerObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1529">src/devicecontroller/DefaultDeviceController.ts:1529</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1534">src/devicecontroller/DefaultDeviceController.ts:1534</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -961,7 +961,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1514">src/devicecontroller/DefaultDeviceController.ts:1514</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1519">src/devicecontroller/DefaultDeviceController.ts:1519</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -995,7 +995,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1494">src/devicecontroller/DefaultDeviceController.ts:1494</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1499">src/devicecontroller/DefaultDeviceController.ts:1499</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1042,7 +1042,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1485">src/devicecontroller/DefaultDeviceController.ts:1485</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/devicecontroller/DefaultDeviceController.ts#L1490">src/devicecontroller/DefaultDeviceController.ts:1490</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/devicecontroller/DefaultDeviceController.ts
+++ b/src/devicecontroller/DefaultDeviceController.ts
@@ -931,7 +931,12 @@ export default class DefaultDeviceController
     observerFunc: (obsever: MediaStreamBrokerObserver) => void
   ): void {
     for (const observer of this.mediaStreamBrokerObservers) {
-      observerFunc(observer);
+      AsyncScheduler.nextTick(() => {
+        /* istanbul ignore else */
+        if (this.mediaStreamBrokerObservers.has(observer)) {
+          observerFunc(observer);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
**Issue #:**
https://github.com/aws/amazon-chime-sdk-js/issues/2709

**Conditions to occur:**

Whenever there's a change in the audio input, the SDK calls the `RTCRtpSender: replaceTrack` API in the browser to swap out the track that's currently in use.

1. Join a meeting with Web Audio disabled.
1. Call `startAudioInput` with a new audio input.
   - Reusing the existing microphone is okay.
1. In the same JavaScript code block, call `startVideoInput` with the `MediaStream` object.
   - Calling it with a non-`MediaStream` object is okay.
1. In the same JavaScript code block, call `startLocalVideoInput`.
   - Calling it after a 0 ms delay is okay. JavaScript executes the code in the next cycle.

**Root cause:**

If the above conditions are satisfied, the SDK attempts to call the `RTCRtpSender: replaceTrack` API twice.
1. At the end of the `startAudioInput` API.
2. During the update action triggered by the `startLocalVideoTile` API.

The SDK should call the `RTCRtpSender: replaceTrack` in sequence, first in (1) followed by (2). However, in the stated conditions, step (2) happens after step (1).

**Description of changes:**
- Invoke MediaStreamBrokerObservers in the next event loop tick to fix the root cause.

**Testing:**

1. Assume that you have at least one microphone and camera configured in your system.
2. Open the [Chime SDK Serverless Demo](https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/serverless) in your browser.
3. Create and join a Chime SDK meeting.
4. Open the browser console and execute the following code:
    ```js
    (async () => {
      const stream = await navigator.mediaDevices.getUserMedia({
        audio: true,
        video: true,
      });
      
      const audioTracks = stream.getAudioTracks();
      const audioTrack = audioTracks[0];
      
      const videoTracks = stream.getVideoTracks();
      const videoTrack = videoTracks[0];

      // Start audio!
      const audioStream = new MediaStream([audioTrack]);
      await app.audioVideo.startAudioInput(audioStream);

      // Start video!
      const videoStream = new MediaStream([videoTrack]);
      await app.audioVideo.startVideoInput(videoStream);
      app.audioVideo.startLocalVideoTile();
    })();
    ```
1. Ensure that the Chime SDK does not display the **SendingAudioFailed** event in the browser console. Other attendees should not have any issues hearing and seeing you.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Yes. See the **Testing** section.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No.

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

