### PR TITLE
Receive notification messages from server and print received messages to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow receiving notification messages from server and print messages received to console
+
 ### Removed
 
 ### Changed

--- a/docs/classes/monitortask.html
+++ b/docs/classes/monitortask.html
@@ -141,7 +141,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L49">src/task/MonitorTask.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L53">src/task/MonitorTask.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L35">src/task/MonitorTask.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L39">src/task/MonitorTask.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstart">audioVideoDidStart</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L265">src/task/MonitorTask.ts:265</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L269">src/task/MonitorTask.ts:269</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -219,7 +219,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstartconnecting">audioVideoDidStartConnecting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L270">src/task/MonitorTask.ts:270</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L274">src/task/MonitorTask.ts:274</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -248,7 +248,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstop">audioVideoDidStop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L276">src/task/MonitorTask.ts:276</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L280">src/task/MonitorTask.ts:280</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -306,7 +306,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#connectionhealthdidchange">connectionHealthDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L211">src/task/MonitorTask.ts:211</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L215">src/task/MonitorTask.ts:215</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -353,7 +353,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/signalingclientobserver.html">SignalingClientObserver</a>.<a href="../interfaces/signalingclientobserver.html#handlesignalingclientevent">handleSignalingClientEvent</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L316">src/task/MonitorTask.ts:316</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L320">src/task/MonitorTask.ts:320</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -406,7 +406,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#metricsdidreceive">metricsDidReceive</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L185">src/task/MonitorTask.ts:185</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L189">src/task/MonitorTask.ts:189</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -481,7 +481,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L103">src/task/MonitorTask.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L107">src/task/MonitorTask.ts:107</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -499,7 +499,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/removableobserver.html">RemovableObserver</a>.<a href="../interfaces/removableobserver.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L73">src/task/MonitorTask.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L77">src/task/MonitorTask.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -521,7 +521,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L107">src/task/MonitorTask.ts:107</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L111">src/task/MonitorTask.ts:111</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -539,7 +539,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L87">src/task/MonitorTask.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L91">src/task/MonitorTask.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -594,7 +594,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#videotiledidupdate">videoTileDidUpdate</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L121">src/task/MonitorTask.ts:121</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/MonitorTask.ts#L125">src/task/MonitorTask.ts:125</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/protocol/SignalingProtocol.proto
+++ b/protocol/SignalingProtocol.proto
@@ -26,6 +26,7 @@ message SdkSignalFrame {
         PRIMARY_MEETING_JOIN = 25;
         PRIMARY_MEETING_JOIN_ACK = 26;
         PRIMARY_MEETING_LEAVE = 27;
+        NOTIFICATION = 34;
     }
     required uint64 timestamp_ms = 1;
     required Type type = 2;
@@ -50,6 +51,7 @@ message SdkSignalFrame {
     optional SdkPrimaryMeetingJoinFrame primary_meeting_join = 26;
     optional SdkPrimaryMeetingJoinAckFrame primary_meeting_join_ack = 27;
     optional SdkPrimaryMeetingLeaveFrame primary_meeting_leave = 28;
+    optional SdkNotificationFrame notification = 35;
 }
 
 message SdkErrorFrame {
@@ -428,6 +430,16 @@ message SdkVideoSubscriptionConfiguration {
     optional uint32 priority = 4;
     optional uint32 target_bitrate_kbps = 5;
     optional uint32 group_id = 6;
+}
+
+message SdkNotificationFrame {
+    enum NotificationLevel {
+        INFO = 1;
+        WARNING = 2;
+        ERROR = 3;
+    }
+    optional NotificationLevel level = 1 [default=ERROR];
+    optional string message = 2;
 }
 
 message SdkPrimaryMeetingJoinFrame {

--- a/src/signalingprotocol/SignalingProtocol.d.ts
+++ b/src/signalingprotocol/SignalingProtocol.d.ts
@@ -71,6 +71,9 @@ export interface ISdkSignalFrame {
 
     /** SdkSignalFrame primaryMeetingLeave */
     primaryMeetingLeave?: (ISdkPrimaryMeetingLeaveFrame|null);
+
+    /** SdkSignalFrame notification */
+    notification?: (ISdkNotificationFrame|null);
 }
 
 /** Represents a SdkSignalFrame. */
@@ -150,6 +153,9 @@ export class SdkSignalFrame implements ISdkSignalFrame {
 
     /** SdkSignalFrame primaryMeetingLeave. */
     public primaryMeetingLeave?: (ISdkPrimaryMeetingLeaveFrame|null);
+
+    /** SdkSignalFrame notification. */
+    public notification?: (ISdkNotificationFrame|null);
 
     /**
      * Creates a new SdkSignalFrame instance using the specified properties.
@@ -246,7 +252,8 @@ export namespace SdkSignalFrame {
         REMOTE_VIDEO_UPDATE = 24,
         PRIMARY_MEETING_JOIN = 25,
         PRIMARY_MEETING_JOIN_ACK = 26,
-        PRIMARY_MEETING_LEAVE = 27
+        PRIMARY_MEETING_LEAVE = 27,
+        NOTIFICATION = 34
     }
 }
 
@@ -4713,6 +4720,112 @@ export class SdkVideoSubscriptionConfiguration implements ISdkVideoSubscriptionC
      * @returns JSON object
      */
     public toJSON(): { [k: string]: any };
+}
+
+/** Properties of a SdkNotificationFrame. */
+export interface ISdkNotificationFrame {
+
+    /** SdkNotificationFrame level */
+    level?: (SdkNotificationFrame.NotificationLevel|null);
+
+    /** SdkNotificationFrame message */
+    message?: (string|null);
+}
+
+/** Represents a SdkNotificationFrame. */
+export class SdkNotificationFrame implements ISdkNotificationFrame {
+
+    /**
+     * Constructs a new SdkNotificationFrame.
+     * @param [properties] Properties to set
+     */
+    constructor(properties?: ISdkNotificationFrame);
+
+    /** SdkNotificationFrame level. */
+    public level: SdkNotificationFrame.NotificationLevel;
+
+    /** SdkNotificationFrame message. */
+    public message: string;
+
+    /**
+     * Creates a new SdkNotificationFrame instance using the specified properties.
+     * @param [properties] Properties to set
+     * @returns SdkNotificationFrame instance
+     */
+    public static create(properties?: ISdkNotificationFrame): SdkNotificationFrame;
+
+    /**
+     * Encodes the specified SdkNotificationFrame message. Does not implicitly {@link SdkNotificationFrame.verify|verify} messages.
+     * @param message SdkNotificationFrame message or plain object to encode
+     * @param [writer] Writer to encode to
+     * @returns Writer
+     */
+    public static encode(message: ISdkNotificationFrame, writer?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Encodes the specified SdkNotificationFrame message, length delimited. Does not implicitly {@link SdkNotificationFrame.verify|verify} messages.
+     * @param message SdkNotificationFrame message or plain object to encode
+     * @param [writer] Writer to encode to
+     * @returns Writer
+     */
+    public static encodeDelimited(message: ISdkNotificationFrame, writer?: $protobuf.Writer): $protobuf.Writer;
+
+    /**
+     * Decodes a SdkNotificationFrame message from the specified reader or buffer.
+     * @param reader Reader or buffer to decode from
+     * @param [length] Message length if known beforehand
+     * @returns SdkNotificationFrame
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): SdkNotificationFrame;
+
+    /**
+     * Decodes a SdkNotificationFrame message from the specified reader or buffer, length delimited.
+     * @param reader Reader or buffer to decode from
+     * @returns SdkNotificationFrame
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): SdkNotificationFrame;
+
+    /**
+     * Verifies a SdkNotificationFrame message.
+     * @param message Plain object to verify
+     * @returns `null` if valid, otherwise the reason why it is not
+     */
+    public static verify(message: { [k: string]: any }): (string|null);
+
+    /**
+     * Creates a SdkNotificationFrame message from a plain object. Also converts values to their respective internal types.
+     * @param object Plain object
+     * @returns SdkNotificationFrame
+     */
+    public static fromObject(object: { [k: string]: any }): SdkNotificationFrame;
+
+    /**
+     * Creates a plain object from a SdkNotificationFrame message. Also converts values to other types if specified.
+     * @param message SdkNotificationFrame
+     * @param [options] Conversion options
+     * @returns Plain object
+     */
+    public static toObject(message: SdkNotificationFrame, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+    /**
+     * Converts this SdkNotificationFrame to JSON.
+     * @returns JSON object
+     */
+    public toJSON(): { [k: string]: any };
+}
+
+export namespace SdkNotificationFrame {
+
+    /** NotificationLevel enum. */
+    enum NotificationLevel {
+        INFO = 1,
+        WARNING = 2,
+        ERROR = 3
+    }
 }
 
 /** Properties of a SdkPrimaryMeetingJoinFrame. */

--- a/src/signalingprotocol/SignalingProtocol.js
+++ b/src/signalingprotocol/SignalingProtocol.js
@@ -38,6 +38,7 @@ $root.SdkSignalFrame = (function() {
      * @property {ISdkPrimaryMeetingJoinFrame|null} [primaryMeetingJoin] SdkSignalFrame primaryMeetingJoin
      * @property {ISdkPrimaryMeetingJoinAckFrame|null} [primaryMeetingJoinAck] SdkSignalFrame primaryMeetingJoinAck
      * @property {ISdkPrimaryMeetingLeaveFrame|null} [primaryMeetingLeave] SdkSignalFrame primaryMeetingLeave
+     * @property {ISdkNotificationFrame|null} [notification] SdkSignalFrame notification
      */
 
     /**
@@ -240,6 +241,14 @@ $root.SdkSignalFrame = (function() {
     SdkSignalFrame.prototype.primaryMeetingLeave = null;
 
     /**
+     * SdkSignalFrame notification.
+     * @member {ISdkNotificationFrame|null|undefined} notification
+     * @memberof SdkSignalFrame
+     * @instance
+     */
+    SdkSignalFrame.prototype.notification = null;
+
+    /**
      * Creates a new SdkSignalFrame instance using the specified properties.
      * @function create
      * @memberof SdkSignalFrame
@@ -307,6 +316,8 @@ $root.SdkSignalFrame = (function() {
             $root.SdkPrimaryMeetingJoinAckFrame.encode(message.primaryMeetingJoinAck, writer.uint32(/* id 27, wireType 2 =*/218).fork()).ldelim();
         if (message.primaryMeetingLeave != null && Object.hasOwnProperty.call(message, "primaryMeetingLeave"))
             $root.SdkPrimaryMeetingLeaveFrame.encode(message.primaryMeetingLeave, writer.uint32(/* id 28, wireType 2 =*/226).fork()).ldelim();
+        if (message.notification != null && Object.hasOwnProperty.call(message, "notification"))
+            $root.SdkNotificationFrame.encode(message.notification, writer.uint32(/* id 35, wireType 2 =*/282).fork()).ldelim();
         return writer;
     };
 
@@ -410,6 +421,9 @@ $root.SdkSignalFrame = (function() {
             case 28:
                 message.primaryMeetingLeave = $root.SdkPrimaryMeetingLeaveFrame.decode(reader, reader.uint32());
                 break;
+            case 35:
+                message.notification = $root.SdkNotificationFrame.decode(reader, reader.uint32());
+                break;
             default:
                 reader.skipType(tag & 7);
                 break;
@@ -475,6 +489,7 @@ $root.SdkSignalFrame = (function() {
         case 25:
         case 26:
         case 27:
+        case 34:
             break;
         }
         if (message.error != null && message.hasOwnProperty("error")) {
@@ -581,6 +596,11 @@ $root.SdkSignalFrame = (function() {
             var error = $root.SdkPrimaryMeetingLeaveFrame.verify(message.primaryMeetingLeave);
             if (error)
                 return "primaryMeetingLeave." + error;
+        }
+        if (message.notification != null && message.hasOwnProperty("notification")) {
+            var error = $root.SdkNotificationFrame.verify(message.notification);
+            if (error)
+                return "notification." + error;
         }
         return null;
     };
@@ -691,6 +711,10 @@ $root.SdkSignalFrame = (function() {
         case 27:
             message.type = 27;
             break;
+        case "NOTIFICATION":
+        case 34:
+            message.type = 34;
+            break;
         }
         if (object.error != null) {
             if (typeof object.error !== "object")
@@ -797,6 +821,11 @@ $root.SdkSignalFrame = (function() {
                 throw TypeError(".SdkSignalFrame.primaryMeetingLeave: object expected");
             message.primaryMeetingLeave = $root.SdkPrimaryMeetingLeaveFrame.fromObject(object.primaryMeetingLeave);
         }
+        if (object.notification != null) {
+            if (typeof object.notification !== "object")
+                throw TypeError(".SdkSignalFrame.notification: object expected");
+            message.notification = $root.SdkNotificationFrame.fromObject(object.notification);
+        }
         return message;
     };
 
@@ -841,6 +870,7 @@ $root.SdkSignalFrame = (function() {
             object.primaryMeetingJoin = null;
             object.primaryMeetingJoinAck = null;
             object.primaryMeetingLeave = null;
+            object.notification = null;
         }
         if (message.timestampMs != null && message.hasOwnProperty("timestampMs"))
             if (typeof message.timestampMs === "number")
@@ -891,6 +921,8 @@ $root.SdkSignalFrame = (function() {
             object.primaryMeetingJoinAck = $root.SdkPrimaryMeetingJoinAckFrame.toObject(message.primaryMeetingJoinAck, options);
         if (message.primaryMeetingLeave != null && message.hasOwnProperty("primaryMeetingLeave"))
             object.primaryMeetingLeave = $root.SdkPrimaryMeetingLeaveFrame.toObject(message.primaryMeetingLeave, options);
+        if (message.notification != null && message.hasOwnProperty("notification"))
+            object.notification = $root.SdkNotificationFrame.toObject(message.notification, options);
         return object;
     };
 
@@ -930,6 +962,7 @@ $root.SdkSignalFrame = (function() {
      * @property {number} PRIMARY_MEETING_JOIN=25 PRIMARY_MEETING_JOIN value
      * @property {number} PRIMARY_MEETING_JOIN_ACK=26 PRIMARY_MEETING_JOIN_ACK value
      * @property {number} PRIMARY_MEETING_LEAVE=27 PRIMARY_MEETING_LEAVE value
+     * @property {number} NOTIFICATION=34 NOTIFICATION value
      */
     SdkSignalFrame.Type = (function() {
         var valuesById = {}, values = Object.create(valuesById);
@@ -954,6 +987,7 @@ $root.SdkSignalFrame = (function() {
         values[valuesById[25] = "PRIMARY_MEETING_JOIN"] = 25;
         values[valuesById[26] = "PRIMARY_MEETING_JOIN_ACK"] = 26;
         values[valuesById[27] = "PRIMARY_MEETING_LEAVE"] = 27;
+        values[valuesById[34] = "NOTIFICATION"] = 34;
         return values;
     })();
 
@@ -12563,6 +12597,250 @@ $root.SdkVideoSubscriptionConfiguration = (function() {
     };
 
     return SdkVideoSubscriptionConfiguration;
+})();
+
+$root.SdkNotificationFrame = (function() {
+
+    /**
+     * Properties of a SdkNotificationFrame.
+     * @exports ISdkNotificationFrame
+     * @interface ISdkNotificationFrame
+     * @property {SdkNotificationFrame.NotificationLevel|null} [level] SdkNotificationFrame level
+     * @property {string|null} [message] SdkNotificationFrame message
+     */
+
+    /**
+     * Constructs a new SdkNotificationFrame.
+     * @exports SdkNotificationFrame
+     * @classdesc Represents a SdkNotificationFrame.
+     * @implements ISdkNotificationFrame
+     * @constructor
+     * @param {ISdkNotificationFrame=} [properties] Properties to set
+     */
+    function SdkNotificationFrame(properties) {
+        if (properties)
+            for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                if (properties[keys[i]] != null)
+                    this[keys[i]] = properties[keys[i]];
+    }
+
+    /**
+     * SdkNotificationFrame level.
+     * @member {SdkNotificationFrame.NotificationLevel} level
+     * @memberof SdkNotificationFrame
+     * @instance
+     */
+    SdkNotificationFrame.prototype.level = 3;
+
+    /**
+     * SdkNotificationFrame message.
+     * @member {string} message
+     * @memberof SdkNotificationFrame
+     * @instance
+     */
+    SdkNotificationFrame.prototype.message = "";
+
+    /**
+     * Creates a new SdkNotificationFrame instance using the specified properties.
+     * @function create
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {ISdkNotificationFrame=} [properties] Properties to set
+     * @returns {SdkNotificationFrame} SdkNotificationFrame instance
+     */
+    SdkNotificationFrame.create = function create(properties) {
+        return new SdkNotificationFrame(properties);
+    };
+
+    /**
+     * Encodes the specified SdkNotificationFrame message. Does not implicitly {@link SdkNotificationFrame.verify|verify} messages.
+     * @function encode
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {ISdkNotificationFrame} message SdkNotificationFrame message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SdkNotificationFrame.encode = function encode(message, writer) {
+        if (!writer)
+            writer = $Writer.create();
+        if (message.level != null && Object.hasOwnProperty.call(message, "level"))
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.level);
+        if (message.message != null && Object.hasOwnProperty.call(message, "message"))
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.message);
+        return writer;
+    };
+
+    /**
+     * Encodes the specified SdkNotificationFrame message, length delimited. Does not implicitly {@link SdkNotificationFrame.verify|verify} messages.
+     * @function encodeDelimited
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {ISdkNotificationFrame} message SdkNotificationFrame message or plain object to encode
+     * @param {$protobuf.Writer} [writer] Writer to encode to
+     * @returns {$protobuf.Writer} Writer
+     */
+    SdkNotificationFrame.encodeDelimited = function encodeDelimited(message, writer) {
+        return this.encode(message, writer).ldelim();
+    };
+
+    /**
+     * Decodes a SdkNotificationFrame message from the specified reader or buffer.
+     * @function decode
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @param {number} [length] Message length if known beforehand
+     * @returns {SdkNotificationFrame} SdkNotificationFrame
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SdkNotificationFrame.decode = function decode(reader, length) {
+        if (!(reader instanceof $Reader))
+            reader = $Reader.create(reader);
+        var end = length === undefined ? reader.len : reader.pos + length, message = new $root.SdkNotificationFrame();
+        while (reader.pos < end) {
+            var tag = reader.uint32();
+            switch (tag >>> 3) {
+            case 1:
+                message.level = reader.int32();
+                break;
+            case 2:
+                message.message = reader.string();
+                break;
+            default:
+                reader.skipType(tag & 7);
+                break;
+            }
+        }
+        return message;
+    };
+
+    /**
+     * Decodes a SdkNotificationFrame message from the specified reader or buffer, length delimited.
+     * @function decodeDelimited
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+     * @returns {SdkNotificationFrame} SdkNotificationFrame
+     * @throws {Error} If the payload is not a reader or valid buffer
+     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+     */
+    SdkNotificationFrame.decodeDelimited = function decodeDelimited(reader) {
+        if (!(reader instanceof $Reader))
+            reader = new $Reader(reader);
+        return this.decode(reader, reader.uint32());
+    };
+
+    /**
+     * Verifies a SdkNotificationFrame message.
+     * @function verify
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {Object.<string,*>} message Plain object to verify
+     * @returns {string|null} `null` if valid, otherwise the reason why it is not
+     */
+    SdkNotificationFrame.verify = function verify(message) {
+        if (typeof message !== "object" || message === null)
+            return "object expected";
+        if (message.level != null && message.hasOwnProperty("level"))
+            switch (message.level) {
+            default:
+                return "level: enum value expected";
+            case 1:
+            case 2:
+            case 3:
+                break;
+            }
+        if (message.message != null && message.hasOwnProperty("message"))
+            if (!$util.isString(message.message))
+                return "message: string expected";
+        return null;
+    };
+
+    /**
+     * Creates a SdkNotificationFrame message from a plain object. Also converts values to their respective internal types.
+     * @function fromObject
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {Object.<string,*>} object Plain object
+     * @returns {SdkNotificationFrame} SdkNotificationFrame
+     */
+    SdkNotificationFrame.fromObject = function fromObject(object) {
+        if (object instanceof $root.SdkNotificationFrame)
+            return object;
+        var message = new $root.SdkNotificationFrame();
+        switch (object.level) {
+        case "INFO":
+        case 1:
+            message.level = 1;
+            break;
+        case "WARNING":
+        case 2:
+            message.level = 2;
+            break;
+        case "ERROR":
+        case 3:
+            message.level = 3;
+            break;
+        }
+        if (object.message != null)
+            message.message = String(object.message);
+        return message;
+    };
+
+    /**
+     * Creates a plain object from a SdkNotificationFrame message. Also converts values to other types if specified.
+     * @function toObject
+     * @memberof SdkNotificationFrame
+     * @static
+     * @param {SdkNotificationFrame} message SdkNotificationFrame
+     * @param {$protobuf.IConversionOptions} [options] Conversion options
+     * @returns {Object.<string,*>} Plain object
+     */
+    SdkNotificationFrame.toObject = function toObject(message, options) {
+        if (!options)
+            options = {};
+        var object = {};
+        if (options.defaults) {
+            object.level = options.enums === String ? "ERROR" : 3;
+            object.message = "";
+        }
+        if (message.level != null && message.hasOwnProperty("level"))
+            object.level = options.enums === String ? $root.SdkNotificationFrame.NotificationLevel[message.level] : message.level;
+        if (message.message != null && message.hasOwnProperty("message"))
+            object.message = message.message;
+        return object;
+    };
+
+    /**
+     * Converts this SdkNotificationFrame to JSON.
+     * @function toJSON
+     * @memberof SdkNotificationFrame
+     * @instance
+     * @returns {Object.<string,*>} JSON object
+     */
+    SdkNotificationFrame.prototype.toJSON = function toJSON() {
+        return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+    };
+
+    /**
+     * NotificationLevel enum.
+     * @name SdkNotificationFrame.NotificationLevel
+     * @enum {number}
+     * @property {number} INFO=1 INFO value
+     * @property {number} WARNING=2 WARNING value
+     * @property {number} ERROR=3 ERROR value
+     */
+    SdkNotificationFrame.NotificationLevel = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[1] = "INFO"] = 1;
+        values[valuesById[2] = "WARNING"] = 2;
+        values[valuesById[3] = "ERROR"] = 3;
+        return values;
+    })();
+
+    return SdkNotificationFrame;
 })();
 
 $root.SdkPrimaryMeetingJoinFrame = (function() {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Receive notification messages from server and print received messages to console.

**Testing:**
Added unit tests and smoke tested to verify messages are received and printed correctly.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
This requires server side to send messages. Currently, server-side message sending is not enabled, so not testable in demo application.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

