### PR TITLE
Add PRE_RUN_SCRIPT_URL env variable to BG Blur Tests

### DIFF
--- a/.github/workflows/browser-compatibility-test-previous-major-version.yml
+++ b/.github/workflows/browser-compatibility-test-previous-major-version.yml
@@ -13,6 +13,7 @@ env:
   SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
+  PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
 
 jobs:
   get-previous-version:

--- a/.github/workflows/browser-compatibility-test.yml
+++ b/.github/workflows/browser-compatibility-test.yml
@@ -14,6 +14,7 @@ env:
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
   SLACK_JS_SDK_DEV_CORE_WEBHOOK: ${{secrets.SLACK_JS_SDK_DEV_CORE_WEBHOOK}}
+  PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
 
 jobs:
   browser-compatibility-audio:


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Fix BG blur browser compatiblity test - this prerun script needs to run before this test is executed.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

