### PR TITLE
Add inline sources in source map files

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -13,6 +13,7 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "sourceMap": true,
+    "inlineSources": true,
     "stripInternal": true,
     "target": "ES2015",
     "esModuleInterop": true


### PR DESCRIPTION
**Issue #2594:**

**Description of changes:**
We did not include the source code in the build artifacts which cause error from bundle and require to exclude `amazon-chime-sdk-js`: 
```
failed to parse source map from '.../node_modules/amazon-chime-sdk-js/src/websocketadapter/defaultwebsocketadapter.ts'
file: error: enoent: no such file or directory, open '.../node_modules/amazon-chime-sdk-js/src/websocketadapter/defaultwebsocketadapter.ts'
```
Instead of #2595 , I tried to add the source code inline to the map files which reduce the final size of the npm package but it still increases to about 1.5MB (3.8 to 5.3 npm unpacked) but since this is just source map files used to debugging it should be fine.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? N/A


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

