### PR TITLE
Harden serverless demo check on attendee count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Do not allow redundant audio worker to enqueue any audio payloads larger than 1000 bytes to avoid permanently stopping the audio flow.
-- Make uplink loss estimation more accurate so that redundant audio does not turn off prematurely
+- Make uplink loss estimation more accurate so that redundant audio does not turn off prematurely.
 
 ## [3.18.2] - 2023-10-09
 

--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -131,7 +131,7 @@ function serve(host = '127.0.0.1:8080') {
                   requestUrl.query.v_rs === 'None' || 
                   requestUrl.query.c_rs === 'UHD' ||
                   requestUrl.query.c_rs === 'None' ||
-                  requestUrl.query.a_cnt != '-999') {
+                  requestUrl.query.a_cnt > 1 && requestUrl.query.a_cnt <= 250) {
               request.MeetingFeatures = {};
               if (requestUrl.query.ns_es === 'true') {
                 request.MeetingFeatures.Audio = {
@@ -148,7 +148,7 @@ function serve(host = '127.0.0.1:8080') {
                   MaxResolution: requestUrl.query.c_rs
                 }
               }
-              if (requestUrl.query.a_cnt != '-999') {
+              if (requestUrl.query.a_cnt > 1 && requestUrl.query.a_cnt <= 250) {
                 request.MeetingFeatures.Attendee = {
                   MaxCount: Number(requestUrl.query.a_cnt)
                 }

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -132,7 +132,7 @@ exports.join = async (event, context) => {
             query.v_rs === 'None' || 
             query.c_rs === 'UHD' ||
             query.c_rs === 'None' ||
-            query.a_cnt != '-999') {
+            query.a_cnt > 1 && query.a_cnt <= 250) {
         request.MeetingFeatures = {};
         if (query.ns_es === 'true') {
           request.MeetingFeatures.Audio = {
@@ -149,7 +149,7 @@ exports.join = async (event, context) => {
             MaxResolution: query.c_rs
           }
         }
-        if (query.a_cnt != '-999') {
+        if (query.a_cnt > 1 && query.a_cnt <= 250) {
           request.MeetingFeatures.Attendee = {
             MaxCount: Number(query.a_cnt)
           }


### PR DESCRIPTION
**Issue #:** None, issue is with unreleased changes.

**Description of changes:** Previously would set value if `null`, which would fail against backends.

**Testing:**
Deployed to serverless demo and tested with mobile SDK client.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Start a primary meeting.
2. On a Mobile SDK client create and join a replica meeting

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

