### PR TITLE
Prevent dataMessage callback errors from killing a meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+
+- Prevent DataMessage callback errors from killing a meeting
+
 ## [3.26.0] - 2024-10-07
 
 ### Added
@@ -130,15 +142,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.19.0] - 2023-09-20
 
 ### Added
+
 - Add support for high-definition WebRTC sessions with 1080p webcam video and 4K screen share. Developers can choose video encoding bitrates up to 2.5Mbps, frame rates up to 30fps, and the codec, including new options VP9, AV1, and scalable video coding (SVC).
 - Update AWS SDK version to 3.477.0
 
 ### Removed
 
 ### Changed
+
 - Revert: Improve reconnection behavior on signaling disconnection mid call or during join/subscribe. This was leading to unexpected `AudioJoinedFromAnotherDevice` events in certain edge conditions. It will be re-released in a later version.
 
 ### Fixed
+
 - Prevent video processing with filters from being throttled when an attendees meeting tab moves into the background.
 - Do not allow redundant audio worker to enqueue any audio payloads larger than 1000 bytes to avoid permanently stopping the audio flow.
 - Make uplink loss estimation more accurate so that redundant audio does not turn off prematurely.
@@ -152,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
 - Save the redundant audio worker code during build time so that the worker code stays intact and is able to be loaded
 
 ## [3.18.1] - 2023-09-29
@@ -163,11 +179,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
 - Fixed bug that prevented sending and receiving audio, video, and content share when using Simulcast and Redundant Audio at the same time
 
 ## [3.18.0] - 2023-09-11
 
 ### Added
+
 - Support sending and receiving redundant audio data to help reduce the effects of packet loss on audio quality. See README for more details.
 - Send a few additional metrics to backend
 
@@ -176,6 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
 - Fixed audio send failing for the rest of the meeting when writing frames larger than 1000 bytes in Chrome, which could be caused by sending redundant audio
 
 ## [3.17.0] - 2023-08-15
@@ -186,11 +205,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new meeting event, `deviceLabelTriggerFailed`, for device label trigger failures. By default, the Chime SDK for JavaScript requests access to the microphone and camera in order to retrieve device labels. The SDK will send the `deviceLabelTriggerFailed` event when either the microphone, camera or both requests fail. (Before this PR, the SDK would emit `audioInputFailed` and `videoInputFailed` events simultaneously, which could lead to confusion.) If a custom function is supplied with `meetingSession.audioVideo.setDeviceLabelTrigger`, the SDK will send this event when the custom function is not successful.
 
 ### Removed
+
 - Resolution constraint for content share
 
 - Remove unused legacy TURN credentials path.
 
 ### Changed
+
 - Improve reconnection behavior on signaling disconnection mid call or during join/subscribe
 
 ### Fixed
@@ -391,7 +412,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `AbortError` when turning video ON in Safari.
-- `MessagingSession` reconnects with refreshed endpoint and credentials if needed.  `EndpointUrl` on `MessagingSessionConfiguration` is deprecated as it is resolved by calling `getMessagingSessionEndpoint` internally.
+- `MessagingSession` reconnects with refreshed endpoint and credentials if needed. `EndpointUrl` on `MessagingSessionConfiguration` is deprecated as it is resolved by calling `getMessagingSessionEndpoint` internally.
 
 ## [3.6.0] - 2022-06-23
 
@@ -433,7 +454,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue for mute local when there is no audio input.
 - Fix trucation of video subscriptions not occuring if the resubscribe was driven by `MonitorTask`.
 - Fix protobuf generation script for upgrade.
-- Optional chain signaling client observer removal to fix [issue](https://github.com/aws/amazon-chime-sdk-js/issues/2265) if  `audioVideo.stop()` is called before `audioVideo.start()`.
+- Optional chain signaling client observer removal to fix [issue](https://github.com/aws/amazon-chime-sdk-js/issues/2265) if `audioVideo.stop()` is called before `audioVideo.start()`.
 
 ## [3.4.0] - 2022-05-24
 

--- a/docs/classes/defaultrealtimecontroller.html
+++ b/docs/classes/defaultrealtimecontroller.html
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L60">src/realtimecontroller/DefaultRealtimeController.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L61">src/realtimecontroller/DefaultRealtimeController.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -247,7 +247,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimecanunmutelocalaudio">realtimeCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L164">src/realtimecontroller/DefaultRealtimeController.ts:164</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L165">src/realtimecontroller/DefaultRealtimeController.ts:165</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeislocalaudiomuted">realtimeIsLocalAudioMuted</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L236">src/realtimecontroller/DefaultRealtimeController.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L237">src/realtimecontroller/DefaultRealtimeController.ts:237</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimemutelocalaudio">realtimeMuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L168">src/realtimecontroller/DefaultRealtimeController.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L169">src/realtimecontroller/DefaultRealtimeController.ts:169</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -320,7 +320,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimereceivedatamessage">realtimeReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L414">src/realtimecontroller/DefaultRealtimeController.ts:414</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L415">src/realtimecontroller/DefaultRealtimeController.ts:415</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -349,7 +349,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesenddatamessage">realtimeSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L377">src/realtimecontroller/DefaultRealtimeController.ts:377</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L378">src/realtimecontroller/DefaultRealtimeController.ts:378</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -384,7 +384,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of RealtimeController.realtimeSetAttendeeIdPresence</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L75">src/realtimecontroller/DefaultRealtimeController.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L76">src/realtimecontroller/DefaultRealtimeController.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -420,7 +420,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesetcanunmutelocalaudio">realtimeSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L131">src/realtimecontroller/DefaultRealtimeController.ts:131</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L132">src/realtimecontroller/DefaultRealtimeController.ts:132</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -450,7 +450,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of RealtimeController.realtimeSetLocalAttendeeId</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L70">src/realtimecontroller/DefaultRealtimeController.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L71">src/realtimecontroller/DefaultRealtimeController.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -477,7 +477,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetoattendeeidpresence">realtimeSubscribeToAttendeeIdPresence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L94">src/realtimecontroller/DefaultRealtimeController.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L95">src/realtimecontroller/DefaultRealtimeController.ts:95</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -587,7 +587,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetolocalsignalstrengthchange">realtimeSubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L329">src/realtimecontroller/DefaultRealtimeController.ts:329</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L330">src/realtimecontroller/DefaultRealtimeController.ts:330</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -634,7 +634,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetomuteandunmutelocalaudio">realtimeSubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L217">src/realtimecontroller/DefaultRealtimeController.ts:217</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L218">src/realtimecontroller/DefaultRealtimeController.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -681,7 +681,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetoreceivedatamessage">realtimeSubscribeToReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L391">src/realtimecontroller/DefaultRealtimeController.ts:391</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L392">src/realtimecontroller/DefaultRealtimeController.ts:392</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -731,7 +731,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetosenddatamessage">realtimeSubscribeToSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L352">src/realtimecontroller/DefaultRealtimeController.ts:352</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L353">src/realtimecontroller/DefaultRealtimeController.ts:353</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -784,7 +784,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetosetcanunmutelocalaudio">realtimeSubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L145">src/realtimecontroller/DefaultRealtimeController.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L146">src/realtimecontroller/DefaultRealtimeController.ts:146</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -831,7 +831,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimesubscribetovolumeindicator">realtimeSubscribeToVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L242">src/realtimecontroller/DefaultRealtimeController.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L243">src/realtimecontroller/DefaultRealtimeController.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -866,7 +866,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunmutelocalaudio">realtimeUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L190">src/realtimecontroller/DefaultRealtimeController.ts:190</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L191">src/realtimecontroller/DefaultRealtimeController.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -893,7 +893,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromreceivedatamessage">realtimeUnsubscribeFromReceiveDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L406">src/realtimecontroller/DefaultRealtimeController.ts:406</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L407">src/realtimecontroller/DefaultRealtimeController.ts:407</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -922,7 +922,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromsenddatamessage">realtimeUnsubscribeFromSendDataMessage</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L363">src/realtimecontroller/DefaultRealtimeController.ts:363</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L364">src/realtimecontroller/DefaultRealtimeController.ts:364</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -975,7 +975,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribefromvolumeindicator">realtimeUnsubscribeFromVolumeIndicator</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L260">src/realtimecontroller/DefaultRealtimeController.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L261">src/realtimecontroller/DefaultRealtimeController.ts:261</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1009,7 +1009,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribetoattendeeidpresence">realtimeUnsubscribeToAttendeeIdPresence</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L110">src/realtimecontroller/DefaultRealtimeController.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L111">src/realtimecontroller/DefaultRealtimeController.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1115,7 +1115,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribetolocalsignalstrengthchange">realtimeUnsubscribeToLocalSignalStrengthChange</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L341">src/realtimecontroller/DefaultRealtimeController.ts:341</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L342">src/realtimecontroller/DefaultRealtimeController.ts:342</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1162,7 +1162,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribetomuteandunmutelocalaudio">realtimeUnsubscribeToMuteAndUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L225">src/realtimecontroller/DefaultRealtimeController.ts:225</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L226">src/realtimecontroller/DefaultRealtimeController.ts:226</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1209,7 +1209,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/realtimecontroller.html">RealtimeController</a>.<a href="../interfaces/realtimecontroller.html#realtimeunsubscribetosetcanunmutelocalaudio">realtimeUnsubscribeToSetCanUnmuteLocalAudio</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L153">src/realtimecontroller/DefaultRealtimeController.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L154">src/realtimecontroller/DefaultRealtimeController.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1256,7 +1256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of RealtimeController.realtimeUpdateVolumeIndicator</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L278">src/realtimecontroller/DefaultRealtimeController.ts:278</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/realtimecontroller/DefaultRealtimeController.ts#L279">src/realtimecontroller/DefaultRealtimeController.ts:279</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -5,6 +5,7 @@ import DataMessage from '../datamessage/DataMessage';
 import MediaStreamBroker from '../mediastreambroker/MediaStreamBroker';
 import DefaultTranscriptionController from '../transcript/DefaultTranscriptionController';
 import TranscriptionController from '../transcript/TranscriptionController';
+import { iterateEvery } from '../utils/Utils';
 import RealtimeAttendeePositionInFrame from './RealtimeAttendeePositionInFrame';
 import RealtimeController from './RealtimeController';
 import RealtimeState from './RealtimeState';
@@ -413,13 +414,11 @@ export default class DefaultRealtimeController implements RealtimeController {
 
   realtimeReceiveDataMessage(dataMessage: DataMessage): void {
     try {
-      if (this.state.receiveDataMessageCallbacks.has(dataMessage.topic)) {
-        for (const fn of this.state.receiveDataMessageCallbacks.get(dataMessage.topic)) {
-          fn(dataMessage);
-        }
-      }
+      iterateEvery(this.state.receiveDataMessageCallbacks.get(dataMessage.topic), fn => {
+        fn(dataMessage);
+      });
     } catch (e) {
-      this.onError(e);
+      // TODO: these are not fatal errors, but how can we bubble them up?
     }
   }
 

--- a/src/realtimecontroller/DefaultRealtimeController.ts
+++ b/src/realtimecontroller/DefaultRealtimeController.ts
@@ -418,7 +418,8 @@ export default class DefaultRealtimeController implements RealtimeController {
         fn(dataMessage);
       });
     } catch (e) {
-      // TODO: these are not fatal errors, but how can we bubble them up?
+      // We don't want to throw to our caller, but we still want to surface the error in the console
+      Promise.reject(e);
     }
   }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -86,16 +86,19 @@ export function getRandomValues(buffer: Uint32Array): void {
  * https://github.com/tc39/proposal-explicit-resource-management?tab=readme-ov-file#the-suppressederror-error
  */
 export class SuppressedError extends Error {
-  constructor(readonly error: any, readonly suppressed?: SuppressedError, message?: string) {
-    super(
-      message ??
-        `${error && typeof error === 'object' && 'message' in error ? error.message : error}`
-    );
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public readonly error: any,
+    public readonly suppressed?: SuppressedError,
+    message?: string
+  ) {
+    /* istanbul ignore next -- because coverage can't detect all the branches */
+    super(message ?? `${error?.message ?? error}`);
   }
 }
 
 /**
- * Run a callback over the set of all values, absorb all errors, and re-throw any errors at the end.
+ * Run a callback over the set of all values, suppress any errors, and only throw after iteration completes.
  * @param iterable - The iterable to iterate over
  * @param callback - The callback to run on each iteration
  * @throws If any of the callbacks throw an error
@@ -103,7 +106,7 @@ export class SuppressedError extends Error {
 export function iterateEvery<T>(
   iterable: Iterable<T> | undefined | null,
   callback: (value: T) => void
-) {
+): void {
   if (!iterable) return;
   let suppressedError: SuppressedError | undefined;
   for (const value of iterable) {

--- a/test/realtimecontroller/DefaultRealtimeController.test.ts
+++ b/test/realtimecontroller/DefaultRealtimeController.test.ts
@@ -1427,7 +1427,7 @@ describe('DefaultRealtimeController', () => {
       expectError(fatal, 'Oh no');
     });
 
-    it('handles a receive message callback that throws', () => {
+    it('does not throw when it receives a message callback that throws', () => {
       const fatal = sinon.stub();
       rt.realtimeSubscribeToFatalError(fatal);
       rt.realtimeSubscribeToReceiveDataMessage('foo', _m => {
@@ -1436,7 +1436,7 @@ describe('DefaultRealtimeController', () => {
 
       const message = new DataMessage(Date.now(), 'foo', new Uint8Array(), 'abc', 'def', false);
       rt.realtimeReceiveDataMessage(message);
-      expectError(fatal, 'Oh no');
+      expect(fatal.called).to.be.false;
     });
   });
 });

--- a/test/utils/Utils.test.ts
+++ b/test/utils/Utils.test.ts
@@ -5,8 +5,10 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 
 import {
+  iterateEvery,
   getFormattedOffset,
   getRandomValues,
+  SuppressedError,
   toLowerCasePropertyNames,
   wait,
 } from '../../src/utils/Utils';
@@ -135,14 +137,90 @@ describe('Utils', () => {
   });
 
   describe('getRandomValues', () => {
-    describe('getRandomValues', () => {
-      it('should handle catch block for Node environment', () => {
-        const buffer = new Uint32Array(1);
-        const dataViewSpy = sinon.spy(DataView.prototype, 'setUint32');
-        getRandomValues(buffer);
-        expect(dataViewSpy.calledOnce).to.be.true;
-        dataViewSpy.restore();
+    it('should handle catch block for Node environment', () => {
+      const buffer = new Uint32Array(1);
+      const dataViewSpy = sinon.spy(DataView.prototype, 'setUint32');
+      getRandomValues(buffer);
+      expect(dataViewSpy.calledOnce).to.be.true;
+      dataViewSpy.restore();
+    });
+  });
+
+  describe('SuppressedError', () => {
+    it('should properly construct a SuppressedError', () => {
+      const err = new Error('bad');
+
+      // string message
+      const a = new SuppressedError(err, undefined, 'message');
+      expect(a.message).to.eq('message');
+      expect(a.suppressed).to.be.undefined;
+
+      // value-as-error stringified
+      const b = new SuppressedError(1, a);
+      expect(b.message).to.eq('1');
+      expect(b.suppressed).to.eq(a);
+
+      // error.message
+      const c = new SuppressedError(err);
+      expect(c.message).to.eq('bad');
+    });
+
+    it('should suppress anything', () => {
+      expect(() => {
+        // b/c JS can throw anything, SuppressedError has to handle anything as an error
+        const a = new SuppressedError(undefined, undefined, undefined);
+        const values: any[] = [
+          'string',
+          1,
+          {},
+          [],
+          new Date(),
+          new Map(),
+          new Set(),
+          globalThis,
+          null,
+          Symbol('error'),
+        ];
+        values.forEach((value, i) => {
+          new SuppressedError(value, a, i.toString());
+        });
+      }).not.to.throw;
+    });
+  });
+
+  describe('iterateEvery', () => {
+    it('should iterate over every value even if some callbacks throw and collect all errors into a single SuppressedError', () => {
+      const values = [1, 2, 3, 4, 5, 6];
+      const evens = values.filter(a => a % 2 === 0);
+      const throwEven = sinon.spy((a: number) => {
+        if (a % 2 === 0) throw new Error(`${a}`);
       });
+      let error = undefined;
+      try {
+        iterateEvery(values, throwEven);
+      } catch (err) {
+        error = err;
+      }
+      expect(throwEven.callCount).to.eq(values.length);
+      expect(throwEven.exceptions.filter(e => !!e).length).to.eq(evens.length);
+      expect(error).to.be.instanceof(SuppressedError);
+
+      const messages: string[] = [];
+      let se = error instanceof SuppressedError ? error : undefined;
+      while (se) {
+        messages.push(se.message);
+        se = se.suppressed;
+      }
+      expect(messages).to.eql(evens.map(n => n.toString()).reverse());
+    });
+
+    it('should not throw an error for null or undefined', () => {
+      expect(() => iterateEvery(null, () => {})).not.to.throw;
+      expect(() => iterateEvery(undefined, () => {})).not.to.throw;
+    });
+
+    it('should throw an error when the data is not iterable', () => {
+      expect(() => iterateEvery(3 as any, () => {})).to.throw;
     });
   });
 });

--- a/test/utils/Utils.test.ts
+++ b/test/utils/Utils.test.ts
@@ -5,9 +5,9 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 
 import {
-  iterateEvery,
   getFormattedOffset,
   getRandomValues,
+  iterateEvery,
   SuppressedError,
   toLowerCasePropertyNames,
   wait,
@@ -169,7 +169,7 @@ describe('Utils', () => {
       expect(() => {
         // b/c JS can throw anything, SuppressedError has to handle anything as an error
         const a = new SuppressedError(undefined, undefined, undefined);
-        const values: any[] = [
+        const values = [
           'string',
           1,
           {},
@@ -220,7 +220,8 @@ describe('Utils', () => {
     });
 
     it('should throw an error when the data is not iterable', () => {
-      expect(() => iterateEvery(3 as any, () => {})).to.throw;
+      // @ts-expect-error 3 is not iterable
+      expect(() => iterateEvery(3, () => {})).to.throw;
     });
   });
 });


### PR DESCRIPTION
**Issue #:** #2974

**Description of changes:**

Do not create a fatal error when the user-defined callbacks throw an error.

**Testing:**

Unit tested. POC tested in internal application.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Yes
