### PR TITLE
Content constraint revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.0] - 2023-09-11
+
+### Added
+
+### Removed
+- Resolution constraint for content share
+
+### Changed
+
+### Fixed
+
 ## [3.17.0] - 2023-08-15
 
 ### Added

--- a/src/task/ReceiveVideoInputTask.ts
+++ b/src/task/ReceiveVideoInputTask.ts
@@ -75,27 +75,6 @@ export default class ReceiveVideoInputTask extends BaseTask {
       );
       const trackSettings = videoTracks[0].getSettings();
 
-      // apply video track constraints for content share
-      if (isContentAttendee) {
-        const constraint = {
-          width: { ideal: 1920 },
-          height: { ideal: 1080 },
-          frameRate: { ideal: 30 },
-        };
-        this.context.logger.info(
-          `Video track (content = ${isContentAttendee}) with constraint: ${JSON.stringify(
-            constraint
-          )}, trackSettings: ${JSON.stringify(trackSettings)}`
-        );
-        try {
-          await videoTracks[0].applyConstraints(constraint);
-        } catch (error) {
-          this.context.logger.info(
-            'Could not apply constraint for video track (content = ${isContentAttendee})'
-          );
-        }
-      }
-
       // For video, we currently enforce 720p for simulcast. This logic should be removed in the future.
       if (this.context.enableSimulcast && !isContentAttendee) {
         const constraint = this.context.videoUplinkBandwidthPolicy.chooseMediaTrackConstraints();

--- a/test/task/ReceiveVideoInputTask.test.ts
+++ b/test/task/ReceiveVideoInputTask.test.ts
@@ -96,43 +96,6 @@ describe('ReceiveVideoInputTask', () => {
       assert.exists(context.activeVideoInput);
     });
 
-    it('will acquire the video input and query constraint (unicast - content with video track constraint)', async () => {
-      context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
-      context.enableSimulcast = false;
-      context.meetingSessionConfiguration.credentials.attendeeId = 'foo-attendee#content';
-      context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy(
-        'attendee',
-        new NoOpLogger()
-      );
-      context.videoTileController.startLocalVideoTile();
-      context.mediaStreamBroker = new MockMediaStreamBroker({
-        acquireVideoInputDeviceSucceeds: true,
-      });
-
-      const task = new ReceiveVideoInputTask(context);
-      await task.run();
-      assert.exists(context.activeVideoInput);
-    });
-
-    it('will acquire the video input and query constraint (unicast - content without video track constraint)', async () => {
-      domMockBehavior.applyConstraintSucceeds = false;
-      context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
-      context.enableSimulcast = false;
-      context.meetingSessionConfiguration.credentials.attendeeId = 'foo-attendee#content';
-      context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy(
-        'attendee',
-        new NoOpLogger()
-      );
-      context.videoTileController.startLocalVideoTile();
-      context.mediaStreamBroker = new MockMediaStreamBroker({
-        acquireVideoInputDeviceSucceeds: true,
-      });
-
-      const task = new ReceiveVideoInputTask(context);
-      await task.run();
-      assert.exists(context.activeVideoInput);
-    });
-
     it('will acquire the video input and query constraint', async () => {
       context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
       context.enableSimulcast = true;


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Revert resolution constraint for content share

Previous related PR:  https://github.com/aws/amazon-chime-sdk-js/pull/2682/files

**Testing:**
Passed:

* npm run test
* npm run build:release

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Yes