### PR TITLE
Fixed packets received check on Safari 17.3 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [3.21.1] - 2024-03-28
+
+### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+- Fixed packets received check on Safari 17.3 and below
+
 ## [3.21.0] - 2024-02-12
 
 ### Added

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../..": {
-      "version": "3.21.0",
+      "version": "3.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts
+++ b/src/connectionmonitor/SignalingAndMetricsConnectionMonitor.ts
@@ -15,8 +15,8 @@ import ConnectionMonitor from './ConnectionMonitor';
 export default class SignalingAndMetricsConnectionMonitor
   implements ConnectionMonitor, PingPongObserver, AudioVideoObserver {
   private isActive = false;
-  private hasSeenValidPacketMetricsBefore = false;
-  private lastTotalPacketsReceived = 0;
+  private hasSeenValidCandidatePairMetricsBefore = false;
+  private lastTotalBytesReceived = 0;
 
   constructor(
     private audioVideoController: AudioVideoController,
@@ -87,28 +87,28 @@ export default class SignalingAndMetricsConnectionMonitor
       this.connectionHealthData.setAudioSpeakerDelayMs(audioSpeakerDelayMs);
     }
 
-    // To get the total packets received, including RTCP, we need to sum up
+    // To get the total bytes received, including RTCP, we need to sum up
     // all candidate pair metrics (in case the candidate pair changes).
     //
     // The stats collector currently doesn't account for candidate pair stats
     // so we just use the raw report for now.
     const webrtcReport = clientMetricReport.getRTCStatsReport();
 
-    let totalPacketsReceived = 0;
+    let totalBytesReceived = 0;
     webrtcReport.forEach(stat => {
-      if (stat.type === 'candidate-pair' && stat.packetsReceived) {
-        totalPacketsReceived += stat.packetsReceived;
+      if (stat.type === 'candidate-pair' && stat.bytesReceived) {
+        totalBytesReceived += stat.bytesReceived;
       }
     });
-    const packetsReceived = totalPacketsReceived - this.lastTotalPacketsReceived;
-    this.lastTotalPacketsReceived = totalPacketsReceived;
+    const bytesReceived = totalBytesReceived - this.lastTotalBytesReceived;
+    this.lastTotalBytesReceived = totalBytesReceived;
     if (
       typeof potentialAudioPacketsReceived === 'number' &&
       typeof potentialAudioFractionPacketsLostInbound === 'number'
     ) {
       audioPacketsReceived = potentialAudioPacketsReceived;
       audiofractionPacketsLostInbound = potentialAudioFractionPacketsLostInbound;
-      if (audioPacketsReceived < 0 || audiofractionPacketsLostInbound < 0 || packetsReceived < 0) {
+      if (audioPacketsReceived < 0 || audiofractionPacketsLostInbound < 0 || bytesReceived < 0) {
         // The stats collector or logic above may emit negative numbers on this metric after reconnect
         // which we should not use.
         return;
@@ -124,10 +124,13 @@ export default class SignalingAndMetricsConnectionMonitor
       this.connectionHealthData.fractionPacketsLostInboundInLastMinute,
       audiofractionPacketsLostInbound
     );
-    if (packetsReceived > 0) {
-      this.hasSeenValidPacketMetricsBefore = true;
+
+    // We use candidate pair bytes received as a proxy for packets received
+    // since not all versions of all browsers have 'packetsReceived' for candidate pairs
+    if (bytesReceived > 0) {
+      this.hasSeenValidCandidatePairMetricsBefore = true;
       this.connectionHealthData.setConsecutiveStatsWithNoPackets(0);
-    } else if (this.hasSeenValidPacketMetricsBefore) {
+    } else if (this.hasSeenValidCandidatePairMetricsBefore) {
       this.connectionHealthData.setConsecutiveStatsWithNoPackets(
         this.connectionHealthData.consecutiveStatsWithNoPackets + 1
       );

--- a/test/connectionmonitor/SignalingAndMetricsConnectionMonitor.test.ts
+++ b/test/connectionmonitor/SignalingAndMetricsConnectionMonitor.test.ts
@@ -114,7 +114,7 @@ describe('SignalingAndMetricsConnectionMonitor', () => {
     videoDownstreamFrameHeight: RawMetrics = 100;
     videoDownstreamFrameWidth: RawMetrics = 100;
     audioPacketsSent: RawMetrics = 50;
-    totalPacketsReceived: number = 0;
+    totalBytesReceived: number = 0;
 
     getObservableMetrics(): { [id: string]: number } {
       return {
@@ -145,7 +145,7 @@ describe('SignalingAndMetricsConnectionMonitor', () => {
           {
             type: 'candidate-pair',
             ...{
-              packetsReceived: this.totalPacketsReceived,
+              bytesReceived: this.totalBytesReceived,
             },
           },
         ],
@@ -154,7 +154,7 @@ describe('SignalingAndMetricsConnectionMonitor', () => {
           {
             type: 'candidate-pair',
             ...{
-              packetsReceived: 0,
+              bytesReceived: 0,
             },
           },
         ],
@@ -287,12 +287,12 @@ describe('SignalingAndMetricsConnectionMonitor', () => {
     expect(lastPacketLossInboundTimestampMsCalled).to.equal(false);
   });
 
-  it('can return without changing stats when total packets received is negative', () => {
-    testClientMetricReport.totalPacketsReceived = 4;
+  it('can return without changing stats when total bytes received is negative', () => {
+    testClientMetricReport.totalBytesReceived = 4;
     testClientMetricReport.fractionLoss = 0;
     testClientMetricReport.audioPacketsReceived = 1;
     sendClientMetricReport(testClientMetricReport);
-    testClientMetricReport.totalPacketsReceived = 2;
+    testClientMetricReport.totalBytesReceived = 2;
     testClientMetricReport.fractionLoss = 0;
     testClientMetricReport.audioPacketsReceived = 1;
     sendClientMetricReport(testClientMetricReport);
@@ -301,18 +301,18 @@ describe('SignalingAndMetricsConnectionMonitor', () => {
     expect(lastPacketLossInboundTimestampMsCalled).to.equal(false);
   });
 
-  it('can reset and increment consecutive stats with no packets when packets received are followed by no packets', () => {
-    testClientMetricReport.totalPacketsReceived = 1;
+  it('can reset and increment consecutive stats with no bytes when bytes received are followed by no bytes', () => {
+    testClientMetricReport.totalBytesReceived = 1;
     testClientMetricReport.fractionLoss = 0;
     testClientMetricReport.audioPacketsReceived = 1;
     sendClientMetricReport(testClientMetricReport);
     expect(consecutiveStatsWithNoPackets).to.equal(0);
-    testClientMetricReport.totalPacketsReceived = 1;
+    testClientMetricReport.totalBytesReceived = 1;
     testClientMetricReport.fractionLoss = 0;
     testClientMetricReport.audioPacketsReceived = 0;
     sendClientMetricReport(testClientMetricReport);
     expect(consecutiveStatsWithNoPackets).to.equal(1);
-    testClientMetricReport.totalPacketsReceived = 1;
+    testClientMetricReport.totalBytesReceived = 1;
     testClientMetricReport.fractionLoss = 0;
     testClientMetricReport.audioPacketsReceived = 0;
     sendClientMetricReport(testClientMetricReport);


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** Safari only has bytes received on 17.3 and below, so switching to that should be sufficient. Ping-pong check doesn't work in these cases to trigger reconnect itself even though websocket is snapped, but will fix that another day. I made a new minor version since I am just going to hotfix this out.

This original change was released in 3.20, and lead to re-connections not occurring on network changes.

**Testing:**
Tested on Safari 17.3 ios, 17.4 macos, firefox, chrome with forced toggle.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Join with Safari 17.3 browser
2. Toggle WiFi off and on. You may need to delay how long you keep it off.
3. Should reconnect after around 15 seconds

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

