### PR TITLE
Properly wrap 'setSinkId' in try/catch to fix firefox integ. test failures

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -3009,8 +3009,12 @@ export class DemoMeetingApp
     // Set it for the content share stream if we can.
     const videoElem = document.getElementById('content-share-video') as HTMLVideoElement;
     if (this.defaultBrowserBehavior.supportsSetSinkId()) {
-      // @ts-ignore
-      videoElem.setSinkId(device);
+      try {
+        // @ts-ignore
+        await videoElem.setSinkId(device);
+      } catch (e) {
+        this.log('Failed to set audio output', e);
+      }
     }
 
     await this.audioVideo.chooseAudioOutput(device);


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
Properly wrap 'setSinkId' in try/catch to fix firefox integ. test failures. This was annoying to debug...

**Testing:**
Forced exception thrown in `setDeviceLabelTrigger` which leads to the uncaught rejection.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

