### PR TITLE
Fix content disapearing in demo when remote video is enabled

### DIFF
--- a/demos/browser/app/meetingV2/video/VideoTileCollection.ts
+++ b/demos/browser/app/meetingV2/video/VideoTileCollection.ts
@@ -246,6 +246,8 @@ export default class VideoTileCollection implements AudioVideoObserver {
   }
 
   private isLocalAttendee(attendeeId: string) {
+    // This covers both the actual local attendee ID and the attendee ID
+    // of any local content share
     return attendeeId.startsWith(this.localAttendeeId);
   }
 

--- a/demos/browser/app/meetingV2/video/VideoTileCollection.ts
+++ b/demos/browser/app/meetingV2/video/VideoTileCollection.ts
@@ -152,9 +152,8 @@ export default class VideoTileCollection implements AudioVideoObserver {
     for (const source of videoSources) {
         this.pagination.add(source.attendee.attendeeId);
     }
-    const localTileId = this.localTileId()
     this.pagination.removeIf((value: string) => {
-      return !videoSources.some((source: VideoSource) => source.attendee.attendeeId === value) && (localTileId && this.tileIdToAttendeeId[localTileId] !== value);
+      return !videoSources.some((source: VideoSource) => source.attendee.attendeeId === value) && !this.isLocalAttendee(value);
     });
 
     // Update the preference manager explicitly as it needs to add default preferences
@@ -211,7 +210,7 @@ export default class VideoTileCollection implements AudioVideoObserver {
     demoVideoTile.attendeeId = tileState.boundAttendeeId;
 
     // We need to add local video or content to pagination from tile updates
-    const shouldUpdatePagination = tileState.localTile || (tileState.isContent && tileState.boundAttendeeId.startsWith(this.localAttendeeId));
+    const shouldUpdatePagination = this.isLocalAttendee(tileState.boundAttendeeId);
     if (tileState.boundVideoStream) {
         if (shouldUpdatePagination) {
             this.pagination.add(tileState.boundAttendeeId);
@@ -244,6 +243,10 @@ export default class VideoTileCollection implements AudioVideoObserver {
     demoVideoTile.nameplate = "";
     demoVideoTile.pauseState = "";
     this.updateLayout();
+  }
+
+  private isLocalAttendee(attendeeId: string) {
+    return attendeeId.startsWith(this.localAttendeeId);
   }
 
   showVideoWebRTCStats(videoMetricReport: { [id: string]: { [id: string]: {} } }): void {

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../..": {
-      "version": "3.22.0",
+      "version": "3.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
Previous any new remote videos would cause local content to be filtered out. This fixes that.

**Testing:**
See steps below.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Enable video and content on one attendee
2. Enable video on the second and look at the first. You should see 3 total displayed videos.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

