### PR TITLE
Change config AWS creds to role to unblock previous major version test

### DIFF
--- a/.github/actions/setup-integration-test/action.yml
+++ b/.github/actions/setup-integration-test/action.yml
@@ -13,13 +13,13 @@ inputs:
     required: false
     description: "The datacenter endpoint for the SauceLabs Connect Proxy."
     default: "https://saucelabs.com/rest/v1"
-  aws-access-key-id:
+  aws-role-to-assume:
     required: true
-    description: "The access key of the AWS account"
+    description: "The AWS Role to assume"
     default: ""
-  aws-secret-access-key:
-    required: true
-    description: "The secret access key of the AWS account"
+  aws-role-session-name:
+    required: false
+    description: "The AWS Role Session Name"
     default: ""
 runs:
   using: "composite"
@@ -44,10 +44,10 @@ runs:
       run: echo "${{ steps.create-job-id.outputs.uuid }}"
       shell: bash
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-session-name: ${{ inputs.aws-role-session-name }}
         aws-region: us-east-1
     - name: Setup Sauce Connect
       uses: saucelabs/sauce-connect-action@v1


### PR DESCRIPTION
**Issue #:**

https://github.com/aws/amazon-chime-sdk-js/actions/runs/12242248006

**Description of changes:**

Change config AWS creds to role to unblock previous major version test
Apply the PR https://github.com/aws/amazon-chime-sdk-js/pull/3018 to v2 integration test

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

