### PR TITLE
Update uplink policy at codec degradation triggered by encoding health monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update uplink policy at codec degradation triggered by encoding health monitor.
+
 ## [3.23.0] - 2024-05-14
 
 ### Added

--- a/src/task/MonitorTask.ts
+++ b/src/task/MonitorTask.ts
@@ -493,6 +493,14 @@ export default class MonitorTask
           this.context.meetingSupportedVideoSendCodecPreferences[0]
         );
         this.context.meetingSupportedVideoSendCodecPreferences = newMeetingSupportedVideoSendCodecPreferences;
+
+        if (this.context.videoUplinkBandwidthPolicy.setMeetingSupportedVideoSendCodecs) {
+          this.context.videoUplinkBandwidthPolicy.setMeetingSupportedVideoSendCodecs(
+            this.context.meetingSupportedVideoSendCodecPreferences,
+            this.context.videoSendCodecPreferences
+          );
+        }
+
         this.context.audioVideoController.update({ needsRenegotiation: true });
       } else {
         this.context.logger.warn(

--- a/test/task/MonitorTask.test.ts
+++ b/test/task/MonitorTask.test.ts
@@ -56,6 +56,7 @@ import DefaultVideoTileController from '../../src/videotilecontroller/DefaultVid
 import DefaultVideoTileFactory from '../../src/videotilefactory/DefaultVideoTileFactory';
 import DefaultSimulcastUplinkPolicy from '../../src/videouplinkbandwidthpolicy/DefaultSimulcastUplinkPolicy';
 import NoVideoUplinkBandwidthPolicy from '../../src/videouplinkbandwidthpolicy/NoVideoUplinkBandwidthPolicy';
+import NScaleVideoUplinkBandwidthPolicy from '../../src/videouplinkbandwidthpolicy/NScaleVideoUplinkBandwidthPolicy';
 import DefaultWebSocketAdapter from '../../src/websocketadapter/DefaultWebSocketAdapter';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
 import DOMMockBuilder from '../dommock/DOMMockBuilder';
@@ -1460,7 +1461,7 @@ describe('MonitorTask', () => {
       ).to.be.true;
     });
 
-    it('should degrade when there is more than one codec preferences', async () => {
+    it('should degrade when there is more than one codec preferences with NScaleVideoUplinkBandwidthPolicy', async () => {
       context.meetingSupportedVideoSendCodecPreferences = [
         VideoCodecCapability.vp9Profile0(),
         VideoCodecCapability.vp8(),
@@ -1469,6 +1470,28 @@ describe('MonitorTask', () => {
         VideoCodecCapability.vp9Profile0(),
         VideoCodecCapability.vp8(),
       ];
+      context.videoUplinkBandwidthPolicy = new NScaleVideoUplinkBandwidthPolicy(
+        'self',
+        true,
+        logger
+      );
+      // @ts-ignore
+      task.degradeVideoCodec();
+      expect(
+        context.meetingSupportedVideoSendCodecPreferences[0].equals(VideoCodecCapability.vp8())
+      ).to.be.true;
+    });
+
+    it('should degrade when there is more than one codec preferences with DefaultSimulcastUplinkPolicy', async () => {
+      context.meetingSupportedVideoSendCodecPreferences = [
+        VideoCodecCapability.vp9Profile0(),
+        VideoCodecCapability.vp8(),
+      ];
+      context.videoSendCodecPreferences = [
+        VideoCodecCapability.vp9Profile0(),
+        VideoCodecCapability.vp8(),
+      ];
+      context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy('self', logger);
       // @ts-ignore
       task.degradeVideoCodec();
       expect(


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Update uplink policy at codec degradation triggered by encoding health monitor. Error messages like `InvalidModificationError: Failed to execute 'setParameters' on 'RTCRtpSender': Attempted to set RtpParameters scalabilityMode to an unsupported value for the current codecs.` will emit when degrading codec with SVC enabled.

**Testing:**
Smoke tested to verify the aforementioned error message is not emitted at codec degradation triggered by high encode CPU.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
no

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

