### PR TITLE
Add kind to the meetingReadingessChecker when looking for audio stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for node 20 and drop support for node < 18.
 - Add support for H.264 profiles besides Constrained Baseline Profile.
+- Fix MeetingReadinessChecker demo by checking for audio `kind`
 
 ### Removed
 

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L417">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:417</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L426">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:426</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L373">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:373</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L382">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:382</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L330">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:330</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L335">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:335</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
+++ b/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts
@@ -278,7 +278,12 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
     const checkAudioConnectivityMetricsObserver: AudioVideoObserver = {
       metricsDidReceive(clientMetricReport: ClientMetricReport) {
         clientMetricReport.getRTCStatsReport().forEach(report => {
-          if (report.type === 'inbound-rtp' && report.mediaType === 'audio') {
+          // TODO: remove mediaType in next version as it is deprecated
+          // mediaType was deprecated and replaced with kind
+          if (
+            report.type === 'inbound-rtp' &&
+            (report.mediaType === 'audio' || report.kind === 'audio')
+          ) {
             audioConnectivityMetrics.packetsReceived = report.packetsReceived;
           }
         });
@@ -334,7 +339,11 @@ export default class DefaultMeetingReadinessChecker implements MeetingReadinessC
       metricsDidReceive(clientMetricReport: ClientMetricReport) {
         const rawStats = clientMetricReport.getRTCStatsReport();
         rawStats.forEach(report => {
-          if (report.type === 'outbound-rtp' && report.mediaType === 'video') {
+          // TODO: remove mediaType in next version as it is deprecated
+          if (
+            report.type === 'outbound-rtp' &&
+            (report.mediaType === 'video' || report.kind === 'video')
+          ) {
             packetsSent = report.packetsSent;
           }
         });

--- a/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
+++ b/test/meetingreadinesschecker/DefaultMeetingReadinessChecker.test.ts
@@ -595,12 +595,11 @@ describe('DefaultMeetingReadinessChecker', () => {
       expect(result).to.equal(CheckAudioConnectivityFeedback.AudioNotReceived);
     });
 
-    it('success', async () => {
+    it('success with audio kind', async () => {
       domMockBehavior.rtcPeerConnectionGetStatsReports.push({
         bytesReceived: 100000,
         packetsReceived: 100,
         kind: 'audio',
-        mediaType: 'audio',
         type: 'inbound-rtp',
       });
       const result = await meetingReadinessCheckerController.checkAudioConnectivity(
@@ -614,7 +613,6 @@ describe('DefaultMeetingReadinessChecker', () => {
         bytesSent: 100000,
         packetsSent: 100,
         kind: 'audio',
-        mediaType: 'audio',
         type: 'outbound-rtp',
       });
       const result = await meetingReadinessCheckerController.checkAudioConnectivity(
@@ -669,14 +667,13 @@ describe('DefaultMeetingReadinessChecker', () => {
       expect(result).to.equal(CheckVideoConnectivityFeedback.VideoNotSent);
     });
 
-    it('success', async () => {
+    it('success with video kind', async () => {
       domMockBehavior.getUserMediaSucceeds = true;
       domMockBehavior.rtcPeerConnectionGetStatsReports = [
         {
           bytesSent: 100000,
           packetsSent: 100,
           kind: 'video',
-          mediaType: 'video',
           type: 'outbound-rtp',
         },
       ];


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
 - `mediaType` is missing from the RTCStatsReport. 

https://developer.mozilla.org/en-US/docs/Web/API/RTCInboundRtpStreamStats#:~:text=A%20string%20whose%20value%20is%20%22audio%22%20if%20the%20associated%20MediaStreamTrack%20is%20audio%2Donly%20or%20%22video%22%20if%20the%20track%20contains%20video.%20This%20value%20will%20match%20that%20of%20the%20media%20type%20indicated%20by%20RTCCodecStats.codec%2C%20as%20well%20as%20the%20track%27s%20kind%20property.%20Previously%20called%20mediaType.

MediaType was deprecated and replaced with `kind` - for backwards compatibility, we can just look for the new field `kind` or `mediaType`

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- npm run build and npm run start meetingreadinesschecker demo

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
- yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

