### PR TITLE
Avoid unnecessary transceiver creation by using no-video policy for content share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Simplified simulcast uplink policy to not unnecesarily try to compensate for uplink bandwidth estimation.
+- Avoid unnecessary transceiver creation by using no-video policy for content share.
 
 ### Fixed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1586,9 +1586,10 @@ export class DemoMeetingApp
       this.toggleButton(button, isPromoted ? 'off' : 'disabled');
     }
 
-    // Additionally mute audio so it's not in an unexpected state when demoted
+    // Additionally mute audio and stop local video so it's not in an unexpected state when demoted
     if (!isPromoted) {
       this.audioVideo.realtimeMuteLocalAudio();
+      this.audioVideo.stopLocalVideoTile();
     }
   }
 

--- a/docs/classes/defaultcontentsharecontroller.html
+++ b/docs/classes/defaultcontentsharecontroller.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L47">src/contentsharecontroller/DefaultContentShareController.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L49">src/contentsharecontroller/DefaultContentShareController.ts:49</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">destroyed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L47">src/contentsharecontroller/DefaultContentShareController.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L49">src/contentsharecontroller/DefaultContentShareController.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#addcontentshareobserver">addContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L160">src/contentsharecontroller/DefaultContentShareController.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L162">src/contentsharecontroller/DefaultContentShareController.ts:162</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,7 +208,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstart">audioVideoDidStart</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L178">src/contentsharecontroller/DefaultContentShareController.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L180">src/contentsharecontroller/DefaultContentShareController.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -231,7 +231,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideoobserver.html">AudioVideoObserver</a>.<a href="../interfaces/audiovideoobserver.html#audiovideodidstop">audioVideoDidStop</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L184">src/contentsharecontroller/DefaultContentShareController.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L186">src/contentsharecontroller/DefaultContentShareController.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/destroyable.html">Destroyable</a>.<a href="../interfaces/destroyable.html#destroy">destroy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L140">src/contentsharecontroller/DefaultContentShareController.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L142">src/contentsharecontroller/DefaultContentShareController.ts:142</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -285,7 +285,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#enablesvcforcontentshare">enableSVCForContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L78">src/contentsharecontroller/DefaultContentShareController.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L80">src/contentsharecontroller/DefaultContentShareController.ts:80</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -316,7 +316,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#enablesimulcastforcontentshare">enableSimulcastForContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L62">src/contentsharecontroller/DefaultContentShareController.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L64">src/contentsharecontroller/DefaultContentShareController.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -353,7 +353,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#foreachcontentshareobserver">forEachContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L168">src/contentsharecontroller/DefaultContentShareController.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L170">src/contentsharecontroller/DefaultContentShareController.ts:170</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -401,7 +401,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#pausecontentshare">pauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L120">src/contentsharecontroller/DefaultContentShareController.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L122">src/contentsharecontroller/DefaultContentShareController.ts:122</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -427,7 +427,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#removecontentshareobserver">removeContentShareObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L164">src/contentsharecontroller/DefaultContentShareController.ts:164</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L166">src/contentsharecontroller/DefaultContentShareController.ts:166</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -456,7 +456,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#setcontentaudioprofile">setContentAudioProfile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L58">src/contentsharecontroller/DefaultContentShareController.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L60">src/contentsharecontroller/DefaultContentShareController.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -487,7 +487,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#setcontentsharevideocodecpreferences">setContentShareVideoCodecPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L136">src/contentsharecontroller/DefaultContentShareController.ts:136</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L138">src/contentsharecontroller/DefaultContentShareController.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -517,7 +517,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#startcontentshare">startContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L86">src/contentsharecontroller/DefaultContentShareController.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L88">src/contentsharecontroller/DefaultContentShareController.ts:88</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -546,7 +546,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#startcontentsharefromscreencapture">startContentShareFromScreenCapture</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L108">src/contentsharecontroller/DefaultContentShareController.ts:108</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L110">src/contentsharecontroller/DefaultContentShareController.ts:110</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -578,7 +578,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#stopcontentshare">stopContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L155">src/contentsharecontroller/DefaultContentShareController.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L157">src/contentsharecontroller/DefaultContentShareController.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -601,7 +601,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/contentsharecontroller.html">ContentShareController</a>.<a href="../interfaces/contentsharecontroller.html#unpausecontentshare">unpauseContentShare</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L128">src/contentsharecontroller/DefaultContentShareController.ts:128</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L130">src/contentsharecontroller/DefaultContentShareController.ts:130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -623,7 +623,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L26">src/contentsharecontroller/DefaultContentShareController.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/contentsharecontroller/DefaultContentShareController.ts#L27">src/contentsharecontroller/DefaultContentShareController.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/contentsharecontroller/DefaultContentShareController.ts
+++ b/src/contentsharecontroller/DefaultContentShareController.ts
@@ -14,6 +14,7 @@ import DefaultModality from '../modality/DefaultModality';
 import AsyncScheduler from '../scheduler/AsyncScheduler';
 import VideoCodecCapability from '../sdp/VideoCodecCapability';
 import { Maybe } from '../utils/Types';
+import NoVideoDownlinkBandwidthPolicy from '../videodownlinkbandwidthpolicy/NoVideoDownlinkBandwidthPolicy';
 import VideoTile from '../videotile/VideoTile';
 import ContentShareSimulcastEncodingParameters from '../videouplinkbandwidthpolicy/ContentShareSimulcastEncodingParameters';
 import DefaultSimulcastUplinkPolicyForContentShare from '../videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicyForContentShare';
@@ -39,6 +40,7 @@ export default class DefaultContentShareController
     contentShareConfiguration.credentials.joinToken =
       configuration.credentials.joinToken + ContentShareConstants.Modality;
     contentShareConfiguration.meetingFeatures = configuration.meetingFeatures.clone();
+    contentShareConfiguration.videoDownlinkBandwidthPolicy = new NoVideoDownlinkBandwidthPolicy();
     return contentShareConfiguration;
   }
 


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:** 
TLDR: It probably could be reproduced without content but basically,
* The content share peer connection actually subscribes to all remote videos but the backend just marks all sections as inactive (has always been like this).
* On the backend, we label the inactive sections with the static label inactive, as some multiple year old mitigation I added for a Firefox Unsignaled SSRC bug.
* [libwebrtc now rejects the SDP](https://webrtc.googlesource.com/src/+/6a8236617dd9416ea0fe7767166cc8e8c729d5e6) if there are two sections with the same msid like that, since the spec.

I'm pushing a fix on the backend to disambiguate the dummy MSIDs in the next week which fully mitigates this issue, but felt like removing the unnecessary subscriptions from the client side as well.

**Testing:**
Mitigates issue without aforementioned backend fix.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Join 2 attendees with video
2. Enable content share

For unrelated demo fix
1. Join replica meeting and promote
2. Enable video
3. Demote
4. Demo should automatically turn off video


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

