### PR TITLE
Add meetings af-south-1 as supported control plane region

### DIFF
--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -48,6 +48,7 @@ const supportedControlRegions = [
   'ca-central-1',
   'us-gov-east-1',
   'us-gov-west-1',
+  'af-south-1',
 ];
 
 let chimeSDKMediaPipelinesEndpoint = 'https://media-pipelines-chime.us-east-1.amazonaws.com';
@@ -59,6 +60,12 @@ const supportedMediaPipelinesControlRegions = [
   'eu-central-1',
   'us-east-1',
   'us-west-2',
+  'ap-south-1',
+  'ap-northeast-2',
+  'ap-southeast-2',
+  'ap-northeast-1',
+  'ca-central-1',
+  'eu-west-2',
 ];
 
 function usage() {
@@ -272,8 +279,8 @@ function ensureRegion() {
 }
 
 function ensureMediaPipelinesRegion() {
-  if (!(new Set(supportedMediaPipelinesControlRegions)).has(region)) {
-      console.error(`Amazon Chime SDK Media Pipelines does not support ${region} (control region). Specify one of the following regions: ${supportedMediaPipelinesControlRegions.join(', ')}.\nSee https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines for more information.`);
+  if (!(new Set(supportedMediaPipelinesControlRegions)).has(mediaPipelinesControlRegion)) {
+      console.error(`Amazon Chime SDK Media Pipelines does not support ${mediaPipelinesControlRegion} (control region). Specify one of the following regions: ${supportedMediaPipelinesControlRegions.join(', ')}.\nSee https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines for more information.`);
       process.exit(1);
   }
 }


### PR DESCRIPTION
**Issue #:**

Update serverless deploy script post ChimeMeetingsSDK af-south-1 launch.

**Description of changes:**

1. Add `af-south-1` as supported meetings control plane region for ChimeMeetingsSDK namespace
2. Fix media pipeline control place region check

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

1. Deployed serverless demo using below command:
```
npm run deploy -- -r af-south-1 -b devalevd-cpt-burner -s js-sdk-serverless-cpt -a meeting -m https://meetings-chime.af-south-1.amazonaws.com
```
2. Verified meeting join.


**Checklist:**

1. Have you successfully run `npm run build:release` locally? NA


4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? NA


5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? NA


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

