### PR TITLE
Make uplink loss percent estimation for redundant audio more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Do not allow redundant audio worker to enqueue any audio payloads larger than 1000 bytes to avoid permanently stopping the audio flow
+- Make uplink loss estimation more accurate so that redundant audio does not turn off prematurely
 
 ## [3.18.2] - 2023-10-09
 

--- a/docs/classes/defaulttransceivercontroller.html
+++ b/docs/classes/defaulttransceivercontroller.html
@@ -284,7 +284,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#addredundantaudiorecoverymetricsobserver">addRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L815">src/transceivercontroller/DefaultTransceiverController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L828">src/transceivercontroller/DefaultTransceiverController.ts:828</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -507,7 +507,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/transceivercontroller.html">TransceiverController</a>.<a href="../interfaces/transceivercontroller.html#removeredundantaudiorecoverymetricsobserver">removeRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L819">src/transceivercontroller/DefaultTransceiverController.ts:819</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L832">src/transceivercontroller/DefaultTransceiverController.ts:832</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/simulcastcontentsharetransceivercontroller.html
+++ b/docs/classes/simulcastcontentsharetransceivercontroller.html
@@ -359,7 +359,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="simulcasttransceivercontroller.html">SimulcastTransceiverController</a>.<a href="simulcasttransceivercontroller.html#addredundantaudiorecoverymetricsobserver">addRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L815">src/transceivercontroller/DefaultTransceiverController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L828">src/transceivercontroller/DefaultTransceiverController.ts:828</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -628,7 +628,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="simulcasttransceivercontroller.html">SimulcastTransceiverController</a>.<a href="simulcasttransceivercontroller.html#removeredundantaudiorecoverymetricsobserver">removeRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L819">src/transceivercontroller/DefaultTransceiverController.ts:819</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L832">src/transceivercontroller/DefaultTransceiverController.ts:832</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/simulcasttransceivercontroller.html
+++ b/docs/classes/simulcasttransceivercontroller.html
@@ -358,7 +358,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#addredundantaudiorecoverymetricsobserver">addRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L815">src/transceivercontroller/DefaultTransceiverController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L828">src/transceivercontroller/DefaultTransceiverController.ts:828</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -625,7 +625,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#removeredundantaudiorecoverymetricsobserver">removeRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L819">src/transceivercontroller/DefaultTransceiverController.ts:819</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L832">src/transceivercontroller/DefaultTransceiverController.ts:832</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoonlytransceivercontroller.html
+++ b/docs/classes/videoonlytransceivercontroller.html
@@ -285,7 +285,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#addredundantaudiorecoverymetricsobserver">addRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L815">src/transceivercontroller/DefaultTransceiverController.ts:815</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L828">src/transceivercontroller/DefaultTransceiverController.ts:828</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -509,7 +509,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaulttransceivercontroller.html">DefaultTransceiverController</a>.<a href="defaulttransceivercontroller.html#removeredundantaudiorecoverymetricsobserver">removeRedundantAudioRecoveryMetricsObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L819">src/transceivercontroller/DefaultTransceiverController.ts:819</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/transceivercontroller/DefaultTransceiverController.ts#L832">src/transceivercontroller/DefaultTransceiverController.ts:832</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">


### PR DESCRIPTION
**Issue #:** n/a

**Description of changes:**

During canary testing, it was discovered that the local uplink loss metric that was being calculated was 10-20% higher than the actual uplink loss being simulated. Because of this discrepancy, RED kept turning off when 60% uplink loss was being simulated because the client-side RED thought that the uplink packet loss was 65-80%, which would constantly trigger the functionality to disable RED to avoid congestion collapse. This causes RED to turn off prematurely even when the uplink loss is considerably lower than 75%. This change makes the estimation more accurate so that RED does not turn off prematurely.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Join a meeting with RED enabled
2. Simulate 60% uplink loss using something like Network Link Conditioner for Mac
3. When viewing the browser logs, RED should not be turning off constantly since 60% uplink loss is much lower than the 75% turn off threshold.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

