### PR TITLE
Make redundant audio worker code generation script also work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed rare race conditions with simulcast + server side network adaptation on third attendee join.
+- Make redundant audio worker code generation script work on Windows
 
 ## [3.22.0] - 2024-03-15
 


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/2779

**Description of changes:**
1. Use a common `tsc` path
2. Handle carriage returns in code string

**Testing:**
1. Successfully built on Windows 10 using `npm run build`
2. Successfully built on Mac using `npm run build:release` with all tests passing


**Checklist:**

1. Have you successfully run `npm run build:release` locally? y


3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? n


4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? n


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

