### PR TITLE
Remove deprecated function in build script

### DIFF
--- a/script/conditional-install
+++ b/script/conditional-install
@@ -8,7 +8,7 @@ end
 # Why not read node_modules/.package-lock.json? Because it's not the same.
 hashfile = 'node_modules/.package-lock.json.hash'
 current = Digest::SHA2.file('package-lock.json').hexdigest
-expected = File.read(hashfile) if File.exists?(hashfile)
+expected = File.read(hashfile) if File.exist?(hashfile)
 
 if expected != current
   puts 'Running npm ci to regenerate node_modules.'

--- a/script/version-utils.js
+++ b/script/version-utils.js
@@ -125,7 +125,7 @@ const versionBump = async (option, branchName) => {
     const currentBranch = (spawnOrFail('git', [' branch --show-current'], { skipOutput: true })).trim();
     spawnOrFail('git', [`checkout -b ${prevReleaseBranch}`]);
     updateBaseBranch(prevReleaseBranch);
-    spawnOrFail('git', ['add -A']);
+    spawnOrFail('git', ['add CHANGELOG.md package.json package-lock.json']);
     spawnOrFail('git', [`commit -m "Update base branch to ${prevReleaseBranch}"`]);
     spawnOrFail('git', [`push origin HEAD:${prevReleaseBranch} -f`]);
     logger.log(`Branch ${prevReleaseBranch} is created. Please make sure to set branch protection.`);


### PR DESCRIPTION

**Description of changes:**
- Remove deprecated Ruby function `exists` in build script. This has been on the deprecated path since Ruby 2.5 and has been removed in Ruby 3.2 and later.
- Update release script to only include relevant files to avoid accidentally include unwanted files.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally? N/A


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

