### PR TITLE
Do not display a warning message when calling setVideoCodecSendPrefer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Do not display a warning message when invoking `meetingSession.audioVideo.setVideoCodecSendPreferences` prior to the start of the session.
+
 ## [3.16.0] - 2023-06-26
 
 ### Added

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -455,7 +455,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1631">src/audiovideocontroller/DefaultAudioVideoController.ts:1631</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1633">src/audiovideocontroller/DefaultAudioVideoController.ts:1633</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1604">src/audiovideocontroller/DefaultAudioVideoController.ts:1604</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1606">src/audiovideocontroller/DefaultAudioVideoController.ts:1606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -534,7 +534,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1570">src/audiovideocontroller/DefaultAudioVideoController.ts:1570</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1572">src/audiovideocontroller/DefaultAudioVideoController.ts:1572</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -643,7 +643,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1560">src/audiovideocontroller/DefaultAudioVideoController.ts:1560</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1562">src/audiovideocontroller/DefaultAudioVideoController.ts:1562</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -750,7 +750,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1579">src/audiovideocontroller/DefaultAudioVideoController.ts:1579</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1581">src/audiovideocontroller/DefaultAudioVideoController.ts:1581</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1250,7 +1250,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1613">src/audiovideocontroller/DefaultAudioVideoController.ts:1613</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1615">src/audiovideocontroller/DefaultAudioVideoController.ts:1615</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -378,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1631">src/audiovideocontroller/DefaultAudioVideoController.ts:1631</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1633">src/audiovideocontroller/DefaultAudioVideoController.ts:1633</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1570">src/audiovideocontroller/DefaultAudioVideoController.ts:1570</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1572">src/audiovideocontroller/DefaultAudioVideoController.ts:1572</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1560">src/audiovideocontroller/DefaultAudioVideoController.ts:1560</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1562">src/audiovideocontroller/DefaultAudioVideoController.ts:1562</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1166,7 +1166,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1613">src/audiovideocontroller/DefaultAudioVideoController.ts:1613</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1615">src/audiovideocontroller/DefaultAudioVideoController.ts:1615</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -1554,7 +1554,9 @@ export default class DefaultAudioVideoController
   setVideoCodecSendPreferences(preferences: VideoCodecCapability[]): void {
     this.videoSendCodecPreferences = preferences; // In case we haven't called `initSignalingClient` yet
     this.meetingSessionContext.videoSendCodecPreferences = preferences;
-    this.update({ needsRenegotiation: true });
+    if (this.sessionStateController.state() !== SessionStateControllerState.NotConnected) {
+      this.update({ needsRenegotiation: true });
+    }
   }
 
   getRemoteVideoSources(): VideoSource[] {

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -4253,6 +4253,21 @@ describe('DefaultAudioVideoController', () => {
 
       expect(spy.callCount).to.equal(1);
     });
+
+    it('does not trigger an update if invoked before the session starts.', async () => {
+      audioVideoController = new DefaultAudioVideoController(
+        configuration,
+        new NoOpDebugLogger(),
+        webSocketAdapter,
+        new NoOpDeviceController(),
+        reconnectController
+      );
+
+      // @ts-ignore
+      const spy = sinon.spy(audioVideoController, 'update');
+      audioVideoController.setVideoCodecSendPreferences([VideoCodecCapability.vp8()]);
+      expect(spy.callCount).to.equal(0);
+    });
   });
 
   describe('getRTCPeerConnectionStats', () => {


### PR DESCRIPTION
…ences before start

**Issue #:**
#2734

**Description of changes:**
- Do not display a warning message when invoking `meetingSession.audioVideo.setVideoCodecSendPreferences` prior to the start of the session.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes.

1. Navigate to the Chime SDK Serverless Demo.
2. Enter the meeting title and your name, then click the **Continue** button.
3. On the **Select devices** page, open the browser console.
4. Run the following script.
   ```
   app.audioVideo.setVideoCodecSendPreferences([])
   ```
5. Ensure that the SDK does not produce any warning message like `[WARN] SDK - no transition found from NotConnected with Update`.
6. Click the **Join** button on the **Select devices** page.
7. Once you're in the meeting view, open the browser console again.
8. Run the following script.
   ```
   app.audioVideo.setVideoCodecSendPreferences([])
   ```
9. Make sure that the SDK performs the update action by checking for the following log:
   ```
   [INFO] SDK - transitioning from Connected to Updating with Update
   ```
**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No, the PR fixes the implementation.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

