### PR TITLE
Update redundant audio version in the documentation to 3.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,7 +1217,7 @@ meetingSession.audioVideo.setContentAudioProfile(AudioProfile.fullbandMusicStere
 
 **Use case 35.** Redundant Audio
 
-Starting from version 3.18.1, the SDK starts sending redundant audio data to our servers on detecting packet loss
+Starting from version 3.18.2, the SDK starts sending redundant audio data to our servers on detecting packet loss
 to help reduce its effect on audio quality. Redundant audio packets are only sent out for packets containing active
 audio, ie, speech or music. This may increase the bandwidth consumed by audio to up to 3 times the normal amount
 depending on the amount of packet loss detected. The SDK will automatically stop sending redundant data if it hasn't

--- a/docs/index.html
+++ b/docs/index.html
@@ -1166,7 +1166,7 @@
 				<pre><code class="language-js"><span style="color: #001080">meetingSession</span><span style="color: #000000">.</span><span style="color: #001080">audioVideo</span><span style="color: #000000">.</span><span style="color: #795E26">setContentAudioProfile</span><span style="color: #000000">(</span><span style="color: #001080">AudioProfile</span><span style="color: #000000">.</span><span style="color: #795E26">fullbandMusicStereo</span><span style="color: #000000">());</span>
 </code></pre>
 				<p><strong>Use case 35.</strong> Redundant Audio</p>
-				<p>Starting from version 3.18.1, the SDK starts sending redundant audio data to our servers on detecting packet loss
+				<p>Starting from version 3.18.2, the SDK starts sending redundant audio data to our servers on detecting packet loss
 					to help reduce its effect on audio quality. Redundant audio packets are only sent out for packets containing active
 					audio, ie, speech or music. This may increase the bandwidth consumed by audio to up to 3 times the normal amount
 					depending on the amount of packet loss detected. The SDK will automatically stop sending redundant data if it hasn&#39;t


### PR DESCRIPTION
**Issue #:** n/a

**Description of changes:**
Update redundant audio version in the documentation to 3.18.2

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
n/a

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
n/a

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n/a

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

