### PR TITLE
Avoid subscribes when simulcast is enabled but not currently sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Avoid subscribes when simulcast is enabled but not currently sending
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
-- Avoid subscribes when simulcast is enabled but not currently sending
+
+- Avoid subscribes when simulcast is enabled but not currently sending, or when using server side network adaptation.
 
 ### Fixed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
 - Fixed packets received check on Safari 17.3 and below
 
 ## [3.21.0] - 2024-02-12

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -455,7 +455,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1674">src/audiovideocontroller/DefaultAudioVideoController.ts:1674</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1675">src/audiovideocontroller/DefaultAudioVideoController.ts:1675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1647">src/audiovideocontroller/DefaultAudioVideoController.ts:1647</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1648">src/audiovideocontroller/DefaultAudioVideoController.ts:1648</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -534,7 +534,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1613">src/audiovideocontroller/DefaultAudioVideoController.ts:1613</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1614">src/audiovideocontroller/DefaultAudioVideoController.ts:1614</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -643,7 +643,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1603">src/audiovideocontroller/DefaultAudioVideoController.ts:1603</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1604">src/audiovideocontroller/DefaultAudioVideoController.ts:1604</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -665,7 +665,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1554">src/audiovideocontroller/DefaultAudioVideoController.ts:1554</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1555">src/audiovideocontroller/DefaultAudioVideoController.ts:1555</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -689,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1483">src/audiovideocontroller/DefaultAudioVideoController.ts:1483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1484">src/audiovideocontroller/DefaultAudioVideoController.ts:1484</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -721,7 +721,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1583">src/audiovideocontroller/DefaultAudioVideoController.ts:1583</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1584">src/audiovideocontroller/DefaultAudioVideoController.ts:1584</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -750,7 +750,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1622">src/audiovideocontroller/DefaultAudioVideoController.ts:1622</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1623">src/audiovideocontroller/DefaultAudioVideoController.ts:1623</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -806,7 +806,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1348">src/audiovideocontroller/DefaultAudioVideoController.ts:1348</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1349">src/audiovideocontroller/DefaultAudioVideoController.ts:1349</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -862,7 +862,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1215">src/audiovideocontroller/DefaultAudioVideoController.ts:1215</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1216">src/audiovideocontroller/DefaultAudioVideoController.ts:1216</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -892,7 +892,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1180">src/audiovideocontroller/DefaultAudioVideoController.ts:1180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1181">src/audiovideocontroller/DefaultAudioVideoController.ts:1181</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -923,7 +923,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1157">src/audiovideocontroller/DefaultAudioVideoController.ts:1157</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1158">src/audiovideocontroller/DefaultAudioVideoController.ts:1158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -965,7 +965,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1589">src/audiovideocontroller/DefaultAudioVideoController.ts:1589</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1024,7 +1024,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1595">src/audiovideocontroller/DefaultAudioVideoController.ts:1595</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1064,7 +1064,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1539">src/audiovideocontroller/DefaultAudioVideoController.ts:1539</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1540">src/audiovideocontroller/DefaultAudioVideoController.ts:1540</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1250,7 +1250,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1656">src/audiovideocontroller/DefaultAudioVideoController.ts:1656</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1657">src/audiovideocontroller/DefaultAudioVideoController.ts:1657</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -455,7 +455,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1677">src/audiovideocontroller/DefaultAudioVideoController.ts:1677</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1681">src/audiovideocontroller/DefaultAudioVideoController.ts:1681</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1650">src/audiovideocontroller/DefaultAudioVideoController.ts:1650</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1654">src/audiovideocontroller/DefaultAudioVideoController.ts:1654</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -534,7 +534,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1616">src/audiovideocontroller/DefaultAudioVideoController.ts:1616</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1620">src/audiovideocontroller/DefaultAudioVideoController.ts:1620</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -643,7 +643,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1606">src/audiovideocontroller/DefaultAudioVideoController.ts:1606</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1610">src/audiovideocontroller/DefaultAudioVideoController.ts:1610</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -665,7 +665,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1557">src/audiovideocontroller/DefaultAudioVideoController.ts:1557</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1561">src/audiovideocontroller/DefaultAudioVideoController.ts:1561</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -689,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1486">src/audiovideocontroller/DefaultAudioVideoController.ts:1486</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1490">src/audiovideocontroller/DefaultAudioVideoController.ts:1490</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -721,7 +721,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1586">src/audiovideocontroller/DefaultAudioVideoController.ts:1586</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -750,7 +750,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1625">src/audiovideocontroller/DefaultAudioVideoController.ts:1625</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1629">src/audiovideocontroller/DefaultAudioVideoController.ts:1629</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -806,7 +806,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1351">src/audiovideocontroller/DefaultAudioVideoController.ts:1351</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1355">src/audiovideocontroller/DefaultAudioVideoController.ts:1355</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -862,7 +862,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1218">src/audiovideocontroller/DefaultAudioVideoController.ts:1218</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1222">src/audiovideocontroller/DefaultAudioVideoController.ts:1222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -892,7 +892,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1183">src/audiovideocontroller/DefaultAudioVideoController.ts:1183</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1187">src/audiovideocontroller/DefaultAudioVideoController.ts:1187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -923,7 +923,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1164">src/audiovideocontroller/DefaultAudioVideoController.ts:1164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -965,7 +965,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1592">src/audiovideocontroller/DefaultAudioVideoController.ts:1592</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1024,7 +1024,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1598">src/audiovideocontroller/DefaultAudioVideoController.ts:1598</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1602">src/audiovideocontroller/DefaultAudioVideoController.ts:1602</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1064,7 +1064,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1542">src/audiovideocontroller/DefaultAudioVideoController.ts:1542</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1546">src/audiovideocontroller/DefaultAudioVideoController.ts:1546</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1232,7 +1232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1120">src/audiovideocontroller/DefaultAudioVideoController.ts:1120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1124">src/audiovideocontroller/DefaultAudioVideoController.ts:1124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1250,7 +1250,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1659">src/audiovideocontroller/DefaultAudioVideoController.ts:1659</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1663">src/audiovideocontroller/DefaultAudioVideoController.ts:1663</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/defaultaudiovideocontroller.html
+++ b/docs/classes/defaultaudiovideocontroller.html
@@ -455,7 +455,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1675">src/audiovideocontroller/DefaultAudioVideoController.ts:1675</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1677">src/audiovideocontroller/DefaultAudioVideoController.ts:1677</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#demotefromprimarymeeting">demoteFromPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1648">src/audiovideocontroller/DefaultAudioVideoController.ts:1648</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1650">src/audiovideocontroller/DefaultAudioVideoController.ts:1650</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -534,7 +534,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/simulcastuplinkobserver.html">SimulcastUplinkObserver</a>.<a href="../interfaces/simulcastuplinkobserver.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1614">src/audiovideocontroller/DefaultAudioVideoController.ts:1614</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1616">src/audiovideocontroller/DefaultAudioVideoController.ts:1616</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -643,7 +643,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1604">src/audiovideocontroller/DefaultAudioVideoController.ts:1604</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1606">src/audiovideocontroller/DefaultAudioVideoController.ts:1606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -665,7 +665,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1555">src/audiovideocontroller/DefaultAudioVideoController.ts:1555</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1557">src/audiovideocontroller/DefaultAudioVideoController.ts:1557</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -689,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1484">src/audiovideocontroller/DefaultAudioVideoController.ts:1484</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1486">src/audiovideocontroller/DefaultAudioVideoController.ts:1486</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -721,7 +721,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1584">src/audiovideocontroller/DefaultAudioVideoController.ts:1584</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1586">src/audiovideocontroller/DefaultAudioVideoController.ts:1586</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -750,7 +750,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#promotetoprimarymeeting">promoteToPrimaryMeeting</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1623">src/audiovideocontroller/DefaultAudioVideoController.ts:1623</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1625">src/audiovideocontroller/DefaultAudioVideoController.ts:1625</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -806,7 +806,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1349">src/audiovideocontroller/DefaultAudioVideoController.ts:1349</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1351">src/audiovideocontroller/DefaultAudioVideoController.ts:1351</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -862,7 +862,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1216">src/audiovideocontroller/DefaultAudioVideoController.ts:1216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1218">src/audiovideocontroller/DefaultAudioVideoController.ts:1218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -892,7 +892,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1181">src/audiovideocontroller/DefaultAudioVideoController.ts:1181</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1183">src/audiovideocontroller/DefaultAudioVideoController.ts:1183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -923,7 +923,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1158">src/audiovideocontroller/DefaultAudioVideoController.ts:1158</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -965,7 +965,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1592">src/audiovideocontroller/DefaultAudioVideoController.ts:1592</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1024,7 +1024,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1598">src/audiovideocontroller/DefaultAudioVideoController.ts:1598</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1064,7 +1064,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/audiovideocontroller.html">AudioVideoController</a>.<a href="../interfaces/audiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1540">src/audiovideocontroller/DefaultAudioVideoController.ts:1540</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1542">src/audiovideocontroller/DefaultAudioVideoController.ts:1542</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1232,7 +1232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1118">src/audiovideocontroller/DefaultAudioVideoController.ts:1118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1120">src/audiovideocontroller/DefaultAudioVideoController.ts:1120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1250,7 +1250,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/mediastreambrokerobserver.html">MediaStreamBrokerObserver</a>.<a href="../interfaces/mediastreambrokerobserver.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1657">src/audiovideocontroller/DefaultAudioVideoController.ts:1657</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1659">src/audiovideocontroller/DefaultAudioVideoController.ts:1659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -378,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1674">src/audiovideocontroller/DefaultAudioVideoController.ts:1674</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1675">src/audiovideocontroller/DefaultAudioVideoController.ts:1675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1613">src/audiovideocontroller/DefaultAudioVideoController.ts:1613</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1614">src/audiovideocontroller/DefaultAudioVideoController.ts:1614</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1603">src/audiovideocontroller/DefaultAudioVideoController.ts:1603</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1604">src/audiovideocontroller/DefaultAudioVideoController.ts:1604</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -589,7 +589,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1554">src/audiovideocontroller/DefaultAudioVideoController.ts:1554</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1555">src/audiovideocontroller/DefaultAudioVideoController.ts:1555</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1483">src/audiovideocontroller/DefaultAudioVideoController.ts:1483</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1484">src/audiovideocontroller/DefaultAudioVideoController.ts:1484</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -645,7 +645,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1583">src/audiovideocontroller/DefaultAudioVideoController.ts:1583</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1584">src/audiovideocontroller/DefaultAudioVideoController.ts:1584</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -730,7 +730,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1348">src/audiovideocontroller/DefaultAudioVideoController.ts:1348</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1349">src/audiovideocontroller/DefaultAudioVideoController.ts:1349</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -786,7 +786,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1215">src/audiovideocontroller/DefaultAudioVideoController.ts:1215</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1216">src/audiovideocontroller/DefaultAudioVideoController.ts:1216</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -816,7 +816,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1180">src/audiovideocontroller/DefaultAudioVideoController.ts:1180</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1181">src/audiovideocontroller/DefaultAudioVideoController.ts:1181</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -847,7 +847,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1157">src/audiovideocontroller/DefaultAudioVideoController.ts:1157</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1158">src/audiovideocontroller/DefaultAudioVideoController.ts:1158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -889,7 +889,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1589">src/audiovideocontroller/DefaultAudioVideoController.ts:1589</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -948,7 +948,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1595">src/audiovideocontroller/DefaultAudioVideoController.ts:1595</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -988,7 +988,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1539">src/audiovideocontroller/DefaultAudioVideoController.ts:1539</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1540">src/audiovideocontroller/DefaultAudioVideoController.ts:1540</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1166,7 +1166,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1656">src/audiovideocontroller/DefaultAudioVideoController.ts:1656</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1657">src/audiovideocontroller/DefaultAudioVideoController.ts:1657</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -378,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1675">src/audiovideocontroller/DefaultAudioVideoController.ts:1675</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1677">src/audiovideocontroller/DefaultAudioVideoController.ts:1677</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1614">src/audiovideocontroller/DefaultAudioVideoController.ts:1614</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1616">src/audiovideocontroller/DefaultAudioVideoController.ts:1616</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1604">src/audiovideocontroller/DefaultAudioVideoController.ts:1604</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1606">src/audiovideocontroller/DefaultAudioVideoController.ts:1606</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -589,7 +589,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1555">src/audiovideocontroller/DefaultAudioVideoController.ts:1555</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1557">src/audiovideocontroller/DefaultAudioVideoController.ts:1557</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1484">src/audiovideocontroller/DefaultAudioVideoController.ts:1484</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1486">src/audiovideocontroller/DefaultAudioVideoController.ts:1486</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -645,7 +645,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1584">src/audiovideocontroller/DefaultAudioVideoController.ts:1584</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1586">src/audiovideocontroller/DefaultAudioVideoController.ts:1586</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -730,7 +730,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1349">src/audiovideocontroller/DefaultAudioVideoController.ts:1349</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1351">src/audiovideocontroller/DefaultAudioVideoController.ts:1351</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -786,7 +786,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1216">src/audiovideocontroller/DefaultAudioVideoController.ts:1216</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1218">src/audiovideocontroller/DefaultAudioVideoController.ts:1218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -816,7 +816,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1181">src/audiovideocontroller/DefaultAudioVideoController.ts:1181</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1183">src/audiovideocontroller/DefaultAudioVideoController.ts:1183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -847,7 +847,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1158">src/audiovideocontroller/DefaultAudioVideoController.ts:1158</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -889,7 +889,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1592">src/audiovideocontroller/DefaultAudioVideoController.ts:1592</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -948,7 +948,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1598">src/audiovideocontroller/DefaultAudioVideoController.ts:1598</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -988,7 +988,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1540">src/audiovideocontroller/DefaultAudioVideoController.ts:1540</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1542">src/audiovideocontroller/DefaultAudioVideoController.ts:1542</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1148,7 +1148,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#updatelocalvideofrompolicy">updateLocalVideoFromPolicy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1118">src/audiovideocontroller/DefaultAudioVideoController.ts:1118</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1120">src/audiovideocontroller/DefaultAudioVideoController.ts:1120</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1166,7 +1166,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1657">src/audiovideocontroller/DefaultAudioVideoController.ts:1657</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1659">src/audiovideocontroller/DefaultAudioVideoController.ts:1659</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/noopaudiovideocontroller.html
+++ b/docs/classes/noopaudiovideocontroller.html
@@ -378,7 +378,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#audioinputdidchange">audioInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1677">src/audiovideocontroller/DefaultAudioVideoController.ts:1677</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1681">src/audiovideocontroller/DefaultAudioVideoController.ts:1681</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -457,7 +457,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#encodingsimulcastlayersdidchange">encodingSimulcastLayersDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1616">src/audiovideocontroller/DefaultAudioVideoController.ts:1616</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1620">src/audiovideocontroller/DefaultAudioVideoController.ts:1620</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -566,7 +566,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#getremotevideosources">getRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1606">src/audiovideocontroller/DefaultAudioVideoController.ts:1606</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1610">src/audiovideocontroller/DefaultAudioVideoController.ts:1610</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -589,7 +589,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlehasbandwidthpriority">handleHasBandwidthPriority</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1557">src/audiovideocontroller/DefaultAudioVideoController.ts:1557</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1561">src/audiovideocontroller/DefaultAudioVideoController.ts:1561</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -613,7 +613,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#handlemeetingsessionstatus">handleMeetingSessionStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1486">src/audiovideocontroller/DefaultAudioVideoController.ts:1486</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1490">src/audiovideocontroller/DefaultAudioVideoController.ts:1490</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -645,7 +645,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#pausereceivingstream">pauseReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1586">src/audiovideocontroller/DefaultAudioVideoController.ts:1586</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1590">src/audiovideocontroller/DefaultAudioVideoController.ts:1590</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -730,7 +730,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#reconnect">reconnect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1351">src/audiovideocontroller/DefaultAudioVideoController.ts:1351</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1355">src/audiovideocontroller/DefaultAudioVideoController.ts:1355</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -786,7 +786,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalaudio">replaceLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1218">src/audiovideocontroller/DefaultAudioVideoController.ts:1218</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1222">src/audiovideocontroller/DefaultAudioVideoController.ts:1222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -816,7 +816,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#replacelocalvideo">replaceLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1183">src/audiovideocontroller/DefaultAudioVideoController.ts:1183</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1187">src/audiovideocontroller/DefaultAudioVideoController.ts:1187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -847,7 +847,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#restartlocalvideo">restartLocalVideo</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1160">src/audiovideocontroller/DefaultAudioVideoController.ts:1160</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1164">src/audiovideocontroller/DefaultAudioVideoController.ts:1164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -889,7 +889,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#resumereceivingstream">resumeReceivingStream</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1592">src/audiovideocontroller/DefaultAudioVideoController.ts:1592</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1596">src/audiovideocontroller/DefaultAudioVideoController.ts:1596</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -948,7 +948,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideocodecsendpreferences">setVideoCodecSendPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1598">src/audiovideocontroller/DefaultAudioVideoController.ts:1598</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1602">src/audiovideocontroller/DefaultAudioVideoController.ts:1602</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -988,7 +988,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#setvideomaxbandwidthkbps">setVideoMaxBandwidthKbps</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1542">src/audiovideocontroller/DefaultAudioVideoController.ts:1542</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1546">src/audiovideocontroller/DefaultAudioVideoController.ts:1546</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1148,7 +1148,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#updatelocalvideofrompolicy">updateLocalVideoFromPolicy</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1120">src/audiovideocontroller/DefaultAudioVideoController.ts:1120</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1124">src/audiovideocontroller/DefaultAudioVideoController.ts:1124</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -1166,7 +1166,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="defaultaudiovideocontroller.html">DefaultAudioVideoController</a>.<a href="defaultaudiovideocontroller.html#videoinputdidchange">videoInputDidChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1659">src/audiovideocontroller/DefaultAudioVideoController.ts:1659</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/audiovideocontroller/DefaultAudioVideoController.ts#L1663">src/audiovideocontroller/DefaultAudioVideoController.ts:1663</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -1122,6 +1122,7 @@ export default class DefaultAudioVideoController
       const encodingParam = this.meetingSessionContext.videoUplinkBandwidthPolicy.chooseEncodingParameters();
       if (
         this.mayNeedRenegotiationForSimulcastLayerChange &&
+        this.meetingSessionContext.transceiverController.hasVideoInput() &&
         !this.negotiatedBitrateLayersAllocationRtpHeaderExtension()
       ) {
         this.logger.info('Needs regenotiation for local video simulcast layer change');

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -1009,9 +1009,11 @@ export default class DefaultAudioVideoController
       });
     }
     this.logger.info(
-      `Request to update remote videos with added: ${added}, updated: ${[
-        ...simulcastStreamUpdates.entries(),
-      ]}, removed: ${removed}`
+      `Request to update remote videos with added: [${added}], updated: [${Array.from(
+        simulcastStreamUpdates.entries()
+      )
+        .map(([key, value]) => `${key}->${value}`)
+        .join(',')}], removed: [${removed}]`
     );
 
     return {

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -1036,6 +1036,10 @@ export default class DefaultAudioVideoController
       return false;
     }
 
+    // Similar to `updateRemoteVideosFromLastVideosToReceive`, we use `subscribeFrameSent` to cache the previous
+    // index so that we don't incorrectly mark a simulcast stream change (e.g. a sender switching from publishing [1, 3] to [2] to [1, 3])
+    // as the add or removal of a source
+    this.meetingSessionContext.videoStreamIndex.subscribeFrameSent();
     return true;
   }
 

--- a/src/transceivercontroller/DefaultTransceiverController.ts
+++ b/src/transceivercontroller/DefaultTransceiverController.ts
@@ -400,7 +400,7 @@ export default class DefaultTransceiverController
   }
 
   getMidForGroupId(groupId: number): string | undefined {
-    return this.groupIdToTransceiver.get(groupId)?.mid;
+    return this.groupIdToTransceiver.get(groupId)?.mid ?? undefined;
   }
 
   protected transceiverIsVideo(transceiver: RTCRtpTransceiver): boolean {

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -358,7 +358,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('start', () => {
-    it('can be started without policies in configuration', async () => {
+    xit('can be started without policies in configuration', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       audioVideoController = new DefaultAudioVideoController(
@@ -410,7 +410,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(obsever);
     });
 
-    it('can be started with a pre-start', async () => {
+    xit('can be started with a pre-start', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       audioVideoController = new DefaultAudioVideoController(
@@ -457,7 +457,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can stop after only pre-start', async () => {
+    xit('can stop after only pre-start', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -491,7 +491,7 @@ describe('DefaultAudioVideoController', () => {
       expect(audioVideoController.meetingSessionContext.signalingClient.ready()).to.be.false;
     });
 
-    it('is resilient against pre-start errors', async () => {
+    xit('is resilient against pre-start errors', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -511,7 +511,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    it('can be started with null audio host url', async () => {
+    xit('can be started with null audio host url', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       configuration.urls.audioHostURL = null;
@@ -551,7 +551,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started with customized audio and video policies', async () => {
+    xit('can be started with customized audio and video policies', async () => {
       const myUplinkPolicy = new NScaleVideoUplinkBandwidthPolicy('test');
       const myDownlinkPolicy = new AllHighestVideoBandwidthPolicy('test');
       configuration.videoUplinkBandwidthPolicy = myUplinkPolicy;
@@ -618,7 +618,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started with customized video simulcast downlink policy', async () => {
+    xit('can be started with customized video simulcast downlink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
 
@@ -672,7 +672,7 @@ describe('DefaultAudioVideoController', () => {
       bindTileControllerSpy.restore();
     });
 
-    it('can be started with default simulcast uplink and downlink policy', async () => {
+    xit('can be started with default simulcast uplink and downlink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
       const logger = new NoOpDebugLogger();
@@ -719,7 +719,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started with customized video simulcast uplink policy', async () => {
+    xit('can be started with customized video simulcast uplink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
 
@@ -765,7 +765,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started and take a bandwidth update', async () => {
+    xit('can be started and take a bandwidth update', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -813,7 +813,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started and take a bandwidth update without update transceiver controller method', async () => {
+    xit('can be started and take a bandwidth update without update transceiver controller method', async () => {
       class TestVideoUplinkBandwidth extends NoVideoUplinkBandwidthPolicy {
         hasBandwidthPriority: boolean = false;
 
@@ -857,7 +857,7 @@ describe('DefaultAudioVideoController', () => {
       spy3.restore();
     });
 
-    it('can be started and take a bandwidth update with update transceiver controller method', async () => {
+    xit('can be started and take a bandwidth update with update transceiver controller method', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'updateTransceiverController');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -878,7 +878,7 @@ describe('DefaultAudioVideoController', () => {
       spy.restore();
     });
 
-    it('can be started and stopped multiple times with transceiver controller set correctly', async function () {
+    xit('can be started and stopped multiple times with transceiver controller set correctly', async function () {
       this.timeout(5000); // Need to increase the default mocha timeout of 2000ms
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setTransceiverController');
@@ -910,7 +910,7 @@ describe('DefaultAudioVideoController', () => {
       spy.restore();
     });
 
-    it(
+    xit(
       'can be started and stopped multiple times and subscribe and unsubscribe from media stream broker observer' +
         ' correctly',
       async function () {
@@ -942,7 +942,7 @@ describe('DefaultAudioVideoController', () => {
       }
     );
 
-    it('can be started even when the stats collector has an issue starting due to an unsupported browser', async () => {
+    xit('can be started even when the stats collector has an issue starting due to an unsupported browser', async () => {
       setUserAgent(SAFARI_13_USER_AGENT);
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -966,7 +966,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('handles an error', async () => {
+    xit('handles an error', async () => {
       configuration.connectionTimeoutMs = 100;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -989,7 +989,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.called).to.be.true;
     });
 
-    it('does not call the observer if it has been removed', async () => {
+    xit('does not call the observer if it has been removed', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1045,7 +1045,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can fail but does not reconnect', async () => {
+    xit('can fail but does not reconnect', async () => {
       configuration.connectionTimeoutMs = 100;
       const logger = new NoOpDebugLogger();
       const spy = sinon.spy(logger, 'error');
@@ -1108,7 +1108,7 @@ describe('DefaultAudioVideoController', () => {
       await result;
     });
 
-    it('can be started with SVC config', async () => {
+    xit('can be started with SVC config', async () => {
       setUserAgent(CHROME_116_USER_AGENT);
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -1154,7 +1154,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('enable simulcast if both simulcast and SVC are selected', async () => {
+    xit('enable simulcast if both simulcast and SVC are selected', async () => {
       setUserAgent(CHROME_116_USER_AGENT);
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -1202,7 +1202,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('stop', () => {
-    it('can be started and stopped', async () => {
+    xit('can be started and stopped', async () => {
       let called = false;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -1226,7 +1226,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be stopped without having been started', () => {
+    xit('can be stopped without having been started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1238,7 +1238,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.stop();
     });
 
-    it('can be stopped before stop and then stopped again', () => {
+    xit('can be stopped before stop and then stopped again', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1252,7 +1252,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.stop();
     });
 
-    it('disables reconnecting once stop is called', async () => {
+    xit('disables reconnecting once stop is called', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1294,7 +1294,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('update', () => {
-    it('can be started and then start and stop a local video tile', async () => {
+    xit('can be started and then start and stop a local video tile', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1323,7 +1323,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it(
+    xit(
       'can be started and then start and stop a local video tile if video uplink does not implement set transceiver' +
         ' controller',
       async () => {
@@ -1374,7 +1374,7 @@ describe('DefaultAudioVideoController', () => {
       }
     );
 
-    it('restart local video if CreateSDP fails with IncompatibleSDP error', async () => {
+    xit('restart local video if CreateSDP fails with IncompatibleSDP error', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1415,7 +1415,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(5000);
 
-    it('reconnects if the update fails with a task failed meeting status', async () => {
+    xit('reconnects if the update fails with a task failed meeting status', async () => {
       let called = 0;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -1455,7 +1455,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(4000);
 
-    it('will skip renegotiation if video streams are not initialized', async () => {
+    xit('will skip renegotiation if video streams are not initialized', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1477,7 +1477,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will not skip renegotiation if we explicitly request it', async () => {
+    xit('will not skip renegotiation if we explicitly request it', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1502,7 +1502,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it("will not skip renegotiation if we don't have a transceiver", async () => {
+    xit("will not skip renegotiation if we don't have a transceiver", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1533,7 +1533,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it("will not skip renegotiation if transceiver controller doesn't have a mapping", async () => {
+    xit("will not skip renegotiation if transceiver controller doesn't have a mapping", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1569,7 +1569,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it('will not skip renegotiation if we are switching simulcast streams', async () => {
+    xit('will not skip renegotiation if we are switching simulcast streams', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1626,7 +1626,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it('will not skip renegotiation if current video ids are somehow null', async () => {
+    xit('will not skip renegotiation if current video ids are somehow null', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1678,7 +1678,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it('will skip renegotiation if simulcast streams do not change', async () => {
+    xit('will skip renegotiation if simulcast streams do not change', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1770,12 +1770,24 @@ describe('DefaultAudioVideoController', () => {
         hasVideoInput(): boolean {
           return true;
         }
+
+        localVideoTransceiver(): RTCRtpTransceiver {
+          const dummyTransceiver = {
+            mid: '1',
+            sender: new MockRTCRtpSender(),
+            receiver: {
+              track: {
+                kind: 'video',
+                enabled: true,
+              },
+            },
+          };
+          return dummyTransceiver as RTCRtpTransceiver;
+        }
       }
 
       // @ts-ignore
       audioVideoController.meetingSessionContext.transceiverController = new TestTransceiverController();
-      // @ts-ignore
-      audioVideoController.meetingSessionContext.transceiverController.localVideoTransceiver().sender = new MockRTCRtpSender();
       // @ts-ignore
       audioVideoController.meetingSessionContext.lastVideosToReceive = new DefaultVideoStreamIdSet([
         1,
@@ -1794,7 +1806,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will not skip renegotiation if we are updating simulcast layer change without header extension', async () => {
+    xit('will not skip renegotiation if we are updating simulcast layer change without header extension', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1841,7 +1853,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it('will skip renegotiation if we are updating simulcast layer but not sending', async () => {
+    xit('will skip renegotiation if we are updating simulcast layer but not sending', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1888,7 +1900,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will skip renegotiation if we are only completing simulcast stream switches', async () => {
+    xit('will skip renegotiation if we are only completing simulcast stream switches', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1976,7 +1988,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it("will not skip renegotiation if we don't have setStreamId", async () => {
+    xit("will not skip renegotiation if we don't have setStreamId", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2062,7 +2074,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it("will skip renegotiation even if we don't have tile", async () => {
+    xit("will skip renegotiation even if we don't have tile", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2137,7 +2149,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will skip renegotiation if there are no changes', async () => {
+    xit('will skip renegotiation if there are no changes', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2198,7 +2210,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will not skip renegotiation if we are not only completing simulcast stream switches', async () => {
+    xit('will not skip renegotiation if we are not only completing simulcast stream switches', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2258,7 +2270,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    it('will not send remoteVideoUpdate if streams are unchanged', async () => {
+    xit('will not send remoteVideoUpdate if streams are unchanged', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2349,7 +2361,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    it('will send removeVideoUpdate due to video preference', async () => {
+    xit('will send removeVideoUpdate due to video preference', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
 
@@ -2468,7 +2480,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will send removeVideoUpdate due to video preference change', async () => {
+    xit('will send removeVideoUpdate due to video preference change', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
 
@@ -2591,7 +2603,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will send removeVideoUpdate due to video preference removal', async () => {
+    xit('will send removeVideoUpdate due to video preference removal', async () => {
       const logger = new NoOpDebugLogger();
 
       const policyConfig = new VideoPriorityBasedPolicyConfig();
@@ -2711,7 +2723,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    it('will not skip renegotiation if video streams are not initialized with server side network adaptation', async () => {
+    xit('will not skip renegotiation if video streams are not initialized with server side network adaptation', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2738,7 +2750,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    it('will not send remoteVideoUpdate to video preference if missing preference', async () => {
+    xit('will not send remoteVideoUpdate to video preference if missing preference', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2831,7 +2843,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    it('will not send remoteVideoUpdate if videosToReceive changed but mid not found', async () => {
+    xit('will not send remoteVideoUpdate if videosToReceive changed but mid not found', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2931,7 +2943,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    it('will send remoteVideoUpdate if videosToReceive changed', async () => {
+    xit('will send remoteVideoUpdate if videosToReceive changed', async () => {
       const logger = new NoOpDebugLogger();
 
       const policy = new VideoPriorityBasedPolicy(logger);
@@ -3046,7 +3058,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.true;
     });
 
-    it('will send remoteVideoUpdate if videosToReceive changed with streamID 0', async () => {
+    xit('will send remoteVideoUpdate if videosToReceive changed with streamID 0', async () => {
       const logger = new NoOpDebugLogger();
       const policyConfig = new VideoPriorityBasedPolicyConfig();
       policyConfig.serverSideNetworkAdaption =
@@ -3166,7 +3178,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.true;
     });
 
-    it('will not send update if current videos ids are empty', async () => {
+    xit('will not send update if current videos ids are empty', async () => {
       const logger = new NoOpDebugLogger();
       const policyConfig = new VideoPriorityBasedPolicyConfig();
       policyConfig.serverSideNetworkAdaption =
@@ -3282,7 +3294,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    it('will not send remoteVideoUpdate if videosToReceive is empty', async () => {
+    xit('will not send remoteVideoUpdate if videosToReceive is empty', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3374,7 +3386,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    it('will skip renegotiation but not due to video preferences if videosToReceive remains same', async () => {
+    xit('will skip renegotiation but not due to video preferences if videosToReceive remains same', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3472,7 +3484,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('restartLocalVideo', () => {
-    it('restarts local video', async () => {
+    xit('restarts local video', async () => {
       class TestDeviceController extends NoOpDeviceController {
         async acquireVideoInputStream(): Promise<MediaStream> {
           const mediaStream = new MediaStream();
@@ -3517,7 +3529,7 @@ describe('DefaultAudioVideoController', () => {
       expect(called).to.be.true;
     }).timeout(5000);
 
-    it('can defer restartLocalVideo and performs a single update operation when the local video is turned off', async () => {
+    xit('can defer restartLocalVideo and performs a single update operation when the local video is turned off', async () => {
       let called = false;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3571,13 +3583,13 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('throw error video stream has no track', () => {
+    xit('throw error video stream has no track', () => {
       return expect(audioVideoController.replaceLocalVideo(new MediaStream())).to.be.rejectedWith(
         'could not acquire video track'
       );
     });
 
-    it('Throw error if no peer connection is established', async () => {
+    xit('Throw error if no peer connection is established', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3588,7 +3600,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('replaces video track', async () => {
+    xit('replaces video track', async () => {
       const stream = new MediaStream();
       // @ts-ignore
       stream.id = '2';
@@ -3633,7 +3645,7 @@ describe('DefaultAudioVideoController', () => {
       await audioVideoController.removeObserver(observer);
     });
 
-    it('Do not replace local video if local tile is null', async () => {
+    xit('Do not replace local video if local tile is null', async () => {
       const stream = new MediaStream();
       // @ts-ignore
       stream.id = '2';
@@ -3686,13 +3698,13 @@ describe('DefaultAudioVideoController', () => {
         reconnectController
       );
     });
-    it('fails if has no active audio stream', () => {
+    xit('fails if has no active audio stream', () => {
       return expect(
         audioVideoController.replaceLocalAudio(new MediaStream())
       ).to.eventually.be.rejectedWith('could not acquire audio track');
     });
 
-    it('Throw error if no peer connection is established', async () => {
+    xit('Throw error if no peer connection is established', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3703,7 +3715,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('replaces audio track', async () => {
+    xit('replaces audio track', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3734,7 +3746,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('reject if transceiver fails to replaces audio track', async () => {
+    xit('reject if transceiver fails to replaces audio track', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3771,7 +3783,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('reconnect', () => {
-    it('reconnects, calling audioVideoDidStartConnecting and audioVideoDidStart but not audioVideoDidStop', async () => {
+    xit('reconnects, calling audioVideoDidStartConnecting and audioVideoDidStart but not audioVideoDidStop', async () => {
       const sequence: string[] = [];
       let startConnectingCalled = 0;
       let startCalled = 0;
@@ -3826,7 +3838,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(5000);
 
-    it('publish meeting reconnected', async () => {
+    xit('publish meeting reconnected', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -3861,7 +3873,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     }).timeout(5000);
 
-    it('does not reconnect if canceled', async () => {
+    xit('does not reconnect if canceled', async () => {
       let called = 0;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3888,7 +3900,7 @@ describe('DefaultAudioVideoController', () => {
 
     // FinishGatheringICECandidatesTask does not throw the ICEGatheringTimeoutWorkaround error if
     // the session connection timeout is less than 5000ms.
-    it('reconnects when the start operation fails with a non-Terminal meeting status such as ICEGatheringTimeoutWorkaround', function (done) {
+    xit('reconnects when the start operation fails with a non-Terminal meeting status such as ICEGatheringTimeoutWorkaround', function (done) {
       this.timeout(20000);
 
       domMockBehavior.browserName = 'chrome';
@@ -3952,7 +3964,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    it('reconnects when the start operation fails with a task failed meeting status', function (done) {
+    xit('reconnects when the start operation fails with a task failed meeting status', function (done) {
       configuration.connectionTimeoutMs = 100;
       const logger = new NoOpDebugLogger();
       const spy = sinon.spy(logger, 'warn');
@@ -4001,7 +4013,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    it('reconnects when the reconnect operation itself fails', done => {
+    xit('reconnects when the reconnect operation itself fails', done => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'warn');
 
@@ -4041,7 +4053,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    it('uses the custom connection health policy configuration if passed', done => {
+    xit('uses the custom connection health policy configuration if passed', done => {
       // Set the missed pongs upper threshold to zero to force restarting the session.
       const connectionHealthPolicyConfiguration = new ConnectionHealthPolicyConfiguration();
       connectionHealthPolicyConfiguration.connectionWaitTimeMs = 0;
@@ -4086,7 +4098,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('reconnect for no attendee presence', () => {
-    it('reconnects when the start operation fails due to no attendee presence event', function (done) {
+    xit('reconnects when the start operation fails due to no attendee presence event', function (done) {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
@@ -4152,7 +4164,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    it('does not reconnect for no attendee presence event if the attendee presence timeout is set to zero', function (done) {
+    xit('does not reconnect for no attendee presence event if the attendee presence timeout is set to zero', function (done) {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
@@ -4220,7 +4232,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getters', () => {
-    it('returns a device controller for the mediaStreamBroker and deviceController getter', () => {
+    xit('returns a device controller for the mediaStreamBroker and deviceController getter', () => {
       const mediaStreamBroker = new NoOpMediaStreamBroker();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -4245,7 +4257,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('handles VideoCallSwitchToViewOnly', async () => {
+    xit('handles VideoCallSwitchToViewOnly', async () => {
       let called = false;
       const spy = sinon.spy(audioVideoController.videoTileController, 'removeLocalVideoTile');
       class TestObserver implements AudioVideoObserver {
@@ -4267,7 +4279,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('handles IncompatibleSDP', async () => {
+    xit('handles IncompatibleSDP', async () => {
       let called = 0;
       const spy = sinon.spy(audioVideoController, 'restartLocalVideo');
       class TestObserver implements AudioVideoObserver {
@@ -4297,7 +4309,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('does not reconnect for the terminal status or the unknown status', async () => {
+    xit('does not reconnect for the terminal status or the unknown status', async () => {
       let called = false;
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(_sessionStatus: MeetingSessionStatus): void {
@@ -4321,7 +4333,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('does not reconnect if the reconnectController is not set in the context', async () => {
+    xit('does not reconnect if the reconnectController is not set in the context', async () => {
       const spy = sinon.spy(reconnectController, 'disableReconnect');
       audioVideoController.handleMeetingSessionStatus(
         new MeetingSessionStatus(MeetingSessionStatusCode.Left),
@@ -4333,7 +4345,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('pauseReceivingStream', () => {
-    it('is no-op if meeting is not started', () => {
+    xit('is no-op if meeting is not started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4345,7 +4357,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.pauseReceivingStream(0);
     });
 
-    it('sends pause frame through signaling client', async () => {
+    xit('sends pause frame through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4366,7 +4378,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('resumeReceivingStream', () => {
-    it('is no-op if meeting is not started', () => {
+    xit('is no-op if meeting is not started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4378,7 +4390,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.resumeReceivingStream(0);
     });
 
-    it('sends resume frame through signaling client', async () => {
+    xit('sends resume frame through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4400,7 +4412,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('setVideoCodecSendPreferences', () => {
-    it('calls update', async () => {
+    xit('calls update', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4420,7 +4432,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.callCount).to.equal(1);
     });
 
-    it('does not trigger an update if invoked before the session starts.', async () => {
+    xit('does not trigger an update if invoked before the session starts.', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4437,7 +4449,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getRTCPeerConnectionStats', () => {
-    it('calls getStats', async () => {
+    xit('calls getStats', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4456,7 +4468,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnceWith()).to.be.true;
     });
 
-    it('calls getStats with media stream strack', async () => {
+    xit('calls getStats with media stream strack', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4476,7 +4488,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnceWith(track)).to.be.true;
     });
 
-    it('return null if no peer connection is established', async () => {
+    xit('return null if no peer connection is established', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4491,7 +4503,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('when simulcast is enabled', () => {
-    it('will be automatically switched off if platform is not Chrome', async () => {
+    xit('will be automatically switched off if platform is not Chrome', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -4507,7 +4519,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    it('can be started', async () => {
+    xit('can be started', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome116';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4569,7 +4581,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('can be started for content share attendee', async () => {
+    xit('can be started for content share attendee', async () => {
       const attendeeId = defaultAttendeeId + ContentShareConstants.Modality;
       configuration.credentials.attendeeId = attendeeId;
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -4613,7 +4625,7 @@ describe('DefaultAudioVideoController', () => {
     });
   });
 
-  it('can be started for content share attendee with UHD feature', async () => {
+  xit('can be started for content share attendee with UHD feature', async () => {
     const attendeeId = defaultAttendeeId + ContentShareConstants.Modality;
     configuration.meetingFeatures.contentMaxResolution = VideoQualitySettings.VideoResolutionUHD;
     configuration.credentials.attendeeId = attendeeId;
@@ -4664,7 +4676,7 @@ describe('DefaultAudioVideoController', () => {
     audioVideoController.removeObserver(observer);
   });
 
-  it('can be started for camera video attendee with FHD feature', async () => {
+  xit('can be started for camera video attendee with FHD feature', async () => {
     const attendeeId = defaultAttendeeId;
     configuration.meetingFeatures.videoMaxResolution = VideoQualitySettings.VideoResolutionFHD;
     configuration.credentials.attendeeId = attendeeId;
@@ -4714,7 +4726,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('meeting events', () => {
-    it('sends meeting events', async () => {
+    xit('sends meeting events', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4747,7 +4759,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     });
 
-    it('sends failure events', async () => {
+    xit('sends failure events', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4787,7 +4799,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     });
 
-    it('sends failure events with a non-empty error message', async () => {
+    xit('sends failure events with a non-empty error message', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4828,7 +4840,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getRemoteVideoSources', () => {
-    it('should match index frame sources excluding self', async () => {
+    xit('should match index frame sources excluding self', async () => {
       const compare = (a: VideoSource, b: VideoSource): number =>
         a.attendee.attendeeId.localeCompare(b.attendee.attendeeId);
 
@@ -4869,7 +4881,7 @@ describe('DefaultAudioVideoController', () => {
       expect(success).to.be.false;
     });
 
-    it('should return an array of length 0, when videoStreamIndex is not initialized', async () => {
+    xit('should return an array of length 0, when videoStreamIndex is not initialized', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4882,7 +4894,7 @@ describe('DefaultAudioVideoController', () => {
       expect(videoSources).to.have.lengthOf(0);
     });
 
-    it('should return [] when called after meeting session is stopped', async () => {
+    xit('should return [] when called after meeting session is stopped', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4899,7 +4911,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('encodingSimulcastLayersDidChange', () => {
-    it('observer should get called only when added', async () => {
+    xit('observer should get called only when added', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4958,7 +4970,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('observer should get called', async () => {
+    xit('observer should get called', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4985,7 +4997,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('observer should not get called with non-simulcast policy', async () => {
+    xit('observer should not get called with non-simulcast policy', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5012,7 +5024,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('promoteToPrimaryMeeting & demoteFromPrimaryMeeting', () => {
-    it('sends promotion through signaling client and waits for ack, demotes sends through signaling client', async () => {
+    xit('sends promotion through signaling client and waits for ack, demotes sends through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5059,7 +5071,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('fails promotion if timeout', async () => {
+    xit('fails promotion if timeout', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5106,7 +5118,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('calls demotion observer when leave is received', async () => {
+    xit('calls demotion observer when leave is received', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5143,7 +5155,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    it('calls demotion observer when disconnection occurs', async () => {
+    xit('calls demotion observer when disconnection occurs', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5187,7 +5199,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('setVideoMaxBandwidthKbps', () => {
-    it('can set video max bandwidth', async () => {
+    xit('can set video max bandwidth', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setIdealMaxBandwidthKbps');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -5205,7 +5217,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('can set video max bandwidth before meeting start', async () => {
+    xit('can set video max bandwidth before meeting start', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setIdealMaxBandwidthKbps');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -5223,7 +5235,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    it('bandwidth has to be positive', () => {
+    xit('bandwidth has to be positive', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5277,7 +5289,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('Does nothing if meeting has not started yet', () => {
+    xit('Does nothing if meeting has not started yet', () => {
       const replaceAudioSpy = sinon.spy(audioVideoController, 'replaceLocalAudio');
       mediaStreamBroker.addMediaStreamBrokerObserver(audioVideoController);
       mediaStreamBroker.triggerAudioInputChangeEvent(new MediaStream());
@@ -5286,7 +5298,7 @@ describe('DefaultAudioVideoController', () => {
       replaceAudioSpy.restore();
     });
 
-    it('replace local audio', async () => {
+    xit('replace local audio', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5302,7 +5314,7 @@ describe('DefaultAudioVideoController', () => {
       replaceAudioSpy.restore();
     });
 
-    it('Try to acquire audio stream if receive undefined audio stream', async () => {
+    xit('Try to acquire audio stream if receive undefined audio stream', async () => {
       await start();
       const replaceAudioSpy = sinon.spy(audioVideoController, 'replaceLocalAudio');
       const acquireAudioSpy = sinon.spy(mediaStreamBroker, 'acquireAudioInputStream');
@@ -5315,7 +5327,7 @@ describe('DefaultAudioVideoController', () => {
       acquireAudioSpy.restore();
     });
 
-    it('throw error if failed to acquire audio input stream', async () => {
+    xit('throw error if failed to acquire audio input stream', async () => {
       class FailedObserverMediaStreamBroker extends ObserverMediaStreamBroker {
         async acquireAudioInputStream(): Promise<MediaStream> {
           throw Error('Failed');
@@ -5389,7 +5401,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    it('Does nothing if meeting has not started yet', () => {
+    xit('Does nothing if meeting has not started yet', () => {
       const replaceVideoSpy = sinon.spy(audioVideoController, 'replaceLocalVideo');
       mediaStreamBroker.addMediaStreamBrokerObserver(audioVideoController);
       mediaStreamBroker.triggerVideoInputChangeEvent(new MediaStream());
@@ -5398,7 +5410,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    it('Does nothing if local tile is not started yet', async () => {
+    xit('Does nothing if local tile is not started yet', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5413,7 +5425,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    it('replace local video if local tile started and video stream changes', async () => {
+    xit('replace local video if local tile started and video stream changes', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5431,7 +5443,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    it('stop local video if local tile started and video stream is undefined', async () => {
+    xit('stop local video if local tile started and video stream is undefined', async () => {
       await start();
       audioVideoController.videoTileController.startLocalVideoTile();
       await sendICEEventAndSubscribeAckFrame();

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -1831,6 +1831,20 @@ describe('DefaultAudioVideoController', () => {
         hasVideoInput(): boolean {
           return true;
         }
+
+        localVideoTransceiver(): RTCRtpTransceiver {
+          const dummyTransceiver = {
+            mid: '1',
+            sender: new RTCRtpSender(),
+            receiver: {
+              track: {
+                kind: 'video',
+                enabled: true,
+              },
+            },
+          };
+          return dummyTransceiver as RTCRtpTransceiver;
+        }
       }
 
       // @ts-ignore

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -358,7 +358,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('start', () => {
-    xit('can be started without policies in configuration', async () => {
+    it('can be started without policies in configuration', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       audioVideoController = new DefaultAudioVideoController(
@@ -410,7 +410,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(obsever);
     });
 
-    xit('can be started with a pre-start', async () => {
+    it('can be started with a pre-start', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       audioVideoController = new DefaultAudioVideoController(
@@ -457,7 +457,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can stop after only pre-start', async () => {
+    it('can stop after only pre-start', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -491,7 +491,7 @@ describe('DefaultAudioVideoController', () => {
       expect(audioVideoController.meetingSessionContext.signalingClient.ready()).to.be.false;
     });
 
-    xit('is resilient against pre-start errors', async () => {
+    it('is resilient against pre-start errors', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -511,7 +511,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    xit('can be started with null audio host url', async () => {
+    it('can be started with null audio host url', async () => {
       configuration.videoUplinkBandwidthPolicy = null;
       configuration.videoDownlinkBandwidthPolicy = null;
       configuration.urls.audioHostURL = null;
@@ -551,7 +551,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started with customized audio and video policies', async () => {
+    it('can be started with customized audio and video policies', async () => {
       const myUplinkPolicy = new NScaleVideoUplinkBandwidthPolicy('test');
       const myDownlinkPolicy = new AllHighestVideoBandwidthPolicy('test');
       configuration.videoUplinkBandwidthPolicy = myUplinkPolicy;
@@ -618,7 +618,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started with customized video simulcast downlink policy', async () => {
+    it('can be started with customized video simulcast downlink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
 
@@ -672,7 +672,7 @@ describe('DefaultAudioVideoController', () => {
       bindTileControllerSpy.restore();
     });
 
-    xit('can be started with default simulcast uplink and downlink policy', async () => {
+    it('can be started with default simulcast uplink and downlink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
       const logger = new NoOpDebugLogger();
@@ -719,7 +719,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started with customized video simulcast uplink policy', async () => {
+    it('can be started with customized video simulcast uplink policy', async () => {
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
 
@@ -765,7 +765,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started and take a bandwidth update', async () => {
+    it('can be started and take a bandwidth update', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -813,7 +813,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started and take a bandwidth update without update transceiver controller method', async () => {
+    it('can be started and take a bandwidth update without update transceiver controller method', async () => {
       class TestVideoUplinkBandwidth extends NoVideoUplinkBandwidthPolicy {
         hasBandwidthPriority: boolean = false;
 
@@ -857,7 +857,7 @@ describe('DefaultAudioVideoController', () => {
       spy3.restore();
     });
 
-    xit('can be started and take a bandwidth update with update transceiver controller method', async () => {
+    it('can be started and take a bandwidth update with update transceiver controller method', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'updateTransceiverController');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -878,7 +878,7 @@ describe('DefaultAudioVideoController', () => {
       spy.restore();
     });
 
-    xit('can be started and stopped multiple times with transceiver controller set correctly', async function () {
+    it('can be started and stopped multiple times with transceiver controller set correctly', async function () {
       this.timeout(5000); // Need to increase the default mocha timeout of 2000ms
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setTransceiverController');
@@ -910,7 +910,7 @@ describe('DefaultAudioVideoController', () => {
       spy.restore();
     });
 
-    xit(
+    it(
       'can be started and stopped multiple times and subscribe and unsubscribe from media stream broker observer' +
         ' correctly',
       async function () {
@@ -942,7 +942,7 @@ describe('DefaultAudioVideoController', () => {
       }
     );
 
-    xit('can be started even when the stats collector has an issue starting due to an unsupported browser', async () => {
+    it('can be started even when the stats collector has an issue starting due to an unsupported browser', async () => {
       setUserAgent(SAFARI_13_USER_AGENT);
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -966,7 +966,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('handles an error', async () => {
+    it('handles an error', async () => {
       configuration.connectionTimeoutMs = 100;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -989,7 +989,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.called).to.be.true;
     });
 
-    xit('does not call the observer if it has been removed', async () => {
+    it('does not call the observer if it has been removed', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1045,7 +1045,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can fail but does not reconnect', async () => {
+    it('can fail but does not reconnect', async () => {
       configuration.connectionTimeoutMs = 100;
       const logger = new NoOpDebugLogger();
       const spy = sinon.spy(logger, 'error');
@@ -1108,7 +1108,7 @@ describe('DefaultAudioVideoController', () => {
       await result;
     });
 
-    xit('can be started with SVC config', async () => {
+    it('can be started with SVC config', async () => {
       setUserAgent(CHROME_116_USER_AGENT);
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -1154,7 +1154,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('enable simulcast if both simulcast and SVC are selected', async () => {
+    it('enable simulcast if both simulcast and SVC are selected', async () => {
       setUserAgent(CHROME_116_USER_AGENT);
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -1202,7 +1202,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('stop', () => {
-    xit('can be started and stopped', async () => {
+    it('can be started and stopped', async () => {
       let called = false;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -1226,7 +1226,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be stopped without having been started', () => {
+    it('can be stopped without having been started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1238,7 +1238,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.stop();
     });
 
-    xit('can be stopped before stop and then stopped again', () => {
+    it('can be stopped before stop and then stopped again', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1252,7 +1252,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.stop();
     });
 
-    xit('disables reconnecting once stop is called', async () => {
+    it('disables reconnecting once stop is called', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1294,7 +1294,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('update', () => {
-    xit('can be started and then start and stop a local video tile', async () => {
+    it('can be started and then start and stop a local video tile', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1323,7 +1323,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit(
+    it(
       'can be started and then start and stop a local video tile if video uplink does not implement set transceiver' +
         ' controller',
       async () => {
@@ -1374,7 +1374,7 @@ describe('DefaultAudioVideoController', () => {
       }
     );
 
-    xit('restart local video if CreateSDP fails with IncompatibleSDP error', async () => {
+    it('restart local video if CreateSDP fails with IncompatibleSDP error', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -1415,7 +1415,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(5000);
 
-    xit('reconnects if the update fails with a task failed meeting status', async () => {
+    it('reconnects if the update fails with a task failed meeting status', async () => {
       let called = 0;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -1455,7 +1455,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(4000);
 
-    xit('will skip renegotiation if video streams are not initialized', async () => {
+    it('will skip renegotiation if video streams are not initialized', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1477,7 +1477,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will not skip renegotiation if we explicitly request it', async () => {
+    it('will not skip renegotiation if we explicitly request it', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1502,7 +1502,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit("will not skip renegotiation if we don't have a transceiver", async () => {
+    it("will not skip renegotiation if we don't have a transceiver", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1533,7 +1533,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit("will not skip renegotiation if transceiver controller doesn't have a mapping", async () => {
+    it("will not skip renegotiation if transceiver controller doesn't have a mapping", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1569,7 +1569,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit('will not skip renegotiation if we are switching simulcast streams', async () => {
+    it('will not skip renegotiation if we are switching simulcast streams', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1626,7 +1626,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit('will not skip renegotiation if current video ids are somehow null', async () => {
+    it('will not skip renegotiation if current video ids are somehow null', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1678,7 +1678,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit('will skip renegotiation if simulcast streams do not change', async () => {
+    it('will skip renegotiation if simulcast streams do not change', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1806,7 +1806,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will not skip renegotiation if we are updating simulcast layer change without header extension', async () => {
+    it('will not skip renegotiation if we are updating simulcast layer change without header extension', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1853,7 +1853,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit('will skip renegotiation if we are updating simulcast layer but not sending', async () => {
+    it('will skip renegotiation if we are updating simulcast layer but not sending', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -1900,7 +1900,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will skip renegotiation if we are only completing simulcast stream switches', async () => {
+    it('will skip renegotiation if we are only completing simulcast stream switches', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -1988,7 +1988,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit("will not skip renegotiation if we don't have setStreamId", async () => {
+    it("will not skip renegotiation if we don't have setStreamId", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2074,7 +2074,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit("will skip renegotiation even if we don't have tile", async () => {
+    it("will skip renegotiation even if we don't have tile", async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2149,7 +2149,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will skip renegotiation if there are no changes', async () => {
+    it('will skip renegotiation if there are no changes', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2210,7 +2210,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will not skip renegotiation if we are not only completing simulcast stream switches', async () => {
+    it('will not skip renegotiation if we are not only completing simulcast stream switches', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2270,7 +2270,7 @@ describe('DefaultAudioVideoController', () => {
         .false;
     });
 
-    xit('will not send remoteVideoUpdate if streams are unchanged', async () => {
+    it('will not send remoteVideoUpdate if streams are unchanged', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2361,7 +2361,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    xit('will send removeVideoUpdate due to video preference', async () => {
+    it('will send removeVideoUpdate due to video preference', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
 
@@ -2480,7 +2480,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will send removeVideoUpdate due to video preference change', async () => {
+    it('will send removeVideoUpdate due to video preference change', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
 
@@ -2603,7 +2603,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will send removeVideoUpdate due to video preference removal', async () => {
+    it('will send removeVideoUpdate due to video preference removal', async () => {
       const logger = new NoOpDebugLogger();
 
       const policyConfig = new VideoPriorityBasedPolicyConfig();
@@ -2723,7 +2723,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    xit('will not skip renegotiation if video streams are not initialized with server side network adaptation', async () => {
+    it('will not skip renegotiation if video streams are not initialized with server side network adaptation', async () => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'info');
       audioVideoController = new DefaultAudioVideoController(
@@ -2750,7 +2750,7 @@ describe('DefaultAudioVideoController', () => {
         .true;
     });
 
-    xit('will not send remoteVideoUpdate to video preference if missing preference', async () => {
+    it('will not send remoteVideoUpdate to video preference if missing preference', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2843,7 +2843,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    xit('will not send remoteVideoUpdate if videosToReceive changed but mid not found', async () => {
+    it('will not send remoteVideoUpdate if videosToReceive changed but mid not found', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -2943,7 +2943,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    xit('will send remoteVideoUpdate if videosToReceive changed', async () => {
+    it('will send remoteVideoUpdate if videosToReceive changed', async () => {
       const logger = new NoOpDebugLogger();
 
       const policy = new VideoPriorityBasedPolicy(logger);
@@ -3058,7 +3058,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.true;
     });
 
-    xit('will send remoteVideoUpdate if videosToReceive changed with streamID 0', async () => {
+    it('will send remoteVideoUpdate if videosToReceive changed with streamID 0', async () => {
       const logger = new NoOpDebugLogger();
       const policyConfig = new VideoPriorityBasedPolicyConfig();
       policyConfig.serverSideNetworkAdaption =
@@ -3178,7 +3178,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.true;
     });
 
-    xit('will not send update if current videos ids are empty', async () => {
+    it('will not send update if current videos ids are empty', async () => {
       const logger = new NoOpDebugLogger();
       const policyConfig = new VideoPriorityBasedPolicyConfig();
       policyConfig.serverSideNetworkAdaption =
@@ -3294,7 +3294,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    xit('will not send remoteVideoUpdate if videosToReceive is empty', async () => {
+    it('will not send remoteVideoUpdate if videosToReceive is empty', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3386,7 +3386,7 @@ describe('DefaultAudioVideoController', () => {
       expect(remoteVideoUpdateCalled).to.be.false;
     });
 
-    xit('will skip renegotiation but not due to video preferences if videosToReceive remains same', async () => {
+    it('will skip renegotiation but not due to video preferences if videosToReceive remains same', async () => {
       const logger = new NoOpDebugLogger();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3484,7 +3484,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('restartLocalVideo', () => {
-    xit('restarts local video', async () => {
+    it('restarts local video', async () => {
       class TestDeviceController extends NoOpDeviceController {
         async acquireVideoInputStream(): Promise<MediaStream> {
           const mediaStream = new MediaStream();
@@ -3529,7 +3529,7 @@ describe('DefaultAudioVideoController', () => {
       expect(called).to.be.true;
     }).timeout(5000);
 
-    xit('can defer restartLocalVideo and performs a single update operation when the local video is turned off', async () => {
+    it('can defer restartLocalVideo and performs a single update operation when the local video is turned off', async () => {
       let called = false;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3583,13 +3583,13 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('throw error video stream has no track', () => {
+    it('throw error video stream has no track', () => {
       return expect(audioVideoController.replaceLocalVideo(new MediaStream())).to.be.rejectedWith(
         'could not acquire video track'
       );
     });
 
-    xit('Throw error if no peer connection is established', async () => {
+    it('Throw error if no peer connection is established', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3600,7 +3600,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('replaces video track', async () => {
+    it('replaces video track', async () => {
       const stream = new MediaStream();
       // @ts-ignore
       stream.id = '2';
@@ -3645,7 +3645,7 @@ describe('DefaultAudioVideoController', () => {
       await audioVideoController.removeObserver(observer);
     });
 
-    xit('Do not replace local video if local tile is null', async () => {
+    it('Do not replace local video if local tile is null', async () => {
       const stream = new MediaStream();
       // @ts-ignore
       stream.id = '2';
@@ -3698,13 +3698,13 @@ describe('DefaultAudioVideoController', () => {
         reconnectController
       );
     });
-    xit('fails if has no active audio stream', () => {
+    it('fails if has no active audio stream', () => {
       return expect(
         audioVideoController.replaceLocalAudio(new MediaStream())
       ).to.eventually.be.rejectedWith('could not acquire audio track');
     });
 
-    xit('Throw error if no peer connection is established', async () => {
+    it('Throw error if no peer connection is established', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3715,7 +3715,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('replaces audio track', async () => {
+    it('replaces audio track', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3746,7 +3746,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('reject if transceiver fails to replaces audio track', async () => {
+    it('reject if transceiver fails to replaces audio track', async () => {
       const stream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -3783,7 +3783,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('reconnect', () => {
-    xit('reconnects, calling audioVideoDidStartConnecting and audioVideoDidStart but not audioVideoDidStop', async () => {
+    it('reconnects, calling audioVideoDidStartConnecting and audioVideoDidStart but not audioVideoDidStop', async () => {
       const sequence: string[] = [];
       let startConnectingCalled = 0;
       let startCalled = 0;
@@ -3838,7 +3838,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     }).timeout(5000);
 
-    xit('publish meeting reconnected', async () => {
+    it('publish meeting reconnected', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -3873,7 +3873,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     }).timeout(5000);
 
-    xit('does not reconnect if canceled', async () => {
+    it('does not reconnect if canceled', async () => {
       let called = 0;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -3900,7 +3900,7 @@ describe('DefaultAudioVideoController', () => {
 
     // FinishGatheringICECandidatesTask does not throw the ICEGatheringTimeoutWorkaround error if
     // the session connection timeout is less than 5000ms.
-    xit('reconnects when the start operation fails with a non-Terminal meeting status such as ICEGatheringTimeoutWorkaround', function (done) {
+    it('reconnects when the start operation fails with a non-Terminal meeting status such as ICEGatheringTimeoutWorkaround', function (done) {
       this.timeout(20000);
 
       domMockBehavior.browserName = 'chrome';
@@ -3964,7 +3964,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    xit('reconnects when the start operation fails with a task failed meeting status', function (done) {
+    it('reconnects when the start operation fails with a task failed meeting status', function (done) {
       configuration.connectionTimeoutMs = 100;
       const logger = new NoOpDebugLogger();
       const spy = sinon.spy(logger, 'warn');
@@ -4013,7 +4013,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    xit('reconnects when the reconnect operation itself fails', done => {
+    it('reconnects when the reconnect operation itself fails', done => {
       const logger = new NoOpDebugLogger();
       const loggerSpy = sinon.spy(logger, 'warn');
 
@@ -4053,7 +4053,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    xit('uses the custom connection health policy configuration if passed', done => {
+    it('uses the custom connection health policy configuration if passed', done => {
       // Set the missed pongs upper threshold to zero to force restarting the session.
       const connectionHealthPolicyConfiguration = new ConnectionHealthPolicyConfiguration();
       connectionHealthPolicyConfiguration.connectionWaitTimeMs = 0;
@@ -4098,7 +4098,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('reconnect for no attendee presence', () => {
-    xit('reconnects when the start operation fails due to no attendee presence event', function (done) {
+    it('reconnects when the start operation fails due to no attendee presence event', function (done) {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
@@ -4164,7 +4164,7 @@ describe('DefaultAudioVideoController', () => {
       });
     });
 
-    xit('does not reconnect for no attendee presence event if the attendee presence timeout is set to zero', function (done) {
+    it('does not reconnect for no attendee presence event if the attendee presence timeout is set to zero', function (done) {
       this.timeout(15000);
 
       const logger = new NoOpDebugLogger();
@@ -4232,7 +4232,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getters', () => {
-    xit('returns a device controller for the mediaStreamBroker and deviceController getter', () => {
+    it('returns a device controller for the mediaStreamBroker and deviceController getter', () => {
       const mediaStreamBroker = new NoOpMediaStreamBroker();
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -4257,7 +4257,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('handles VideoCallSwitchToViewOnly', async () => {
+    it('handles VideoCallSwitchToViewOnly', async () => {
       let called = false;
       const spy = sinon.spy(audioVideoController.videoTileController, 'removeLocalVideoTile');
       class TestObserver implements AudioVideoObserver {
@@ -4279,7 +4279,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('handles IncompatibleSDP', async () => {
+    it('handles IncompatibleSDP', async () => {
       let called = 0;
       const spy = sinon.spy(audioVideoController, 'restartLocalVideo');
       class TestObserver implements AudioVideoObserver {
@@ -4309,7 +4309,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('does not reconnect for the terminal status or the unknown status', async () => {
+    it('does not reconnect for the terminal status or the unknown status', async () => {
       let called = false;
       class TestObserver implements AudioVideoObserver {
         audioVideoDidStop(_sessionStatus: MeetingSessionStatus): void {
@@ -4333,7 +4333,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('does not reconnect if the reconnectController is not set in the context', async () => {
+    it('does not reconnect if the reconnectController is not set in the context', async () => {
       const spy = sinon.spy(reconnectController, 'disableReconnect');
       audioVideoController.handleMeetingSessionStatus(
         new MeetingSessionStatus(MeetingSessionStatusCode.Left),
@@ -4345,7 +4345,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('pauseReceivingStream', () => {
-    xit('is no-op if meeting is not started', () => {
+    it('is no-op if meeting is not started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4357,7 +4357,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.pauseReceivingStream(0);
     });
 
-    xit('sends pause frame through signaling client', async () => {
+    it('sends pause frame through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4378,7 +4378,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('resumeReceivingStream', () => {
-    xit('is no-op if meeting is not started', () => {
+    it('is no-op if meeting is not started', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4390,7 +4390,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.resumeReceivingStream(0);
     });
 
-    xit('sends resume frame through signaling client', async () => {
+    it('sends resume frame through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4412,7 +4412,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('setVideoCodecSendPreferences', () => {
-    xit('calls update', async () => {
+    it('calls update', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4432,7 +4432,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.callCount).to.equal(1);
     });
 
-    xit('does not trigger an update if invoked before the session starts.', async () => {
+    it('does not trigger an update if invoked before the session starts.', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4449,7 +4449,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getRTCPeerConnectionStats', () => {
-    xit('calls getStats', async () => {
+    it('calls getStats', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4468,7 +4468,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnceWith()).to.be.true;
     });
 
-    xit('calls getStats with media stream strack', async () => {
+    it('calls getStats with media stream strack', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4488,7 +4488,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnceWith(track)).to.be.true;
     });
 
-    xit('return null if no peer connection is established', async () => {
+    it('return null if no peer connection is established', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4503,7 +4503,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('when simulcast is enabled', () => {
-    xit('will be automatically switched off if platform is not Chrome', async () => {
+    it('will be automatically switched off if platform is not Chrome', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       audioVideoController = new DefaultAudioVideoController(
         configuration,
@@ -4519,7 +4519,7 @@ describe('DefaultAudioVideoController', () => {
       await stop();
     });
 
-    xit('can be started', async () => {
+    it('can be started', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome116';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4581,7 +4581,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('can be started for content share attendee', async () => {
+    it('can be started for content share attendee', async () => {
       const attendeeId = defaultAttendeeId + ContentShareConstants.Modality;
       configuration.credentials.attendeeId = attendeeId;
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
@@ -4625,7 +4625,7 @@ describe('DefaultAudioVideoController', () => {
     });
   });
 
-  xit('can be started for content share attendee with UHD feature', async () => {
+  it('can be started for content share attendee with UHD feature', async () => {
     const attendeeId = defaultAttendeeId + ContentShareConstants.Modality;
     configuration.meetingFeatures.contentMaxResolution = VideoQualitySettings.VideoResolutionUHD;
     configuration.credentials.attendeeId = attendeeId;
@@ -4676,7 +4676,7 @@ describe('DefaultAudioVideoController', () => {
     audioVideoController.removeObserver(observer);
   });
 
-  xit('can be started for camera video attendee with FHD feature', async () => {
+  it('can be started for camera video attendee with FHD feature', async () => {
     const attendeeId = defaultAttendeeId;
     configuration.meetingFeatures.videoMaxResolution = VideoQualitySettings.VideoResolutionFHD;
     configuration.credentials.attendeeId = attendeeId;
@@ -4726,7 +4726,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('meeting events', () => {
-    xit('sends meeting events', async () => {
+    it('sends meeting events', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4759,7 +4759,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     });
 
-    xit('sends failure events', async () => {
+    it('sends failure events', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4799,7 +4799,7 @@ describe('DefaultAudioVideoController', () => {
       eventController.removeObserver(observer);
     });
 
-    xit('sends failure events with a non-empty error message', async () => {
+    it('sends failure events with a non-empty error message', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4840,7 +4840,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('getRemoteVideoSources', () => {
-    xit('should match index frame sources excluding self', async () => {
+    it('should match index frame sources excluding self', async () => {
       const compare = (a: VideoSource, b: VideoSource): number =>
         a.attendee.attendeeId.localeCompare(b.attendee.attendeeId);
 
@@ -4881,7 +4881,7 @@ describe('DefaultAudioVideoController', () => {
       expect(success).to.be.false;
     });
 
-    xit('should return an array of length 0, when videoStreamIndex is not initialized', async () => {
+    it('should return an array of length 0, when videoStreamIndex is not initialized', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4894,7 +4894,7 @@ describe('DefaultAudioVideoController', () => {
       expect(videoSources).to.have.lengthOf(0);
     });
 
-    xit('should return [] when called after meeting session is stopped', async () => {
+    it('should return [] when called after meeting session is stopped', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -4911,7 +4911,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('encodingSimulcastLayersDidChange', () => {
-    xit('observer should get called only when added', async () => {
+    it('observer should get called only when added', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4970,7 +4970,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('observer should get called', async () => {
+    it('observer should get called', async () => {
       configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = true;
       domMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(domMockBehavior);
@@ -4997,7 +4997,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    xit('observer should not get called with non-simulcast policy', async () => {
+    it('observer should not get called with non-simulcast policy', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5024,7 +5024,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('promoteToPrimaryMeeting & demoteFromPrimaryMeeting', () => {
-    xit('sends promotion through signaling client and waits for ack, demotes sends through signaling client', async () => {
+    it('sends promotion through signaling client and waits for ack, demotes sends through signaling client', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5071,7 +5071,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('fails promotion if timeout', async () => {
+    it('fails promotion if timeout', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5118,7 +5118,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('calls demotion observer when leave is received', async () => {
+    it('calls demotion observer when leave is received', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5155,7 +5155,7 @@ describe('DefaultAudioVideoController', () => {
       audioVideoController.removeObserver(observer);
     });
 
-    xit('calls demotion observer when disconnection occurs', async () => {
+    it('calls demotion observer when disconnection occurs', async () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5199,7 +5199,7 @@ describe('DefaultAudioVideoController', () => {
   });
 
   describe('setVideoMaxBandwidthKbps', () => {
-    xit('can set video max bandwidth', async () => {
+    it('can set video max bandwidth', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setIdealMaxBandwidthKbps');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -5217,7 +5217,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    xit('can set video max bandwidth before meeting start', async () => {
+    it('can set video max bandwidth before meeting start', async () => {
       const policy = new NScaleVideoUplinkBandwidthPolicy('test');
       const spy = sinon.spy(policy, 'setIdealMaxBandwidthKbps');
       configuration.videoUplinkBandwidthPolicy = policy;
@@ -5235,7 +5235,7 @@ describe('DefaultAudioVideoController', () => {
       expect(spy.calledOnce).to.be.true;
     });
 
-    xit('bandwidth has to be positive', () => {
+    it('bandwidth has to be positive', () => {
       audioVideoController = new DefaultAudioVideoController(
         configuration,
         new NoOpDebugLogger(),
@@ -5289,7 +5289,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('Does nothing if meeting has not started yet', () => {
+    it('Does nothing if meeting has not started yet', () => {
       const replaceAudioSpy = sinon.spy(audioVideoController, 'replaceLocalAudio');
       mediaStreamBroker.addMediaStreamBrokerObserver(audioVideoController);
       mediaStreamBroker.triggerAudioInputChangeEvent(new MediaStream());
@@ -5298,7 +5298,7 @@ describe('DefaultAudioVideoController', () => {
       replaceAudioSpy.restore();
     });
 
-    xit('replace local audio', async () => {
+    it('replace local audio', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5314,7 +5314,7 @@ describe('DefaultAudioVideoController', () => {
       replaceAudioSpy.restore();
     });
 
-    xit('Try to acquire audio stream if receive undefined audio stream', async () => {
+    it('Try to acquire audio stream if receive undefined audio stream', async () => {
       await start();
       const replaceAudioSpy = sinon.spy(audioVideoController, 'replaceLocalAudio');
       const acquireAudioSpy = sinon.spy(mediaStreamBroker, 'acquireAudioInputStream');
@@ -5327,7 +5327,7 @@ describe('DefaultAudioVideoController', () => {
       acquireAudioSpy.restore();
     });
 
-    xit('throw error if failed to acquire audio input stream', async () => {
+    it('throw error if failed to acquire audio input stream', async () => {
       class FailedObserverMediaStreamBroker extends ObserverMediaStreamBroker {
         async acquireAudioInputStream(): Promise<MediaStream> {
           throw Error('Failed');
@@ -5401,7 +5401,7 @@ describe('DefaultAudioVideoController', () => {
       );
     });
 
-    xit('Does nothing if meeting has not started yet', () => {
+    it('Does nothing if meeting has not started yet', () => {
       const replaceVideoSpy = sinon.spy(audioVideoController, 'replaceLocalVideo');
       mediaStreamBroker.addMediaStreamBrokerObserver(audioVideoController);
       mediaStreamBroker.triggerVideoInputChangeEvent(new MediaStream());
@@ -5410,7 +5410,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    xit('Does nothing if local tile is not started yet', async () => {
+    it('Does nothing if local tile is not started yet', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5425,7 +5425,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    xit('replace local video if local tile started and video stream changes', async () => {
+    it('replace local video if local tile started and video stream changes', async () => {
       const mediaStream = new MediaStream();
       const track = new MediaStreamTrack();
       // @ts-ignore
@@ -5443,7 +5443,7 @@ describe('DefaultAudioVideoController', () => {
       replaceVideoSpy.restore();
     });
 
-    xit('stop local video if local tile started and video stream is undefined', async () => {
+    it('stop local video if local tile started and video stream is undefined', async () => {
       await start();
       audioVideoController.videoTileController.startLocalVideoTile();
       await sendICEEventAndSubscribeAckFrame();


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
Noticed this during local testing. Receive only clients would trigger subscribes because the inactive send sections would not include the RTP header extension.

**Testing:**
Tested that a receive only client no longer resubscribes when other videos are turned on.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No. Nothing noticeable without log diving.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

