### PR TITLE
Bump Protobuf.js from 7.2.4 to 7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/ua-parser-js": "^0.7.35",
         "detect-browser": "^5.2.0",
         "pako": "^2.0.4",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
         "ua-parser-js": "^1.0.1"
       },
@@ -54,7 +54,7 @@
         "typescript": "^4.2.3"
       },
       "engines": {
-        "node": "^18 || ^19 || ^20",
+        "node": "^18 || ^19 || ^20 || ^22",
         "npm": "^8 || ^9 || ^10"
       }
     },
@@ -5295,9 +5295,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@types/ua-parser-js": "^0.7.35",
     "detect-browser": "^5.2.0",
     "pako": "^2.0.4",
-    "protobufjs": "^7.2.4",
+    "protobufjs": "^7.3.0",
     "resize-observer": "^1.0.0",
     "ua-parser-js": "^1.0.1"
   },


### PR DESCRIPTION
**Issue #:**
As mentioned by [this issue](https://github.com/aws/amazon-chime-sdk-js/issues/2891) and [this comment](https://github.com/aws/amazon-chime-sdk-js/pull/2877#issuecomment-2092663218), protobuf.js was half updated.

**Description of changes:**
Protobuf.js version updated from 7.2.4 to 7.3.0.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

