### PR TITLE
Do not pass the Capabilities for the global endpoint demo

### DIFF
--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -179,7 +179,11 @@ function serve(host = '127.0.0.1:8080') {
           ExternalUserId: `${uuidv4().substring(0, 8)}#${requestUrl.query.name}`.substring(0, 64),
         };
 
-        if (requestUrl.query.attendeeAudioCapability && !requestUrl.query.primaryExternalMeetingId) {
+        if (
+          useChimeSDKMeetings === 'true' &&
+          requestUrl.query.attendeeAudioCapability &&
+          !requestUrl.query.primaryExternalMeetingId
+        ) {
           createAttendeeRequest.Capabilities = {
             Audio: requestUrl.query.attendeeAudioCapability,
             Video: requestUrl.query.attendeeVideoCapability,

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -180,7 +180,7 @@ exports.join = async (event, context) => {
     ExternalUserId: `${uuidv4().substring(0, 8)}#${query.name}`.substring(0, 64),
   };
 
-  if (query.attendeeAudioCapability && !query.primaryExternalMeetingId) {
+  if (useChimeSDKMeetings === 'true' && query.attendeeAudioCapability && !query.primaryExternalMeetingId) {
     createAttendeeRequest['Capabilities'] = {
       Audio : query.attendeeAudioCapability,
       Video : query.attendeeVideoCapability,


### PR DESCRIPTION
**Issue #:**
N/A

**Description of changes:**
- Do not pass the Capabilities for the global endpoint demo.

**Testing:**
N/A. Only a demo change

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
In the demo application using the legacy Chime SDK global endpoint, the attendee capability feature should be unaffected. I've preserved the attendee capability UI for the global endpoint demo because we plan to deprecate the global endpoint soon.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
N/A

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

