### PR TITLE
Fixed serverless deploy script

### DIFF
--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -272,8 +272,8 @@ function ensureRegion() {
 }
 
 function ensureMediaPipelinesRegion() {
-  if (!(new Set(supportedMediaPipelinesControlRegions)).has(region)) {
-      console.error(`Amazon Chime SDK Media Pipelines does not support ${region} (control region). Specify one of the following regions: ${supportedMediaPipelinesControlRegions.join(', ')}.\nSee https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines for more information.`);
+  if (!(new Set(supportedMediaPipelinesControlRegions)).has(mediaPipelinesControlRegion)) {
+      console.error(`Amazon Chime SDK Media Pipelines does not support ${mediaPipelinesControlRegion} (control region). Specify one of the following regions: ${supportedMediaPipelinesControlRegions.join(', ')}.\nSee https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines for more information.`);
       process.exit(1);
   }
 }


### PR DESCRIPTION
Fixed problem of referencing wrong variables

```
npm run deploy -- -r ap-northeast-1 --chime-sdk-media-pipelines-region us-east-1 -b chime-demo-bucket -s chime-demo-stack -a meeting

> amazon-chime-sdk-js-serverless-demos@0.1.0 deploy
> node ./deploy.js -r ap-northeast-1 --chime-sdk-media-pipelines-region us-east-1 -b chime-demo-bucket -s chime-demo-stack -a meeting

Amazon Chime SDK Media Pipelines does not support ap-northeast-1 (control region). Specify one of the following regions: ap-southeast-1, eu-central-1, us-east-1, us-west-2.
See https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines for more information.
```