### PR TITLE
Change getDisplayMedia audio params to exclude noiseSuppression, echo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+ - Remove echoCancellation, autoGainControl, noiseSuppression from getDisplayMedia parameters as they apply processing when its not necessary.
 
 - Fixed rare race conditions with simulcast + server side network adaptation on third attendee join.
 

--- a/src/contentsharecontroller/ContentShareMediaStreamBroker.ts
+++ b/src/contentsharecontroller/ContentShareMediaStreamBroker.ts
@@ -66,7 +66,11 @@ export default class ContentShareMediaStreamBroker implements MediaStreamBroker 
     return {
       audio:
         !sourceId && new DefaultBrowserBehavior().getDisplayMediaAudioCaptureSupport()
-          ? true
+          ? {
+              echoCancellation: false,
+              noiseSuppression: false,
+              autoGainControl: false,
+            }
           : false,
       video: {
         ...(!sourceId && {

--- a/test/contentsharecontroller/ContentShareMediaStreamBroker.test.ts
+++ b/test/contentsharecontroller/ContentShareMediaStreamBroker.test.ts
@@ -181,7 +181,11 @@ describe('ContentShareMediaStreamBroker', () => {
       dommMockBehavior.browserName = 'chrome';
       domMockBuilder = new DOMMockBuilder(dommMockBehavior);
       const streamConstraints: MediaStreamConstraints = {
-        audio: true,
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false,
+        },
         video: {
           frameRate: {
             max: 15,


### PR DESCRIPTION
**Issue #:**
Customer issue with sharing browser tab audio and loud video.

**Description of changes:**

Based on the article: https://medium.com/@trystonperry/why-is-getdisplaymedias-audio-quality-so-bad-b49ba9cfaa83

We don't need these parameters for content sharing. Removing them as they cause unnecessary audio processing.

**Testing:**

Tested on a serverless demo.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?

yes

3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

no

4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

