### PR TITLE
Do not try to manually adjust SVC layers based off target resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Do not try to manually adjust SVC layers based off target resolution, as this may lead to an unnecessarily high minimum bitrate to subscribe to all remote videos. Instead rely on browser logic which drops any layers below around 135p.
 
 ### Fixed
 

--- a/docs/classes/nscalevideouplinkbandwidthpolicy.html
+++ b/docs/classes/nscalevideouplinkbandwidthpolicy.html
@@ -415,7 +415,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#setmeetingsupportedvideosendcodecs">setMeetingSupportedVideoSendCodecs</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L303">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L304">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:304</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -622,7 +622,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/videouplinkbandwidthpolicy.html">VideoUplinkBandwidthPolicy</a>.<a href="../interfaces/videouplinkbandwidthpolicy.html#wantsvideodependencydescriptorrtpheaderextension">wantsVideoDependencyDescriptorRtpHeaderExtension</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L299">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:299</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts#L300">src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts:300</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
+++ b/src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.ts
@@ -264,7 +264,8 @@ export default class NScaleVideoUplinkBandwidthPolicy implements VideoUplinkBand
       if ((this.numParticipants >= 0 && this.numParticipants < 3) || !this.isUsingSVCCodec) {
         scalabilityMode = 'L1T1';
       } else {
-        scalabilityMode = targetHeight >= 720 ? 'L3T3' : targetHeight >= 360 ? 'L2T3' : 'L1T3';
+        // We do not limit the number of layers depending on input resolution, however Chrome will drop anything below around 135p.
+        scalabilityMode = 'L3T3';
       }
       this.logger?.info(
         `calculateEncodingParameters: SVC: ${this.enableSVC}    participants: ${

--- a/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
+++ b/test/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy.test.ts
@@ -898,40 +898,6 @@ describe('NScaleVideoUplinkBandwidthPolicy', () => {
       expect(policy.optimalParameters.isSVCEncoding()).to.be.true;
     });
 
-    it('Degrade to L2T3 scalability mode if target height is between 360 and 720', () => {
-      policy.setTransceiverController(transceiverController);
-      // @ts-ignore
-      policy.isUsingSVCCodec = false;
-      // @ts-ignore
-      policy.numParticipants = 10;
-      // @ts-ignore
-      policy.numberOfPublishedVideoSources = 8;
-      policy.setSVCEnabled(true);
-      policy.setMeetingSupportedVideoSendCodecs(
-        [VideoCodecCapability.vp9Profile0()],
-        [VideoCodecCapability.vp9Profile0(), VideoCodecCapability.h264ConstrainedBaselineProfile()]
-      );
-      // @ts-ignore
-      expect(policy.optimalParameters.isSVCEncoding()).to.be.true;
-    });
-
-    it('Degrade to L1T3 scalability mode if target height is below 360', () => {
-      policy.setTransceiverController(transceiverController);
-      // @ts-ignore
-      policy.isUsingSVCCodec = false;
-      // @ts-ignore
-      policy.numParticipants = 16;
-      // @ts-ignore
-      policy.numberOfPublishedVideoSources = 14;
-      policy.setSVCEnabled(true);
-      policy.setMeetingSupportedVideoSendCodecs(
-        [VideoCodecCapability.vp9Profile0()],
-        [VideoCodecCapability.vp9Profile0(), VideoCodecCapability.h264ConstrainedBaselineProfile()]
-      );
-      // @ts-ignore
-      expect(policy.optimalParameters.isSVCEncoding()).to.be.true;
-    });
-
     it('Enables SVC when SVC is enabled, even if logger is not defined', () => {
       policy = new NScaleVideoUplinkBandwidthPolicy(selfAttendeeId, true);
       policy.setTransceiverController(transceiverController);


### PR DESCRIPTION
**Issue #:** None

**Description of changes:** Do not try to manually adjust SVC layers based off target resolution, as this may lead to an unnecessarily high minimum bitrate to subscribe to all remote videos. Instead rely on browser logic which drops any layers below around 135p.

**Testing:**
Verified SVC still worked and doesn't adjust layers from resolution.
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not really

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

