### PR TITLE
Replace IAM credentials with role in CI workflow

### DIFF
--- a/.github/actions/setup-integration-test/action.yml
+++ b/.github/actions/setup-integration-test/action.yml
@@ -13,13 +13,13 @@ inputs:
     required: false
     description: "The datacenter endpoint for the SauceLabs Connect Proxy."
     default: "https://saucelabs.com/rest/v1"
-  aws-access-key-id:
+  aws-role-to-assume:
     required: true
-    description: "The access key of the AWS account"
+    description: "The AWS Role to assume"
     default: ""
-  aws-secret-access-key:
-    required: true
-    description: "The secret access key of the AWS account"
+  aws-role-session-name:
+    required: false
+    description: "The AWS Role Session Name"
     default: ""
 runs:
   using: "composite"
@@ -44,10 +44,10 @@ runs:
       run: echo "${{ steps.create-job-id.outputs.uuid }}"
       shell: bash
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: ${{ inputs.aws-role-session-name }}
         aws-region: us-east-1
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,9 @@
     SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
     PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
 
+  permissions:
+    id-token: write   # This is required for requesting the JWT
+
   jobs:
     build:
       name: Build and Run Unit Tests
@@ -52,8 +55,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Content Share Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-content-share-test-suite-one
@@ -78,8 +81,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Content Share Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-content-share-test-suite-two
@@ -104,8 +107,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Background Blur Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-background-blur
@@ -133,8 +136,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Audio Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-audio
@@ -161,8 +164,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Setup userArn
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: integration/js/script/test-setup
@@ -190,8 +193,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Data Message Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-data-message
@@ -222,8 +225,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Transcription Integration Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-transcription
@@ -248,8 +251,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Video Integ Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-video
@@ -274,8 +277,8 @@
           with:
             sauce-username: ${{ secrets.SAUCE_USERNAME }}
             sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+            aws-role-session-name: ${{ env.TEST_TYPE }}
         - name: Run Video Test App Integ Test
           if:  steps.test_needed.outputs.integ_test_required == 'true'
           run: npm run test:integration-video-test-app


### PR DESCRIPTION
**Issue #:**

**Description of changes:** 
Replace IAM credentials with role in CI workflow. 
Reference - https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/

**Testing:**

See Checks tab, the CI workflow should succeed.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
NA, github actions change only.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

