### PR TITLE
bump node version in serverless demo from 14.x to 20.x

### DIFF
--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -43,7 +43,7 @@ Conditions:
   ShouldDeployFetchCredentialLambda: !Equals [true, !Ref UseFetchCredentialLambda]
 Globals:
   Function:
-    Runtime: nodejs14.x
+    Runtime: nodejs20.x
     Timeout: 30
     MemorySize: 128
     Environment:


### PR DESCRIPTION
**Issue #:** 2850

**Description of changes:** Building on #2827 could bump the Lambda runtime up to Node 20.x in template.yaml

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

cd demos/serverless
npm install
npm run deploy -- -r us-east-1 -b <bucket-name> -s <cloudformation-stack-name> -a meeting

Wait for deploy to fail. Check Cloudformation Events for cause of failure.


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes

  2361 passing (3m)


=============================== Coverage summary ===============================
Statements   : 100% ( 11759/11759 )
Branches     : 100% ( 5291/5291 )
Functions    : 100% ( 2178/2178 )
Lines        : 100% ( 11590/11590 )
================================================================================


3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

