### PR TITLE
Make server side network adaptation the default when creating `VideoPriorityBasedPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Avoid subscribes when simulcast is enabled but not currently sending, or when using server side network adaptation.
+- Made server side network adaptation the default when creating `VideoPriorityBasedPolicy`.
 
 ### Fixed
 

--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -212,6 +212,10 @@
             <input type="checkbox" id="svc" class="form-check-input">
             <label for="svc" class="form-check-label">Enable SVC for Chrome</label>
           </div>
+          <div class="form-check" style="text-align: left;">
+            <input type="checkbox" id="priority-downlink-policy" class="form-check-input">
+            <label for="priority-downlink-policy" class="form-check-label">Enable remote video quality adaptation</label>
+          </div>
           <label id="pagination-title" for="pagination-page-size" style="padding-top:5px">Paginate displayed video tiles</label>
           <select id="pagination-page-size" class="form-select" style="width:100%;">
             <option value="1">1</option>
@@ -220,18 +224,6 @@
             <option value="16">16</option>
             <option value="25" selected>25</option>
           </select>      
-          <div class="form-check" style="text-align: left;">
-            <input type="checkbox" id="priority-downlink-policy" class="form-check-input">
-            <label for="priority-downlink-policy" class="form-check-label">Use Priority-Based Downlink
-              Policy</label>
-          </div>
-          <label id="server-side-network-adaption-title" for="server-side-network-adaption" style="display: none; padding-top:5px">Server Side Network Adaption</label>
-          <select id="server-side-network-adaption" class="form-select" style="width:100%; display: none;">
-            <option value="default">Default</option>
-            <option value="none">None (Deprecated)</option>
-            <option value="enable-bandwidth-probing">Enable Bandwidth Probing (Deprecated)</option>
-            <option value="enable-bandwidth-probing-and-video-adaption" selected>Enable Bandwidth Probing and Video Quality Adaption</option>
-          </select>
           <div class="form-check" style="text-align: left;">
             <input type="checkbox" checked id="preconnect" class="form-check-input">
             <label for="preconnect" class="form-check-label">Open signaling connection early</label>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -50,7 +50,6 @@ import {
   NoOpVideoFrameProcessor,
   VideoFxConfig,
   RemovableAnalyserNode,
-  ServerSideNetworkAdaption,
   SimulcastLayers,
   Transcript,
   TranscriptEvent,
@@ -63,7 +62,6 @@ import {
   VideoFrameProcessor,
   VideoInputDevice,
   VideoPriorityBasedPolicy,
-  VideoPriorityBasedPolicyConfig,
   VideoQualitySettings,
   VoiceFocusDeviceTransformer,
   VoiceFocusModelComplexity,
@@ -347,7 +345,6 @@ export class DemoMeetingApp
   enableSimulcast = false;
   enableSVC = false;
   usePriorityBasedDownlinkPolicy = false;
-  videoPriorityBasedPolicyConfig = new VideoPriorityBasedPolicyConfig;
   enablePin = false;
   echoReductionCapability = false;
   usingStereoMusicAudioProfile = false;
@@ -664,21 +661,6 @@ export class DemoMeetingApp
 
     document.getElementById('priority-downlink-policy').addEventListener('change', e => {
       this.usePriorityBasedDownlinkPolicy = (document.getElementById('priority-downlink-policy') as HTMLInputElement).checked;
-
-      const serverSideNetworkAdaption = document.getElementById(
-          'server-side-network-adaption'
-      ) as HTMLSelectElement;
-      const serverSideNetworkAdaptionTitle = document.getElementById(
-          'server-side-network-adaption-title'
-      ) as HTMLElement;
-
-      if (this.usePriorityBasedDownlinkPolicy) {
-        serverSideNetworkAdaption.style.display = 'block';
-        serverSideNetworkAdaptionTitle.style.display = 'block';
-      } else {
-        serverSideNetworkAdaption.style.display = 'none';
-        serverSideNetworkAdaptionTitle.style.display = 'none';
-      }
     });
 
     const echoReductionCheckbox = (document.getElementById('echo-reduction-checkbox') as HTMLInputElement);
@@ -1859,22 +1841,7 @@ export class DemoMeetingApp
     configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = this.enableSimulcast;
     configuration.enableSVC = this.enableSVC;
     if (this.usePriorityBasedDownlinkPolicy) {
-      const serverSideNetworkAdaptionDropDown = document.getElementById('server-side-network-adaption') as HTMLSelectElement;
-      switch (serverSideNetworkAdaptionDropDown.value) {
-        case 'default':
-          this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.Default;
-          break;
-        case 'none':
-          this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
-          break;
-        case 'enable-bandwidth-probing':
-          this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.BandwidthProbing;
-          break;
-        case 'enable-bandwidth-probing-and-video-adaption':
-          this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption;
-          break;
-      }
-      this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger, this.videoPriorityBasedPolicyConfig);
+        this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger);
       configuration.videoDownlinkBandwidthPolicy = this.priorityBasedDownlinkPolicy;
       this.priorityBasedDownlinkPolicy.addObserver(this);
     } else {

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1907,7 +1907,8 @@ export class DemoMeetingApp
     this.videoTileCollection = new VideoTileCollection(this.audioVideo,
         this.meetingLogger,
         new RemoteVideoManager(this.meetingLogger, this.usePriorityBasedDownlinkPolicy  ? this.priorityBasedDownlinkPolicy : this.allHighestDownlinkPolicy),
-        paginationPageSize)
+        paginationPageSize,
+        this.meetingSession.configuration.credentials.attendeeId)
     this.audioVideo.addObserver(this.videoTileCollection);
 
     this.contentShare = new ContentShareManager(this.meetingLogger, this.audioVideo, this.usingStereoMusicAudioProfile);

--- a/demos/browser/app/meetingV2/video/PaginationManager.ts
+++ b/demos/browser/app/meetingV2/video/PaginationManager.ts
@@ -20,7 +20,9 @@ export default class PaginationManager<Type> {
   }
 
   remove(toRemove: Type) {
-    this.all.splice(this.all.indexOf(toRemove));
+    if (this.all.includes(toRemove)) {
+        this.all.splice(this.all.indexOf(toRemove));
+    }
   }
 
   removeIf(toRemoveFn: (value: Type) => boolean) {

--- a/demos/browser/app/meetingV2/video/PaginationManager.ts
+++ b/demos/browser/app/meetingV2/video/PaginationManager.ts
@@ -5,7 +5,7 @@ export default class PaginationManager<Type> {
   private currentPageStart: number = 0;
 
   private all = new Array<Type>();
-  
+
   constructor(private pageSize: number) {}
 
   currentPage(): Array<Type> {
@@ -21,7 +21,7 @@ export default class PaginationManager<Type> {
 
   remove(toRemove: Type) {
     if (this.all.includes(toRemove)) {
-        this.all.splice(this.all.indexOf(toRemove));
+      this.all.splice(this.all.indexOf(toRemove), 1);
     }
   }
 
@@ -30,7 +30,7 @@ export default class PaginationManager<Type> {
     if (index === -1) {
       return;
     }
-    this.all.splice(index,1);
+    this.all.splice(index, 1);
   }
 
   hasNextPage(): boolean {
@@ -38,7 +38,7 @@ export default class PaginationManager<Type> {
   }
 
   nextPage(): void {
-    if (!this.hasNextPage) {
+    if (!this.hasNextPage()) {
       return;
     }
     this.currentPageStart += this.pageSize;
@@ -49,6 +49,8 @@ export default class PaginationManager<Type> {
   }
 
   previousPage(): void {
-    this.currentPageStart -= this.pageSize;
+    if (this.hasPreviousPage()) {
+      this.currentPageStart -= this.pageSize;
+    }
   }
 }

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -71,13 +71,6 @@
 						<p><a href="videoadaptiveprobepolicy.html">VideoAdaptiveProbePolicy</a> wraps <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a> with customized behavior to automatically
 						assign a high preference to content share.</p>
 					</div>
-					<dl class="tsd-comment-tags">
-						<dt>deprecated</dt>
-						<dd><p>This class is not compatible with latest priority policy features (i.e. server side network adaptation),
-								<a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a> should be used instead. If high priority for content is desired it can be done trivially
-							by the application.</p>
-						</dd>
-					</dl>
 				</div>
 			</section>
 			<section class="tsd-panel tsd-hierarchy">
@@ -157,7 +150,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L26">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L22">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -369,7 +362,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#chooseremotevideosources">chooseRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L73">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L71">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -570,7 +563,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L34">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L32">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +707,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L40">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L38">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:38</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoadaptiveprobepolicy.html
+++ b/docs/classes/videoadaptiveprobepolicy.html
@@ -65,6 +65,21 @@
 <div class="container container-main">
 	<div class="row">
 		<div class="col-8 col-content">
+			<section class="tsd-panel tsd-comment">
+				<div class="tsd-comment tsd-typography">
+					<div class="lead">
+						<p><a href="videoadaptiveprobepolicy.html">VideoAdaptiveProbePolicy</a> wraps <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a> with customized behavior to automatically
+						assign a high preference to content share.</p>
+					</div>
+					<dl class="tsd-comment-tags">
+						<dt>deprecated</dt>
+						<dd><p>This class is not compatible with latest priority policy features (i.e. server side network adaptation),
+								<a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a> should be used instead. If high priority for content is desired it can be done trivially
+							by the application.</p>
+						</dd>
+					</dl>
+				</div>
+			</section>
 			<section class="tsd-panel tsd-hierarchy">
 				<h3>Hierarchy</h3>
 				<ul class="tsd-hierarchy">
@@ -142,7 +157,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L12">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L26">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -257,7 +272,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L317">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:317</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L324">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:324</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -286,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#bindtotilecontroller">bindToTileController</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L170">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -318,7 +333,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceiveset">calculateOptimalReceiveSet</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L559">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:559</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L566">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:566</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -336,7 +351,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#calculateoptimalreceivestreams">calculateOptimalReceiveStreams</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L335">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L342">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:342</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -354,7 +369,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#chooseremotevideosources">chooseRemoteVideoSources</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L58">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L73">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -385,7 +400,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L299">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:299</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L306">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:306</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -412,7 +427,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L325">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L332">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:332</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -460,7 +475,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getcurrentvideopreferences">getCurrentVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1248">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1255">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videopreferences.html" class="tsd-signature-type" data-tsd-kind="Class">VideoPreferences</a></h4>
@@ -478,7 +493,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getserversidenetworkadaption">getServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1252">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1259">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1259</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -502,7 +517,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#getvideopreferences">getVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1269">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1269</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1276">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1276</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -526,7 +541,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L321">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L328">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -555,7 +570,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L19">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L34">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -578,7 +593,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setserversidenetworkadaption">setServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1256">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1263">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1263</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -608,7 +623,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setvideoprioritybasedpolicyconfigs">setVideoPriorityBasedPolicyConfigs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L331">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:331</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L338">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:338</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -632,7 +647,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#setwantsresubscribeobserver">setWantsResubscribeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L175">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L182">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -674,7 +689,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#supportedserversidenetworkadaptions">supportedServerSideNetworkAdaptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1261">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1261</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1268">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1268</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -699,7 +714,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L25">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts#L40">src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -729,7 +744,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L251">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L258">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -758,7 +773,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#wantsalltemporallayersinindex">wantsAllTemporalLayersInIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1280">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1280</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1287">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -784,7 +799,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="videoprioritybasedpolicy.html">VideoPriorityBasedPolicy</a>.<a href="videoprioritybasedpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L283">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L290">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:290</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoprioritybasedpolicy.html
+++ b/docs/classes/videoprioritybasedpolicy.html
@@ -257,7 +257,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#addobserver">addObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L317">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:317</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L324">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:324</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -286,7 +286,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#bindtotilecontroller">bindToTileController</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L170">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:170</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L177">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:177</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L559">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:559</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L566">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:566</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L335">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L342">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:342</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -351,7 +351,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L182">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L189">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:189</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -375,7 +375,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#choosesubscriptions">chooseSubscriptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L299">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:299</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L306">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:306</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -402,7 +402,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#foreachobserver">forEachObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L325">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L332">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:332</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -449,7 +449,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1248">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1248</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1255">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1255</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="videopreferences.html" class="tsd-signature-type" data-tsd-kind="Class">VideoPreferences</a></h4>
@@ -467,7 +467,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#getserversidenetworkadaption">getServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1252">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1252</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1259">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1259</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -491,7 +491,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#getvideopreferences">getVideoPreferences</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1269">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1269</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1276">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1276</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -515,7 +515,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#removeobserver">removeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L321">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:321</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L328">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:328</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -544,7 +544,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#reset">reset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L138">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L145">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:145</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -567,7 +567,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#setserversidenetworkadaption">setServerSideNetworkAdaption</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1256">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1256</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1263">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1263</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -596,7 +596,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L331">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:331</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L338">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:338</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -620,7 +620,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#setwantsresubscribeobserver">setWantsResubscribeObserver</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L175">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L182">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -662,7 +662,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#supportedserversidenetworkadaptions">supportedServerSideNetworkAdaptions</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1261">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1261</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1268">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1268</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -687,7 +687,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updateindex">updateIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L215">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L222">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -717,7 +717,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#updatemetrics">updateMetrics</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L251">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L258">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -746,7 +746,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsalltemporallayersinindex">wantsAllTemporalLayersInIndex</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1280">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1280</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L1287">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:1287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -772,7 +772,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videodownlinkbandwidthpolicy.html">VideoDownlinkBandwidthPolicy</a>.<a href="../interfaces/videodownlinkbandwidthpolicy.html#wantsresubscribe">wantsResubscribe</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L283">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:283</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts#L290">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts:290</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/videoprioritybasedpolicyconfig.html
+++ b/docs/classes/videoprioritybasedpolicyconfig.html
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L32">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L33">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:33</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -185,8 +185,8 @@
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>Additional server side features to be enabled for network adaption. This
-							may be overridden by the server. The default may be changed in future releases.</p>
+							<p>Additional server side features to be enabled for network adaption. The only currently
+							recommended value is <code>ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption</code></p>
 						</div>
 					</div>
 				</section>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L64">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts#L65">src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/enums/serversidenetworkadaption.html
+++ b/docs/enums/serversidenetworkadaption.html
@@ -139,7 +139,7 @@
 					</aside>
 					<div class="tsd-comment tsd-typography">
 						<div class="lead">
-							<p>No features enabled, but this value may switch to &#39;BandwidthProbingAndRemoteVideoQualityAdaption&#39; in a later release.</p>
+							<p>This value will currently be overwritten to <code>BandwidthProbingAndRemoteVideoQualityAdaption</code></p>
 						</div>
 					</div>
 				</section>

--- a/src/signalingclient/ServerSideNetworkAdaption.ts
+++ b/src/signalingclient/ServerSideNetworkAdaption.ts
@@ -8,7 +8,7 @@ import { SdkServerSideNetworkAdaption } from '../signalingprotocol/SignalingProt
  */
 export enum ServerSideNetworkAdaption {
   /**
-   * No features enabled, but this value may switch to 'BandwidthProbingAndRemoteVideoQualityAdaption' in a later release.
+   * This value will currently be overwritten to `BandwidthProbingAndRemoteVideoQualityAdaption`
    */
   Default,
 

--- a/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
@@ -13,10 +13,6 @@ import VideoPriorityBasedPolicyConfig from './VideoPriorityBasedPolicyConfig';
 
 /** [[VideoAdaptiveProbePolicy]] wraps [[VideoPriorityBasedPolicy]] with customized behavior to automatically
  * assign a high preference to content share.
- *
- * @deprecated This class is not compatible with latest priority policy features (i.e. server side network adaptation),
- * [[VideoPriorityBasedPolicy]] should be used instead. If high priority for content is desired it can be done trivially
- * by the application.
  */
 export default class VideoAdaptiveProbePolicy extends VideoPriorityBasedPolicy {
   private static createConfig(): VideoPriorityBasedPolicyConfig {
@@ -26,6 +22,8 @@ export default class VideoAdaptiveProbePolicy extends VideoPriorityBasedPolicy {
   }
 
   constructor(protected logger: Logger) {
+    // We use a static function to create config because Typescript requires
+    // super(...) calls to be the first line in constructors
     super(logger, VideoAdaptiveProbePolicy.createConfig());
     super.shouldPauseTiles = false;
     this.videoPreferences = undefined;

--- a/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy.ts
@@ -3,15 +3,30 @@
 
 import ContentShareConstants from '../contentsharecontroller/ContentShareConstants';
 import Logger from '../logger/Logger';
+import ServerSideNetworkAdaption from '../signalingclient/ServerSideNetworkAdaption';
 import VideoStreamDescription from '../videostreamindex/VideoStreamDescription';
 import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
 import VideoPreference from './VideoPreference';
 import { VideoPreferences } from './VideoPreferences';
 import VideoPriorityBasedPolicy from './VideoPriorityBasedPolicy';
+import VideoPriorityBasedPolicyConfig from './VideoPriorityBasedPolicyConfig';
 
+/** [[VideoAdaptiveProbePolicy]] wraps [[VideoPriorityBasedPolicy]] with customized behavior to automatically
+ * assign a high preference to content share.
+ *
+ * @deprecated This class is not compatible with latest priority policy features (i.e. server side network adaptation),
+ * [[VideoPriorityBasedPolicy]] should be used instead. If high priority for content is desired it can be done trivially
+ * by the application.
+ */
 export default class VideoAdaptiveProbePolicy extends VideoPriorityBasedPolicy {
+  private static createConfig(): VideoPriorityBasedPolicyConfig {
+    const config = new VideoPriorityBasedPolicyConfig();
+    config.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
+    return config;
+  }
+
   constructor(protected logger: Logger) {
-    super(logger);
+    super(logger, VideoAdaptiveProbePolicy.createConfig());
     super.shouldPauseTiles = false;
     this.videoPreferences = undefined;
   }

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.ts
@@ -132,6 +132,13 @@ export default class VideoPriorityBasedPolicy implements VideoDownlinkBandwidthP
     protected logger: Logger,
     private videoPriorityBasedPolicyConfig: VideoPriorityBasedPolicyConfig = VideoPriorityBasedPolicyConfig.Default
   ) {
+    if (
+      this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption ===
+      ServerSideNetworkAdaption.Default
+    ) {
+      this.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption =
+        ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption;
+    }
     this.reset();
   }
 

--- a/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts
+++ b/src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig.ts
@@ -26,10 +26,11 @@ export default class VideoPriorityBasedPolicyConfig {
   private referenceBitrate: number = 0;
 
   /**
-   * Additional server side features to be enabled for network adaption. This
-   * may be overridden by the server. The default may be changed in future releases.
+   * Additional server side features to be enabled for network adaption. The only currently
+   * recommended value is `ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption`
    */
-  serverSideNetworkAdaption = ServerSideNetworkAdaption.Default;
+  serverSideNetworkAdaption =
+    ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption;
 
   /** Initializes a [[VideoPriorityBasedPolicyConfig]] with the network event delays.
    *

--- a/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
+++ b/test/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy.test.ts
@@ -4,7 +4,6 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 
-import { ServerSideNetworkAdaption, VideoPriorityBasedPolicyConfig } from '../../src';
 import AudioVideoTileController from '../../src/audiovideocontroller/AudioVideoController';
 import NoOpAudioVideoTileController from '../../src/audiovideocontroller/NoOpAudioVideoController';
 import ClientMetricReport from '../../src/clientmetricreport/ClientMetricReport';
@@ -14,6 +13,7 @@ import GlobalMetricReport from '../../src/clientmetricreport/GlobalMetricReport'
 import StreamMetricReport from '../../src/clientmetricreport/StreamMetricReport';
 import ContentShareConstants from '../../src/contentsharecontroller/ContentShareConstants';
 import NoOpDebugLogger from '../../src/logger/NoOpDebugLogger';
+import ServerSideNetworkAdaption from '../../src/signalingclient/ServerSideNetworkAdaption';
 import {
   SdkBitrate,
   SdkBitrateFrame,
@@ -27,9 +27,11 @@ import VideoDownlinkObserver from '../../src/videodownlinkbandwidthpolicy/VideoD
 import VideoPreference from '../../src/videodownlinkbandwidthpolicy/VideoPreference';
 import { VideoPreferences } from '../../src/videodownlinkbandwidthpolicy/VideoPreferences';
 import VideoPriorityBasedPolicy from '../../src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy';
+import VideoPriorityBasedPolicyConfig from '../../src/videodownlinkbandwidthpolicy/VideoPriorityBasedPolicyConfig';
 import VideoQualityAdaptationPreference from '../../src/videodownlinkbandwidthpolicy/VideoQualityAdaptationPreference';
 import SimulcastVideoStreamIndex from '../../src/videostreamindex/SimulcastVideoStreamIndex';
 import VideoTileController from '../../src/videotilecontroller/VideoTileController';
+import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
 
 describe('VideoPriorityBasedPolicy', () => {
@@ -41,6 +43,8 @@ describe('VideoPriorityBasedPolicy', () => {
   let audioVideoController: AudioVideoTileController;
   let tileController: VideoTileController;
 
+  let domMockBuilder: DOMMockBuilder;
+  let behavior: DOMMockBehavior;
   interface DateNow {
     (): number;
   }
@@ -300,9 +304,14 @@ describe('VideoPriorityBasedPolicy', () => {
     startTime = Date.now();
     originalDateNow = Date.now;
     Date.now = mockDateNow;
+    behavior = new DOMMockBehavior();
+    domMockBuilder = new DOMMockBuilder(behavior);
     audioVideoController = new NoOpAudioVideoTileController();
     tileController = audioVideoController.videoTileController;
-    policy = new VideoPriorityBasedPolicy(logger);
+    const policyConfig = new VideoPriorityBasedPolicyConfig();
+    // Most of the tests below are for the legacy path without server side network adaptation
+    policyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
+    policy = new VideoPriorityBasedPolicy(logger, policyConfig);
     policy.bindToTileController(tileController);
     videoStreamIndex = new SimulcastVideoStreamIndex(logger);
   });
@@ -336,7 +345,6 @@ describe('VideoPriorityBasedPolicy', () => {
 
   describe('worksWithoutTileController', () => {
     it('runs without tile controller', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
       updateIndexFrame(videoStreamIndex, 6, 0, 600);
       policy.updateIndex(videoStreamIndex);
       const preferences = VideoPreferences.prepare();
@@ -351,7 +359,6 @@ describe('VideoPriorityBasedPolicy', () => {
 
   describe('default preference', () => {
     it('use default preference', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
       updateIndexFrame(videoStreamIndex, 1, 0, 1200);
       policy.updateIndex(videoStreamIndex);
       let resub = policy.wantsResubscribe();
@@ -389,8 +396,9 @@ describe('VideoPriorityBasedPolicy', () => {
     });
 
     it('use default preference with bandwidth probing', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
-      policy.setServerSideNetworkAdaption(ServerSideNetworkAdaption.BandwidthProbing);
+      const config = new VideoPriorityBasedPolicyConfig();
+      config.serverSideNetworkAdaption = ServerSideNetworkAdaption.BandwidthProbing;
+      const policy = new VideoPriorityBasedPolicy(logger, config);
 
       updateIndexFrame(videoStreamIndex, 1, 0, 1200);
       policy.updateIndex(videoStreamIndex);
@@ -429,7 +437,6 @@ describe('VideoPriorityBasedPolicy', () => {
     });
 
     it('pause tiles if not enough bandwidth for default preference', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
       policy.bindToTileController(tileController);
       updateIndexFrame(videoStreamIndex, 3, 0, 1000);
       policy.updateIndex(videoStreamIndex);
@@ -628,6 +635,25 @@ describe('VideoPriorityBasedPolicy', () => {
 
       // @ts-ignore
       expect(policy.videoPreferencesUpdated).to.be.false;
+
+      updateIndexFrame(videoStreamIndex, 3, 0, 600);
+      policy.updateIndex(videoStreamIndex);
+
+      const resub = policy.wantsResubscribe();
+      expect(resub).to.equal(true);
+      const received = policy.chooseSubscriptions();
+      expect(received.array()).to.deep.equal([2, 4, 6]);
+    });
+
+    it('Interprets default value as BandwidthProbingAndRemoteVideoQualityAdaption', async () => {
+      const config = new VideoPriorityBasedPolicyConfig();
+      config.serverSideNetworkAdaption = ServerSideNetworkAdaption.Default;
+      const policy = new VideoPriorityBasedPolicy(logger, config);
+
+      // @ts-ignore
+      expect(policy.videoPriorityBasedPolicyConfig.serverSideNetworkAdaption).to.be.eq(
+        ServerSideNetworkAdaption.BandwidthProbingAndRemoteVideoQualityAdaption
+      );
 
       updateIndexFrame(videoStreamIndex, 3, 0, 600);
       policy.updateIndex(videoStreamIndex);
@@ -972,7 +998,9 @@ describe('VideoPriorityBasedPolicy', () => {
 
     it('Probe fail with StableNetworkPreset', () => {
       updateIndexFrame(videoStreamIndex, 4, 300, 1200);
-      policy.setVideoPriorityBasedPolicyConfigs(VideoPriorityBasedPolicyConfig.StableNetworkPreset);
+      const policyConfig = VideoPriorityBasedPolicyConfig.StableNetworkPreset;
+      policyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
+      policy.setVideoPriorityBasedPolicyConfigs(policyConfig);
       policy.updateIndex(videoStreamIndex);
       const preferences = VideoPreferences.prepare();
       preferences.add(new VideoPreference('attendee-1', 2));
@@ -1070,7 +1098,6 @@ describe('VideoPriorityBasedPolicy', () => {
 
   describe('paused', () => {
     it('Tile added but not in subscribe', async () => {
-      const domMockBuilder = new DOMMockBuilder();
       const observer: VideoDownlinkObserver = {
         tileWillBePausedByDownlinkPolicy(_tileId: number) {},
         tileWillBeUnpausedByDownlinkPolicy(_tileId: number) {},
@@ -1502,8 +1529,9 @@ describe('VideoPriorityBasedPolicy', () => {
 
   describe('VideoPriorityBasedPolicyConfig', () => {
     it('will not instantly drop videos caused by dip during startup period', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
-      policy.setVideoPriorityBasedPolicyConfigs(VideoPriorityBasedPolicyConfig.StableNetworkPreset);
+      const policyConfig = VideoPriorityBasedPolicyConfig.StableNetworkPreset;
+      policyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
+      policy.setVideoPriorityBasedPolicyConfigs(policyConfig);
       updateIndexFrame(videoStreamIndex, 1, 0, 1200);
       policy.updateIndex(videoStreamIndex);
       let resub = policy.wantsResubscribe();
@@ -1529,8 +1557,9 @@ describe('VideoPriorityBasedPolicy', () => {
     });
 
     it('unstable network with unstable preset', () => {
-      const config = VideoPriorityBasedPolicyConfig.UnstableNetworkPreset;
-      policy.setVideoPriorityBasedPolicyConfigs(config);
+      const policyConfig = VideoPriorityBasedPolicyConfig.UnstableNetworkPreset;
+      policyConfig.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
+      policy.setVideoPriorityBasedPolicyConfigs(policyConfig);
       updateIndexFrame(videoStreamIndex, 3, 300, 1200);
       policy.updateIndex(videoStreamIndex);
       const metricReport = new ClientMetricReport(logger);
@@ -1613,6 +1642,7 @@ describe('VideoPriorityBasedPolicy', () => {
 
     it('stable network with stable preset', () => {
       const config = VideoPriorityBasedPolicyConfig.StableNetworkPreset;
+      config.serverSideNetworkAdaption = ServerSideNetworkAdaption.None;
       policy.setVideoPriorityBasedPolicyConfigs(config);
       updateIndexFrame(videoStreamIndex, 3, 300, 1200);
       policy.updateIndex(videoStreamIndex);
@@ -1734,7 +1764,6 @@ describe('VideoPriorityBasedPolicy', () => {
     });
 
     it('works with non goog stats', () => {
-      const policy = new VideoPriorityBasedPolicy(logger);
       updateIndexFrame(videoStreamIndex, 1, 0, 1200);
       policy.updateIndex(videoStreamIndex);
       let resub = policy.wantsResubscribe();


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** We are no longer iterating on the priority policy without server side network adaptation. So it makes sense that it is the default.

**Testing:**
Confirmed that SSNA is used when not configured.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A no behavior is changed.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

