### PR TITLE
Do not store metrics for video send stream that no longer exists after reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid breaking audio input when external devices are disconnected on iOS browsers when using Web Audio by suspending and resuming the audio context in that case.
 - Fixed incoming audio loss calculation when server side network adaption and redundant audio features are running together.
 - Prevent DataMessage callback errors from killing a meeting
+- Do not store metrics for video send stream that no longer exists after reconnection
 
 ## [3.25.0] - 2024-09-10
 


### PR DESCRIPTION
**Issue #:** Internal

**Description of changes:** See comment.

**Testing:**

Logged out video metrics. Reproduced issue. Confirmed it does not reproduce after the fix.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

No, required custom logs

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

