### PR TITLE
Fix sending of certain metrics to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed incoming audio loss calculation when server side network adaption and redundant audio features are running together.
 - Prevent DataMessage callback errors from killing a meeting
 - Do not store metrics for video send stream that no longer exists after reconnection
+- Send audio downstream decoder loss and jitter buffer size to backend as intended, for internal debugging
 
 ## [3.25.0] - 2024-09-10
 

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -45,7 +45,6 @@
       }
     },
     "../..": {
-      "name": "amazon-chime-sdk-js",
       "version": "3.26.0",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
**Issue #:** None

**Description of changes:**
We have not been sending two metrics to backend since GA...this fixes that.

**Testing:**
It now sends metric.
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

