### PR TITLE
Allow updating of attendee capabilities in the demo

### DIFF
--- a/demos/browser/app/meetingV2/component/Roster.ts
+++ b/demos/browser/app/meetingV2/component/Roster.ts
@@ -1,17 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  DefaultModality
+} from 'amazon-chime-sdk-js';
+
 class Attendee {
-    name : string;
-    id : string;
+    name: string;
+    id: string;
     muted: boolean;
     signalStrength: number;
     speaking: boolean;
+    isContentAttendee: boolean;
 
-    constructor(name: string, id: string) {
+    constructor(id: string, name: string) {
+        this.id = id;
         this.name = name;
-        this.id = name;
         this.signalStrength = 1;
+        this.isContentAttendee = new DefaultModality(id).hasModality(
+           DefaultModality.MODALITY_CONTENT
+        );
     }
 }
 
@@ -24,6 +32,8 @@ export default class Roster {
     static readonly CONTAINER_ID = 'roster';
 
     attendeeInfoMap: Map<string, Attendee> = new Map<string, Attendee>();   
+    
+    selectedAttendeeSet = new Set<Attendee>();
 
     /**
      * Returns a boolean indicating if the attendeeId is part of the roster or not.
@@ -49,7 +59,7 @@ export default class Roster {
      * @param attendeeId - the id to be associated with the attendee
      * @param attendeeName - the name of the attendee
      */
-    addAttendee(attendeeId: string, attendeeName: string): void {
+    addAttendee(attendeeId: string, attendeeName: string, allowAttendeeCapabilities: boolean): void {
         if (this.hasAttendee(attendeeId)) {
             return;
         }
@@ -60,14 +70,32 @@ export default class Roster {
         const attendeeElement : HTMLLIElement = document.createElement('li') as HTMLLIElement;
         const attendeeNameElement: HTMLSpanElement = document.createElement('span') as HTMLSpanElement;
         const attendeeStatusElement: HTMLSpanElement = document.createElement('span') as HTMLSpanElement;
+        const attendeeCheckbox: HTMLInputElement = document.createElement('input') as HTMLInputElement;
 
-        attendeeNameElement.className = 'name';
+        // For the content attendee, set it to invisible to maintain the layout.
+        attendeeCheckbox.className = 'roster-checkbox form-check-input m-0 flex-shrink-0 ' + (attendee.isContentAttendee ? ' invisible' : '');
+        attendeeCheckbox.type = 'checkbox';
+        attendeeCheckbox.value = '';
+        attendeeCheckbox.addEventListener('change', () => {
+            if (attendeeCheckbox.checked) {
+                this.selectedAttendeeSet.add(attendee);
+            } else {
+                this.selectedAttendeeSet.delete(attendee);
+            }
+            this.updateRosterMenu();
+        });
+        
+        attendeeNameElement.className = 'name flex-grow-1 text-truncate';
         attendeeNameElement.innerText = attendeeName;
-
+        
         attendeeStatusElement.className = 'status';
-
-        attendeeElement.className = 'list-group-item d-flex justify-content-between align-items-center';
+        
+        attendeeElement.className = 'list-group-item d-flex align-items-center gap-2';
         attendeeElement.id = Roster.ATTENDEE_ELEMENT_PREFIX + attendeeId;
+        if (allowAttendeeCapabilities) {
+            attendeeElement.classList.add('ps-2');
+            attendeeElement.appendChild(attendeeCheckbox);
+        }
         attendeeElement.appendChild(attendeeNameElement);
         attendeeElement.appendChild(attendeeStatusElement);
 
@@ -91,6 +119,9 @@ export default class Roster {
         const containerElement: HTMLUListElement = this.getContainerElement();
         const childToDelete = document.getElementById(Roster.ATTENDEE_ELEMENT_PREFIX + attendeeId) as HTMLLIElement;
         containerElement.removeChild(childToDelete);
+
+        this.selectedAttendeeSet.delete(this.attendeeInfoMap.get(attendeeId));
+        this.updateRosterMenu();
 
         this.attendeeInfoMap.delete(attendeeId);
         return true;
@@ -145,6 +176,16 @@ export default class Roster {
         const container: HTMLUListElement = this.getContainerElement();
         container.innerHTML = "";
         this.attendeeInfoMap.clear();
+
+        this.unselectAll();
+    }
+
+    unselectAll() {
+        this.selectedAttendeeSet.clear();
+        this.updateRosterMenu();
+        for (const checkboxElement of (Array.from(document.getElementsByClassName('roster-checkbox')) as HTMLInputElement[])) {
+            checkboxElement.checked = false;
+        }
     }
 
     private getContainerElement(): HTMLUListElement {
@@ -172,5 +213,42 @@ export default class Roster {
         
         attendeeStatusElement.className = statusClass;
         attendeeStatusElement.innerText = statusText;
+    }
+
+    private updateRosterMenu(): void {
+        const instruction = document.getElementById('roster-menu-instruction');
+        const rosterMenuOneAttendee = document.getElementById('roster-menu-one-attendee');
+        const rosterMenuNoneSelected = document.getElementById('roster-menu-none-seleced');
+        const rosterMenuAllAttendeesExcept = document.getElementById('roster-menu-all-attendees-except');
+        const rosterMenuAllAttendeesExceptLabel = document.getElementById('roster-menu-all-attendees-except-label');
+
+        const size = this.selectedAttendeeSet.size;
+        if (size > 0) {
+            instruction.innerText = `${size} selected`;
+            rosterMenuNoneSelected.classList.add('hidden');
+            rosterMenuAllAttendeesExceptLabel.innerText = `Update all attendees, except ${size} selected`;
+
+            if (size === 1) {
+                // If one attendee is selected, provide two options:
+                // - Update one attendee only, using the update-attendee-capabilities API
+                // - Update all attendees, except the selected one, using the batch-update-attendee-capabilities-except API
+                rosterMenuOneAttendee.classList.remove('hidden');
+                rosterMenuAllAttendeesExcept.classList.remove('hidden');
+            } else if (size > 1) {
+                // If multiple attendees are selected, provide the following option:
+                // - Update all attendees, except the selected one, using the batch-update-attendee-capabilities-except API
+                rosterMenuOneAttendee.classList.add('hidden');
+                rosterMenuAllAttendeesExcept.classList.remove('hidden');
+            }
+        } else {
+            instruction.innerText = '';
+            rosterMenuAllAttendeesExceptLabel.innerText = `Update all attendees`;
+
+            // If none are selected, show the instruction.
+            rosterMenuNoneSelected.classList.remove('hidden');
+            rosterMenuOneAttendee.classList.add('hidden');
+            rosterMenuAllAttendeesExcept.classList.add('hidden');
+        }
+
     }
 }

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -116,6 +116,33 @@
             </select>
             <label for="videoCodec"  style="text-align: left;">Preferred Video Send Codec:</label>
           </div>
+          <div class="form-floating mb-3">
+            <select name="audioCapability" class="form-select" id="audioCapabilitySelect">
+              <option value="SendReceive">SendReceive</option>
+              <option value="Send">Send</option>
+              <option value="Receive">Receive</option>
+              <option value="None">None</option>
+            </select>
+            <label for="audioCapability"  style="text-align: left;">Audio capability:</label>
+          </div>
+          <div class="form-floating mb-3">
+            <select name="videoCapability" class="form-select" id="videoCapabilitySelect">
+              <option value="SendReceive">SendReceive</option>
+              <option value="Send">Send</option>
+              <option value="Receive">Receive</option>
+              <option value="None">None</option>
+            </select>
+            <label for="videoCapability"  style="text-align: left;">Video capability:</label>
+          </div>
+          <div class="form-floating mb-3">
+            <select name="contentCapability" class="form-select" id="contentCapabilitySelect">
+              <option value="SendReceive">SendReceive</option>
+              <option value="Send">Send</option>
+              <option value="Receive">Receive</option>
+              <option value="None">None</option>
+            </select>
+            <label for="contentCapability"  style="text-align: left;">Content capability:</label>
+          </div>
           <div class="form-check" style="text-align: left;">
             <input type="checkbox" id="join-muted" class="form-check-input"></input>
             <label for="join-muted-setting" class="form-check-label">Join Muted</label>
@@ -198,6 +225,10 @@
           <div class="form-check" style="text-align: left;">
             <input type="checkbox" id="disable-content-keyframe" class="form-check-input">
             <label for="disable-content-keyframe" class="form-check-label">Disable periodic keyframe request to content senders</label>
+          </div>
+          <div class="form-check" style="text-align: left;">
+            <input type="checkbox" id="allow-attendee-capabilities" class="form-check-input">
+            <label for="allow-attendee-capabilities" class="form-check-label">Allow updating of attendee capabilities after start</label>
           </div>
           <div class="form-check" style="text-align: left;">
             <input type="checkbox" id="die" class="form-check-input" checked=true>
@@ -749,6 +780,47 @@
     </div>
     <div id="roster-tile-container" class="row flex-sm-grow-1 overflow-hidden h-100" style="flex: unset;">
       <div id="roster-message-container" class="d-flex flex-column col-12 col-sm-5 col-md-4 col-lg-3 h-100">
+        <div id="roster-menu-container" class="justify-content-end py-2 gap-3" style="flex: 0 0 auto; border-color: transparent !important;">
+          <div id="roster-menu-instruction" class="d-flex align-items-center"></div>
+          <div class="btn-group">
+            <button class="btn btn-sm dropdown-toggle btn-outline-secondary" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <%= require('../../node_modules/open-iconic/svg/ellipses.svg') %>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-start">
+              <li class="px-3 text-nowrap user-select-none">Attendee capabilities</li>
+              <li><hr class="dropdown-divider"></li>
+              <li id="roster-menu-none-seleced">
+                <div class="px-3 text-nowrap text-muted">Select one or more attendees to update.</div>
+              </li>
+              <li id="roster-menu-one-attendee" class="hidden">
+                <button
+                  class="dropdown-item"
+                  type="button"
+                  data-bs-target="#attendee-capabilities-modal"
+                  data-bs-toggle="modal"
+                  data-bs-type="one-attendee">
+                  <div class="me-2 d-inline-block" style="transform: scale(0.75);">
+                    <%= require('../../node_modules/open-iconic/svg/person.svg') %>
+                  </div>
+                  <span>Update the selected attendee</span>
+                </button>
+              </li>
+              <li id="roster-menu-all-attendees-except" class="hidden">
+                <button
+                  class="dropdown-item"
+                  type="button"
+                  data-bs-target="#attendee-capabilities-modal"
+                  data-bs-toggle="modal"
+                  data-bs-type="all-attendees-except">
+                  <div class="me-2 d-inline-block" style="transform: scale(0.75);">
+                    <%= require('../../node_modules/open-iconic/svg/people.svg') %>
+                  </div>
+                  <span id="roster-menu-all-attendees-except-label"></span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
         <div class="bs-component" style="flex: 1 1 auto; overflow-y: auto; height: 50%;">
           <ul id="roster" class="list-group"></ul>
         </div>
@@ -871,5 +943,53 @@
     </form>
   </div>
 </div>
+
+<!-- Attendee capabilities modal -->
+
+<div class="modal fade" id="attendee-capabilities-modal" tabindex="-1"
+     aria-labelledby="attendee-capabilities-modal-label" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="attendee-capabilities-modal-label">Attendee capabilities</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="form-floating mb-3">
+          <div id="attendee-capabilities-modal-description" class="text-wrap text-break"></div>
+        </div>
+        <div class="form-floating mb-3">
+          <select name="audioCapability" class="form-select" id="attendee-capabilities-modal-audio-select">
+            <option value="SendReceive">SendReceive</option>
+            <option value="Send">Send</option>
+            <option value="Receive">Receive</option>
+            <option value="None">None</option>
+          </select>
+          <label for="audioCapability"  style="text-align: left;">Audio capability:</label>
+        </div>
+        <div class="form-floating mb-3">
+          <select name="videoCapability" class="form-select" id="attendee-capabilities-modal-video-select">
+            <option value="SendReceive">SendReceive</option>
+            <option value="Send">Send</option>
+            <option value="Receive">Receive</option>
+            <option value="None">None</option>
+          </select>
+          <label for="videoCapability"  style="text-align: left;">Video capability:</label>
+        </div>
+        <div class="form-floating mb-3">
+          <select name="contentCapability" class="form-select" id="attendee-capabilities-modal-content-select">
+            <option value="SendReceive">SendReceive</option>
+            <option value="Send">Send</option>
+            <option value="Receive">Receive</option>
+            <option value="None">None</option>
+          </select>
+          <label for="contentCapability"  style="text-align: left;">Content capability:</label>
+        </div>
+      </div>
+      <button type="button" class="btn btn-primary" id="attendee-capabilities-save-button">Save</button>
+    </div>
+  </div>
+</div>
+
 </body>
 </html>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -80,6 +80,7 @@ import {
   POSTLogger,
   VideoCodecCapability,
 } from 'amazon-chime-sdk-js';
+import { Modal } from 'bootstrap';
 
 import TestSound from './audio/TestSound';
 import MeetingToast from './util/MeetingToast'; MeetingToast; // Make sure this file is included in webpack
@@ -329,6 +330,11 @@ export class DemoMeetingApp
   enableWebAudio = false;
   logLevel = LogLevel.INFO;
   videoCodecPreferences: VideoCodecCapability[] | undefined = undefined;
+
+  audioCapability: string;
+  videoCapability: string;
+  contentCapability: string;
+
   enableSimulcast = false;
   usePriorityBasedDownlinkPolicy = false;
   videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig;
@@ -362,6 +368,7 @@ export class DemoMeetingApp
   joinInfo: any | undefined;
   deleteOwnAttendeeToLeave = false;
   disablePeriodicKeyframeRequestOnContentSender = false;
+  allowAttendeeCapabilities = false;
 
   blurProcessor: BackgroundBlurProcessor | undefined;
   replacementProcessor: BackgroundReplacementProcessor | undefined;
@@ -1445,7 +1452,15 @@ export class DemoMeetingApp
 
   private async getPrimaryMeetingCredentials(): Promise<MeetingSessionCredentials> {
     // Use the same join endpoint, but point it to the provided primary meeting title and give us an arbitrarily different user name
-    const joinInfo = (await this.sendJoinRequest(this.primaryExternalMeetingId, `promoted-${this.name}`, this.region)).JoinInfo;
+    const joinInfo = (await this.sendJoinRequest(
+      this.primaryExternalMeetingId,
+      `promoted-${this.name}`,
+      this.region,
+      undefined,
+      this.audioCapability,
+      this.videoCapability,
+      this.contentCapability,
+    )).JoinInfo;
     // To avoid duplicating code we reuse the constructor for `MeetingSessionConfiguration` which contains `MeetingSessionCredentials`
     // within it and properly does the parsing of the `chime::CreateAttendee` response
     const configuration = new MeetingSessionConfiguration(joinInfo.Meeting, joinInfo.Attendee);
@@ -1954,7 +1969,7 @@ export class DemoMeetingApp
         this.contentShare.stop();
       }
       const attendeeName =  externalUserId.split('#').slice(-1)[0] + (isContentAttendee ? ' «Content»' : '');
-      this.roster.addAttendee(attendeeId, attendeeName);
+      this.roster.addAttendee(attendeeId, attendeeName, this.allowAttendeeCapabilities);
 
       this.volumeIndicatorHandler = async (
           attendeeId: string,
@@ -2280,12 +2295,25 @@ export class DemoMeetingApp
       meeting: string,
       name: string,
       region: string,
-      primaryExternalMeetingId?: string): Promise<any> {
+      primaryExternalMeetingId?: string,
+      audioCapability?: string,
+      videoCapability?: string,
+      contentCapability?: string,
+    ): Promise<any> {
     let uri = `${DemoMeetingApp.BASE_URL}join?title=${encodeURIComponent(
         meeting
     )}&name=${encodeURIComponent(name)}&region=${encodeURIComponent(region)}`
     if (primaryExternalMeetingId) {
       uri += `&primaryExternalMeetingId=${primaryExternalMeetingId}`;
+    }
+    if (audioCapability) {
+      uri += `&attendeeAudioCapability=${audioCapability}`;
+    }
+    if (videoCapability) {
+      uri += `&attendeeVideoCapability=${videoCapability}`;
+    }
+    if (contentCapability) {
+      uri += `&attendeeContentCapability=${contentCapability}`;
     }
     uri += `&ns_es=${this.echoReductionCapability}`
     const response = await fetch(uri,
@@ -2355,10 +2383,57 @@ export class DemoMeetingApp
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async getAttendee(attendeeId: string): Promise<any> {
     const response = await fetch(
-        `${DemoMeetingApp.BASE_URL}attendee?title=${encodeURIComponent(
+        `${DemoMeetingApp.BASE_URL}get_attendee?title=${encodeURIComponent(
             this.meeting
-        )}&attendee=${encodeURIComponent(attendeeId)}`
+        )}&id=${encodeURIComponent(attendeeId)}`,
+        {
+          method: 'GET',
+        }
     );
+    const json = await response.json();
+    if (json.error) {
+      throw new Error(`Server error: ${json.error}`);
+    }
+    return json;
+  }
+
+  async updateAttendeeCapabilities(
+    attendeeId: string,
+    audioCapability: string,
+    videoCapability: string,
+    contentCapability: string
+  ): Promise<void> {
+    const uri = `${DemoMeetingApp.BASE_URL}update_attendee_capabilities?title=${encodeURIComponent(
+      this.meeting
+    )}&attendeeId=${encodeURIComponent(attendeeId)}&audioCapability=${encodeURIComponent(
+      audioCapability
+    )}&videoCapability=${encodeURIComponent(videoCapability)}&contentCapability=${encodeURIComponent(
+      contentCapability
+    )}`;
+    const response = await fetch(uri, {
+      method: 'POST',
+    });
+    const json = await response.json();
+    if (json.error) {
+      throw new Error(`Server error: ${json.error}`);
+    }
+    return json;
+  }
+
+  async updateAttendeeCapabilitiesExcept(
+    attendees: string[],
+    audioCapability: string,
+    videoCapability: string,
+    contentCapability: string
+  ): Promise<void> {
+    const uri = `${DemoMeetingApp.BASE_URL}batch_update_attendee_capabilities_except?title=${encodeURIComponent(
+      this.meeting
+    )}&attendeeIds=${encodeURIComponent(attendees.join(','))}&audioCapability=${encodeURIComponent(
+      audioCapability
+    )}&videoCapability=${encodeURIComponent(videoCapability)}&contentCapability=${encodeURIComponent(
+      contentCapability
+    )}`;
+    const response = await fetch(uri, { method: 'POST' });
     const json = await response.json();
     if (json.error) {
       throw new Error(`Server error: ${json.error}`);
@@ -3291,7 +3366,15 @@ export class DemoMeetingApp
   }
 
   async authenticate(): Promise<string> {
-    this.joinInfo = (await this.sendJoinRequest(this.meeting, this.name, this.region, this.primaryExternalMeetingId)).JoinInfo;
+    this.joinInfo = (await this.sendJoinRequest(
+      this.meeting,
+      this.name,
+      this.region,
+      this.primaryExternalMeetingId,
+      this.audioCapability,
+      this.videoCapability,
+      this.contentCapability,
+    )).JoinInfo;
     this.region = this.joinInfo.Meeting.Meeting.MediaRegion;
     const configuration = new MeetingSessionConfiguration(this.joinInfo.Meeting, this.joinInfo.Attendee);
     await this.initializeMeetingSession(configuration);
@@ -3301,6 +3384,111 @@ export class DemoMeetingApp
     history.replaceState({}, `${this.meeting}`, url.toString());
     return configuration.meetingId;
   }
+
+  async initAttendeeCapabilityFeature(): Promise<void> {
+    const rosterMenuContainer = document.getElementById('roster-menu-container');
+    if (this.allowAttendeeCapabilities) {
+      rosterMenuContainer.classList.remove('hidden');
+      rosterMenuContainer.classList.add('d-flex');
+
+      const attendeeCapabilitiesModal = document.getElementById('attendee-capabilities-modal');
+      attendeeCapabilitiesModal.addEventListener('show.bs.modal', async (event: any) => {
+        const button = event.relatedTarget;
+        const type = button.getAttribute('data-bs-type');
+        const descriptionElement = document.getElementById('attendee-capabilities-modal-description');
+  
+        const audioSelectElement = document.getElementById('attendee-capabilities-modal-audio-select') as HTMLSelectElement;
+        const videoSelectElement = document.getElementById('attendee-capabilities-modal-video-select') as HTMLSelectElement;
+        const contentSelectElement = document.getElementById('attendee-capabilities-modal-content-select') as HTMLSelectElement;
+  
+        audioSelectElement.value = '';
+        videoSelectElement.value = '';
+        contentSelectElement.value = '';
+  
+        audioSelectElement.disabled = true;
+        videoSelectElement.disabled = true;
+        contentSelectElement.disabled = true;
+  
+        // Clone the `selectedAttendeeSet` upon selecting the menu option to open a modal. 
+        // Note that the `selectedAttendeeSet` may change when API calls are made.
+        const selectedAttendeeSet = new Set(this.roster.selectedAttendeeSet);
+        
+        if (type === 'one-attendee') {
+          const [selectedAttendee] = selectedAttendeeSet;
+          descriptionElement.innerHTML = `Update <b>${selectedAttendee.name}</b>'s attendee capabilities.`;
+  
+          // Load the selected attendee's capabilities.
+          const { Attendee } = await this.getAttendee(selectedAttendee.id);
+          audioSelectElement.value = Attendee.Capabilities.Audio;
+          videoSelectElement.value = Attendee.Capabilities.Video;
+          contentSelectElement.value = Attendee.Capabilities.Content;
+        } else {
+          if (this.roster.selectedAttendeeSet.size === 0)  {
+            descriptionElement.innerHTML = `Update the capabilities of all attendees.`;
+          } else {
+            descriptionElement.innerHTML = `Update the capabilities of all attendees, excluding:<ul> ${
+              [...selectedAttendeeSet].map(attendee => `<li><b>${attendee.name}</b></li>`).join('')
+            }</ul>`;
+          }
+  
+          audioSelectElement.value = 'SendReceive';
+          videoSelectElement.value = 'SendReceive';
+          contentSelectElement.value = 'SendReceive';
+        }
+  
+        audioSelectElement.disabled = false;
+        videoSelectElement.disabled = false;
+        contentSelectElement.disabled = false;
+      
+        const saveButton = document.getElementById('attendee-capabilities-save-button') as HTMLButtonElement;
+        const onClickSaveButton = async () => {
+          saveButton.removeEventListener('click', onClickSaveButton);
+          Modal.getInstance(attendeeCapabilitiesModal).hide();
+          this.roster.unselectAll();
+  
+          try {
+            if (type === 'one-attendee') {
+              const [selectedAttendee] = selectedAttendeeSet;
+              await this.updateAttendeeCapabilities(
+                selectedAttendee.id,
+                audioSelectElement.value,
+                videoSelectElement.value,
+                contentSelectElement.value
+              );
+            } else {
+              await this.updateAttendeeCapabilitiesExcept(
+                [...selectedAttendeeSet].map(attendee => attendee.id),
+                audioSelectElement.value,
+                videoSelectElement.value,
+                contentSelectElement.value
+              );
+            }
+          } catch (error) {
+            console.error(error);
+            const toastContainer = document.getElementById('toast-container');
+            const toast = document.createElement('meeting-toast') as MeetingToast;
+            toastContainer.appendChild(toast);
+            toast.message = `Failed to update attendee capabilities. Please be aware that you can't set content capabilities to "SendReceive" or "Receive" unless you set video capabilities to "SendReceive" or "Receive". Refer to the Amazon Chime SDK guide and the console for additional information.`;
+            toast.delay = '15000';
+            toast.show();
+            const onHidden = () => {
+              toast.removeEventListener('hidden.bs.toast', onHidden);
+              toastContainer.removeChild(toast);
+            };
+            toast.addEventListener('hidden.bs.toast', onHidden);
+          }
+        };
+        saveButton.addEventListener('click', onClickSaveButton);
+  
+        attendeeCapabilitiesModal.addEventListener('hide.bs.modal', async () => {
+          saveButton.removeEventListener('click', onClickSaveButton);
+        });
+      }); 
+    } else {
+      rosterMenuContainer.classList.add('hidden');
+      rosterMenuContainer.classList.remove('d-flex');
+    }
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   log(str: string, ...args: any[]): void {
@@ -3487,6 +3675,7 @@ export class DemoMeetingApp
     this.enableEventReporting = (document.getElementById('event-reporting') as HTMLInputElement).checked;
     this.deleteOwnAttendeeToLeave = (document.getElementById('delete-attendee') as HTMLInputElement).checked;
     this.disablePeriodicKeyframeRequestOnContentSender = (document.getElementById('disable-content-keyframe') as HTMLInputElement).checked;
+    this.allowAttendeeCapabilities = (document.getElementById('allow-attendee-capabilities') as HTMLInputElement).checked;
     this.enableWebAudio = (document.getElementById('webaudio') as HTMLInputElement).checked;
     this.usePriorityBasedDownlinkPolicy = (document.getElementById('priority-downlink-policy') as HTMLInputElement).checked;
     this.echoReductionCapability = (document.getElementById('echo-reduction-capability') as HTMLInputElement).checked;
@@ -3525,6 +3714,10 @@ export class DemoMeetingApp
         // which should be equivalent to `this.videoCodecPreferences = [VideoCodecCapability.h264ConstrainedBaselineProfile()]`
         break;
     }
+
+    this.audioCapability = (document.getElementById('audioCapabilitySelect') as HTMLSelectElement).value;
+    this.videoCapability = (document.getElementById('videoCapabilitySelect') as HTMLSelectElement).value;
+    this.contentCapability = (document.getElementById('contentCapabilitySelect') as HTMLSelectElement).value;
 
     AsyncScheduler.nextTick(
         async (): Promise<void> => {
@@ -3570,6 +3763,7 @@ export class DemoMeetingApp
           await this.initVoiceFocus();
           await this.initBackgroundBlur();
           await this.initBackgroundReplacement();
+          await this.initAttendeeCapabilityFeature();
           await this.resolveSupportsVideoFX();
           await this.populateAllDeviceLists();
           await this.populateVideoFilterInputList(false);

--- a/demos/browser/app/meetingV2/util/MeetingToast.ts
+++ b/demos/browser/app/meetingV2/util/MeetingToast.ts
@@ -5,7 +5,7 @@ import { Toast } from 'bootstrap';
 
 export default class MeetingToast extends HTMLElement {
   innerHTMLToInject = `
-    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-delay="10000">
+    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="10000">
       <div class="toast-body">
         <p class="toast-message"></p>
         <div class="mt-2 pt-2 border-top button-container">
@@ -20,7 +20,7 @@ export default class MeetingToast extends HTMLElement {
   }
 
   public set delay(delay: string) {
-    this.querySelector('.toast').setAttribute("data-delay", delay);
+    this.querySelector('.toast').setAttribute("data-bs-delay", delay);
   }
 
   addButton(label: string, action: () => void) {

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -168,8 +168,7 @@ function serve(host = '127.0.0.1:8080') {
           meetingTable[requestUrl.query.title] = meeting;
         }
 
-        // Create new attendee for the meeting
-        const attendee = await client.createAttendee({
+        const createAttendeeRequest = {
           // The meeting ID of the created meeting to add the attendee to
           MeetingId: meeting.Meeting.MeetingId,
 
@@ -178,7 +177,18 @@ function serve(host = '127.0.0.1:8080') {
           // combined with the name the user provided, which can later
           // be used to help build the roster.
           ExternalUserId: `${uuidv4().substring(0, 8)}#${requestUrl.query.name}`.substring(0, 64),
-        }).promise();
+        };
+
+        if (requestUrl.query.attendeeAudioCapability && !requestUrl.query.primaryExternalMeetingId) {
+          createAttendeeRequest.Capabilities = {
+            Audio: requestUrl.query.attendeeAudioCapability,
+            Video: requestUrl.query.attendeeVideoCapability,
+            Content: requestUrl.query.attendeeContentCapability,
+          };
+        }
+
+       // Create new attendee for the meeting
+       const attendee = await client.createAttendee(createAttendeeRequest).promise();
 
         // Return the meeting and attendee responses. The client will use these
         // to join the meeting.
@@ -409,6 +419,45 @@ function serve(host = '127.0.0.1:8080') {
           }
           respond(response, 200, 'audio/mpeg', data);
         });
+      } else if (request.method === 'POST' && requestUrl.pathname === '/update_attendee_capabilities') {
+        const client = getClientForMeeting(meetingTable[requestUrl.query.title]);
+        const data = await client
+          .updateAttendeeCapabilities({
+            MeetingId: meetingTable[requestUrl.query.title].Meeting.MeetingId,
+            AttendeeId: requestUrl.query.attendeeId,
+            Capabilities: {
+              Audio: requestUrl.query.audioCapability,
+              Video: requestUrl.query.videoCapability,
+              Content: requestUrl.query.contentCapability,
+            },
+          })
+          .promise();
+        respond(response, 200, 'application/json', JSON.stringify(data));
+      } else if (request.method === 'POST' && requestUrl.pathname === '/batch_update_attendee_capabilities_except') {
+        const client = getClientForMeeting(meetingTable[requestUrl.query.title]);
+        const data = await client
+          .batchUpdateAttendeeCapabilitiesExcept({
+            MeetingId: meetingTable[requestUrl.query.title].Meeting.MeetingId,
+            ExcludedAttendeeIds: requestUrl.query.attendeeIds.split(',').map((attendeeId) => {
+              return { AttendeeId: attendeeId };
+            }),
+            Capabilities: {
+              Audio: requestUrl.query.audioCapability,
+              Video: requestUrl.query.videoCapability,
+              Content: requestUrl.query.contentCapability,
+            },
+          })
+          .promise();
+        respond(response, 200, 'application/json', JSON.stringify(data));
+      } else if (request.method === 'GET' && requestUrl.pathname === '/get_attendee') {
+        const client = getClientForMeeting(meetingTable[requestUrl.query.title]);
+        const getAttendeeResponse = await client
+          .getAttendee({
+            MeetingId: meetingTable[requestUrl.query.title].Meeting.MeetingId,
+            AttendeeId: requestUrl.query.id,
+          })
+          .promise();
+        respond(response, 200, 'application/json', JSON.stringify(getAttendeeResponse));      
       } else {
         respond(response, 404, 'text/html', '404 Not Found');
       }

--- a/demos/browser/webpack.config.hot.js
+++ b/demos/browser/webpack.config.hot.js
@@ -45,6 +45,9 @@ module.exports = env => {
         '/fetch_credentials': 'http://127.0.0.1:8081',
         '/audio_file': 'http://127.0.0.1:8081',
         '/stereo_audio_file': 'http://127.0.0.1:8081',
+        '/update_attendee_capabilities': 'http://127.0.0.1:8081',
+        '/batch_update_attendee_capabilities_except': 'http://127.0.0.1:8081',
+        '/get_attendee': 'http://127.0.0.1:8081',
       }
     },
     plugins: [

--- a/demos/browser/webpack.config.js
+++ b/demos/browser/webpack.config.js
@@ -83,6 +83,9 @@ module.exports = env => {
         '/fetch_credentials': 'http://127.0.0.1:8081',
         '/audio_file': 'http://127.0.0.1:8081',
         '/stereo_audio_file': 'http://127.0.0.1:8081',
+        '/update_attendee_capabilities': 'http://127.0.0.1:8081',
+        '/batch_update_attendee_capabilities_except': 'http://127.0.0.1:8081',
+        '/get_attendee': 'http://127.0.0.1:8081',
       }
     },
     plugins: [

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -169,7 +169,7 @@ exports.join = async (event, context) => {
 
   // Create new attendee for the meeting
   console.info('Adding new attendee');
-  const attendee = (await client.createAttendee({
+  const createAttendeeRequest = {
     // The meeting ID of the created meeting to add the attendee to
     MeetingId: meeting.Meeting.MeetingId,
 
@@ -178,7 +178,17 @@ exports.join = async (event, context) => {
     // combined with the name the user provided, which can later
     // be used to help build the roster.
     ExternalUserId: `${uuidv4().substring(0, 8)}#${query.name}`.substring(0, 64),
-  }).promise());
+  };
+
+  if (query.attendeeAudioCapability && !query.primaryExternalMeetingId) {
+    createAttendeeRequest['Capabilities'] = {
+      Audio : query.attendeeAudioCapability,
+      Video : query.attendeeVideoCapability,
+      Content: query.attendeeContentCapability,
+    };
+  }
+
+  const attendee = (await client.createAttendee(createAttendeeRequest).promise());
 
   // Return the meeting and attendee responses. The client will use these
   // to join the meeting.
@@ -219,6 +229,90 @@ exports.deleteAttendee = async (event, context) => {
   }).promise();
 
   return response(200, 'application/json', JSON.stringify({}));
+};
+
+exports.get_attendee = async (event) => {
+  const query = event.queryStringParameters;
+  if (!query.title || !query.id) {
+    return response(400, 'application/json', JSON.stringify({ error: 'Need parameters: title, id' }));
+  }
+  const meeting = await getMeeting(query.title);
+  const client = await getClientForMeeting(meeting);
+  const attendeeResponse = await client
+    .getAttendee({
+      MeetingId: meeting.Meeting.MeetingId,
+      AttendeeId: query.id,
+    })
+    .promise();
+  return response(200, 'application/json', JSON.stringify(attendeeResponse, null, 2));
+};
+
+exports.update_attendee_capabilities = async (event) => {
+  const query = event.queryStringParameters;
+  if (
+    !query.title ||
+    !query.attendeeId ||
+    !query.audioCapability ||
+    !query.videoCapability ||
+    !query.contentCapability
+  ) {
+    return response(
+      400,
+      'application/json',
+      JSON.stringify({
+        error: 'Need parameters: title, attendeeId, audioCapability, videoCapability, contentCapability',
+      })
+    );
+  }
+  const meeting = await getMeeting(query.title);
+  const client = getClientForMeeting(meeting);
+  const attendeeCapsResponse = await client
+    .updateAttendeeCapabilities({
+      MeetingId: meeting.Meeting.MeetingId,
+      AttendeeId: query.attendeeId,
+      Capabilities: {
+        Audio: query.audioCapability,
+        Video: query.videoCapability,
+        Content: query.contentCapability,
+      },
+    })
+    .promise();
+  return response(200, 'application/json', JSON.stringify(attendeeCapsResponse));
+};
+
+exports.batch_update_attendee_capabilities_except = async (event) => {
+  const query = event.queryStringParameters;
+  if (
+    !query.title ||
+    !query.attendeeIds ||
+    !query.audioCapability ||
+    !query.videoCapability ||
+    !query.contentCapability
+  ) {
+    return response(
+      400,
+      'application/json',
+      JSON.stringify({
+        error: 'Need parameters: title, attendeeIds, audioCapability, videoCapability, contentCapability',
+      })
+    );
+  }
+  const meeting = await getMeeting(query.title);
+  const client = getClientForMeeting(meeting);
+  const attendeeCapsExceptResponse = await client
+    .batchUpdateAttendeeCapabilitiesExcept({
+      MeetingId: meeting.Meeting.MeetingId,
+      ExcludedAttendeeIds: query.attendeeIds.split(',').map((attendeeId) => {
+        return { AttendeeId: attendeeId };
+      }),
+      Capabilities: {
+        Audio: query.audioCapability,
+        Video: query.videoCapability,
+        Content: query.contentCapability,
+      },
+    })
+    .promise();
+  return response(200, 'application/json', JSON.stringify(attendeeCapsExceptResponse));
 };
 
 exports.start_transcription = async (event, context) => {

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -104,6 +104,8 @@ Resources:
               - 'chime:DeleteMediaCapturePipeline'
               - 'chime:CreateMediaLiveConnectorPipeline'
               - 'chime:DeleteMediaPipeline'
+              - 'chime:UpdateAttendeeCapabilities'
+              - 'chime:BatchUpdateAttendeeCapabilitiesExcept'
               - 'ivs:CreateChannel'
               - 'ivs:DeleteChannel'
               - 's3:GetBucketPolicy'
@@ -119,6 +121,9 @@ Resources:
         - Ref: ChimeSdkEndCaptureLambdaRole
         - Ref: ChimeSdkStartLiveConnectorLambdaRole
         - Ref: ChimeSdkEndLiveConnectorLambdaRole
+        - Ref: ChimeSdkUpdateAttendeeCapabilitiesLambdaRole
+        - Ref: ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaRole
+        - Ref: ChimeSdkGetAttendeeLambdaRole        
   ChimeMessagingAccessPolicy:
     Type: AWS::IAM::Policy
     Condition: ShouldDeployFetchCredentialLambda
@@ -680,6 +685,57 @@ Resources:
             ]
           }
         - { Source: !Ref ChimeBrowserMeetingEventLogs }
+  ChimeSdkUpdateAttendeeCapabilitiesLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.update_attendee_capabilities
+      CodeUri: src/
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Meetings
+      Environment:
+        Variables:
+          USE_EVENT_BRIDGE: !Ref UseEventBridge
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /update_attendee_capabilities
+            Method: POST
+  ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.batch_update_attendee_capabilities_except
+      CodeUri: src/
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Meetings
+      Environment:
+        Variables:
+          USE_EVENT_BRIDGE: !Ref UseEventBridge
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /batch_update_attendee_capabilities_except
+            Method: POST
+  ChimeSdkGetAttendeeLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.get_attendee
+      CodeUri: src/
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Meetings
+      Environment:
+        Variables:
+          USE_EVENT_BRIDGE: !Ref UseEventBridge
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /get_attendee
+            Method: GET
 Outputs:
   ApiURL:
     Description: "API endpoint URL for Prod environment"


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Configure attendee abilities on the home screen.
- Adjust attendee capabilities during the session.

**Testing:**

- N/A as the PR includes only demo changes.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

See the **Test Steps** section.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



# Test Steps

### Configuring attendee abilities on the home screen

> This section uses the `create-attendee` API in the server application.

1. Open the Chime SDK Serverless Demo.
2. Select the **Additional Options**.
3. Update the values for **Audio Capability**, **Video Capability**, and **Content Capability**.
4. Click on the **Save** button and join a Chime SDK meeting.
5. Ensure that an attendee has specific capabilities.


### Updating one attendee's capabilities during the session

> This section uses the `update-attendee-capabilities` API in the server application.
> https://awscli.amazonaws.com/v2/documentation/api/latest/reference/chime-sdk-meetings/update-attendee-capabilities.html

1. Open the Chime SDK Serverless Demo.
1. Select the **Additional Options**.
1. Check the **Allow updating of attendee capabilities after start** box.
1. Click on the **Save** button and join a Chime SDK meeting.
1. Confirm that the checkbox appears in the roster.
1. Choose an attendee by checking the box next to their name.
1. Click on the menu located at the top-right corner of the roster.
   <img width="668" alt="image" src="https://github.com/aws/amazon-chime-sdk-js/assets/36240708/a84b5747-36d5-4793-962d-ec2c362e62b4">
1. Select the **Update the selected attendee** option.
1. Ensure that the **Attendee capabilities** window appears, displaying the currently selected attendee's capabilities.
1. Edit the attendee capabilities and click on the **Save** button.
1. Confirm that the attendee has the specific capabilities. (See the [update-attendee-capabilities API documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/chime-sdk-meetings/update-attendee-capabilities.html) for expected behaviors.)

### Updating attendee's capabilities, excluding selected attendees, during the session

> This section uses the `batch-update-attendee-capabilities-except` API in the server application.
> https://awscli.amazonaws.com/v2/documentation/api/latest/reference/chime-sdk-meetings/batch-update-attendee-capabilities-except.html

1. Open the Chime SDK Serverless Demo.
1. Select the **Additional Options**.
1. Check the **Allow updating of attendee capabilities after start** box.
1. Click on the **Save** button and join a Chime SDK meeting.
1. Confirm that the checkbox appears in the roster.
1. Choose an attendee by checking the box next to their name.
1. Click on the menu located at the top-right corner of the roster.
   <img width="668" alt="image" src="https://github.com/aws/amazon-chime-sdk-js/assets/36240708/a84b5747-36d5-4793-962d-ec2c362e62b4">
1. Select the **Update all attendees, except 1 selected** option.
1. The **Attendee capabilities** window appears with **SendReceive** set as the default value.
1. Edit the attendee capabilities and click on the **Save** button.
1. Confirm that all attendees, excluding the selected attendees, have the specific capabilities. (See the [batch-update-attendee-capabilities-except API documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/chime-sdk-meetings/batch-update-attendee-capabilities-except.html) for expected behaviors.)
