### PR TITLE
Cloudwatch alarms

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../..": {
-      "version": "3.21.0",
+      "version": "3.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/demos/serverless/chime-awscloudwatchalarms.yaml
+++ b/demos/serverless/chime-awscloudwatchalarms.yaml
@@ -1,0 +1,924 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create CloudWatch Alarms for Chime Lambda functions and SQS queue
+Resources:
+  SQSQueueApproximateAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSQSQueueApproximateAgeAlarm
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 60   
+      EvaluationPeriods: 1
+      Threshold: 60  
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when the ApproximateAgeOfOldestMessage exceeds 1 minutes"
+      Dimensions:
+        - Name: QueueName
+          Value: !Select [5, !Split [":", !ImportValue ChimeSQSQueueArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkIndexLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkIndexLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkIndexLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkIndexLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkAudioFileLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkAudioFileLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkAudioFileLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkAudioFileLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStereoAudioFileLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStereoAudioFileLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStereoAudioFileLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStereoAudioFileLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStartCaptureLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStartCaptureLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStartCaptureLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStartCaptureLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndCaptureLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndCaptureLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndCaptureLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndCaptureLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStartLiveConnectorLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStartLiveConnectorLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStartLiveConnectorLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStartLiveConnectorLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndLiveConnectorLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndLiveConnectorLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndLiveConnectorLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndLiveConnectorLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSQSQueueLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSQSQueueLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSQSQueueLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSQSQueueLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  
+  ChimeSdkBrowserLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserMeetingEventLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserMeetingEventLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserMeetingEventLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserMeetingEventLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserEventIngestionLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserEventIngestionLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserEventIngestionLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserEventIngestionLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserEventIngestionLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserEventIngestionLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserEventIngestionLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserEventIngestionLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserCreateLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserCreateLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserCreateLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserCreateLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserCreateBrowserEventLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserCreateBrowserEventLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserCreateBrowserEventLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserCreateBrowserEventLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sAWSTemplateFormatVersion: '2010-09-09'
+      TreatMissingData: notBreaching
+      
+  ChimeSdkIndexLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkIndexLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkIndexLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkIndexLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkAudioFileLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkAudioFileLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkAudioFileLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkAudioFileLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStereoAudioFileLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStereoAudioFileLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStereoAudioFileLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStereoAudioFileLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStartCaptureLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStartCaptureLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStartCaptureLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStartCaptureLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndCaptureLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndCaptureLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndCaptureLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndCaptureLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStartLiveConnectorLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStartLiveConnectorLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStartLiveConnectorLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStartLiveConnectorLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkEndLiveConnectorLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkEndLiveConnectorLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60  
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkEndLiveConnectorLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkEndLiveConnectorLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSQSQueueLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSQSQueueLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSQSQueueLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSQSQueueLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserMeetingEventLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserMeetingEventLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserMeetingEventLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserMeetingEventLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserEventIngestionLogsLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserEventIngestionLogsLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserEventIngestionLogsLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserEventIngestionLogsLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserEventIngestionLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserEventIngestionLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserEventIngestionLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserEventIngestionLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserCreateLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserCreateLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserCreateLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserCreateLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBrowserCreateBrowserEventLogStreamLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBrowserCreateBrowserEventLogStreamLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBrowserCreateBrowserEventLogStreamLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBrowserCreateBrowserEventLogStreamLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkStartTranscriptionLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStartTranscriptionLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStartTranscriptionLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStartTranscriptionLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+  
+  ChimeSdkStopTranscriptionLambdaAlarm:   
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkStopTranscriptionLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkStopTranscriptionLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkStopTranscriptionLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkUpdateAttendeeCapabilitiesLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkUpdateAttendeeCapabilitiesLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60 
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkUpdateAttendeeCapabilitiesLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkUpdateAttendeeCapabilitiesLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkGetAttendeeLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkGetAttendeeLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkGetAttendeeLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkGetAttendeeLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkJoinLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkJoinLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkJoinLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkJoinLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  ChimeSdkDeleteAttendeeLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: ChimeSdkDeleteAttendeeLambdaErrors
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when ChimeSdkDeleteAttendeeLambda has more than 1 error in 1 minutes"
+      Dimensions:
+        - Name: FunctionName
+          Value: !Select [6, !Split [":", !ImportValue ChimeSdkDeleteAttendeeLambdaArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  DynamodbMeetingsTableReadCapacityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: DynamodbMeetingsTableReadCapacityAlarm
+      MetricName: ConsumedReadCapacityUnits
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 50
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when DynamoDB Meetings table read capacity exceeds 50 units in 1 minute"
+      Dimensions:
+        - Name: TableName
+          Value: !Select [1, !Split ["/", !ImportValue DynamodbMeetingsTableArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+
+  DynamodbMeetingsTableWriteCapacityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: DynamodbMeetingsTableWriteCapacityAlarm
+      MetricName: ConsumedWriteCapacityUnits
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 50
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmDescription: "Alarm when DynamoDB Meetings table write capacity exceeds 50 units in 1 minute"
+      Dimensions:
+        - Name: TableName
+          Value: !Select [1, !Split ["/", !ImportValue DynamodbMeetingsTableArn]]
+      AlarmActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      OKActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      InsufficientDataActions:
+        - arn:aws:sns:ca-central-1:427174714230:SNS_Slack_Topic
+      TreatMissingData: notBreaching
+

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -59,6 +59,7 @@ const supportedMediaPipelinesControlRegions = [
   'eu-central-1',
   'us-east-1',
   'us-west-2',
+	'ca-central-1'
 ];
 
 function usage() {

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -826,6 +826,9 @@ function response(statusCode, contentType, body, isBase64Encoded = false) {
       'Cross-Origin-Opener-Policy': 'same-origin', 
       // enable shared array buffer for videoFxProcessor
       'Cross-Origin-Embedder-Policy': 'require-corp',
+	  'Access-Control-Allow-Headers': '*',
+	  'Access-Control-Allow-Methods': '*',
+	  'Access-Control-Allow-Origin': '*',
     },
     body: body,
     isBase64Encoded,

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -720,6 +720,157 @@ Resources:
             Path: /get_attendee
             Method: GET
 Outputs:
+  ChimeSdkIndexLambdaArn:
+    Description: "ARN of the ChimeSdkIndexLambda"
+    Value: !GetAtt ChimeSdkIndexLambda.Arn
+    Export:
+      Name: ChimeSdkIndexLambdaArn
+
+  ChimeSdkAudioFileLambdaArn:
+    Description: "ARN of the ChimeSdkAudioFileLambda"
+    Value: !GetAtt ChimeSdkAudioFileLambda.Arn
+    Export:
+      Name: ChimeSdkAudioFileLambdaArn
+
+  ChimeSdkStereoAudioFileLambdaArn:
+    Description: "ARN of the ChimeSdkStereoAudioFileLambda"
+    Value: !GetAtt ChimeSdkStereoAudioFileLambda.Arn
+    Export:
+      Name: ChimeSdkStereoAudioFileLambdaArn
+
+  ChimeSdkJoinLambdaArn:
+    Description: "ARN of the ChimeSdkJoinLambda"
+    Value: !GetAtt ChimeSdkJoinLambda.Arn
+    Export:
+      Name: ChimeSdkJoinLambdaArn
+
+  ChimeSdkDeleteAttendeeLambdaArn:
+    Description: "ARN of the ChimeSdkDeleteAttendeeLambda"
+    Value: !GetAtt ChimeSdkDeleteAttendeeLambda.Arn
+    Export:
+      Name: ChimeSdkDeleteAttendeeLambdaArn
+
+  ChimeSdkEndLambdaArn:
+    Description: "ARN of the ChimeSdkEndLambda"
+    Value: !GetAtt ChimeSdkEndLambda.Arn
+    Export:
+      Name: ChimeSdkEndLambdaArn
+
+  ChimeSdkStartCaptureLambdaArn:
+    Description: "ARN of the ChimeSdkStartCaptureLambda"
+    Value: !GetAtt ChimeSdkStartCaptureLambda.Arn
+    Export:
+      Name: ChimeSdkStartCaptureLambdaArn
+
+  ChimeSdkEndCaptureLambdaArn:
+    Description: "ARN of the ChimeSdkEndCaptureLambda"
+    Value: !GetAtt ChimeSdkEndCaptureLambda.Arn
+    Export:
+      Name: ChimeSdkEndCaptureLambdaArn
+
+  ChimeSdkStartLiveConnectorLambdaArn:
+    Description: "ARN of the ChimeSdkStartLiveConnectorLambda"
+    Value: !GetAtt ChimeSdkStartLiveConnectorLambda.Arn
+    Export:
+      Name: ChimeSdkStartLiveConnectorLambdaArn
+
+  ChimeSdkEndLiveConnectorLambdaArn:
+    Description: "ARN of the ChimeSdkEndLiveConnectorLambda"
+    Value: !GetAtt ChimeSdkEndLiveConnectorLambda.Arn
+    Export:
+      Name: ChimeSdkEndLiveConnectorLambdaArn
+
+  ChimeSQSQueueLambdaArn:
+    Description: "ARN of the ChimeSQSQueueLambda"
+    Value: !GetAtt ChimeSQSQueueLambda.Arn
+    Export:
+      Name: ChimeSQSQueueLambdaArn
+
+  ChimeEventBridgeLambdaArn:
+    Description: "ARN of the ChimeEventBridgeLambda"
+    Condition: ShouldUseEventBridge
+    Value: !GetAtt ChimeEventBridgeLambda.Arn
+    Export:
+      Name: ChimeEventBridgeLambdaArn
+
+  ChimeSdkBrowserLogsLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserLogsLambda"
+    Value: !GetAtt ChimeSdkBrowserLogsLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserLogsLambdaArn
+
+  ChimeSdkBrowserMeetingEventLogsLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserMeetingEventLogsLambda"
+    Value: !GetAtt ChimeSdkBrowserMeetingEventLogsLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserMeetingEventLogsLambdaArn
+
+  ChimeSdkBrowserEventIngestionLogsLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserEventIngestionLogsLambda"
+    Value: !GetAtt ChimeSdkBrowserEventIngestionLogsLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserEventIngestionLogsLambdaArn
+
+  ChimeSdkBrowserEventIngestionLogStreamLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserEventIngestionLogStreamLambda"
+    Value: !GetAtt ChimeSdkBrowserEventIngestionLogStreamLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserEventIngestionLogStreamLambdaArn
+
+  ChimeSdkBrowserCreateLogStreamLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserCreateLogStreamLambda"
+    Value: !GetAtt ChimeSdkBrowserCreateLogStreamLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserCreateLogStreamLambdaArn
+
+  ChimeSdkBrowserCreateBrowserEventLogStreamLambdaArn:
+    Description: "ARN of the ChimeSdkBrowserCreateBrowserEventLogStreamLambda"
+    Value: !GetAtt ChimeSdkBrowserCreateBrowserEventLogStreamLambda.Arn
+    Export:
+      Name: ChimeSdkBrowserCreateBrowserEventLogStreamLambdaArn
+
+  ChimeSdkStartTranscriptionLambdaArn:
+    Description: "ARN of the ChimeSdkStartTranscriptionLambda"
+    Value: !GetAtt ChimeSdkStartTranscriptionLambda.Arn
+    Export:
+      Name: ChimeSdkStartTranscriptionLambdaArn
+
+  ChimeSdkStopTranscriptionLambdaArn:
+    Description: "ARN of the ChimeSdkStopTranscriptionLambda"
+    Value: !GetAtt ChimeSdkStopTranscriptionLambda.Arn
+    Export:
+      Name: ChimeSdkStopTranscriptionLambdaArn
+
+  ChimeSdkUpdateAttendeeCapabilitiesLambdaArn:
+    Description: "ARN of the ChimeSdkUpdateAttendeeCapabilitiesLambda"
+    Value: !GetAtt ChimeSdkUpdateAttendeeCapabilitiesLambda.Arn
+    Export:
+      Name: ChimeSdkUpdateAttendeeCapabilitiesLambdaArn
+
+  ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaArn:
+    Description: "ARN of the ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambda"
+    Value: !GetAtt ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambda.Arn
+    Export:
+      Name: ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaArn
+
+  ChimeSdkGetAttendeeLambdaArn:
+    Description: "ARN of the ChimeSdkGetAttendeeLambda"
+    Value: !GetAtt ChimeSdkGetAttendeeLambda.Arn
+    Export:
+      Name: ChimeSdkGetAttendeeLambdaArn
+
+  ChimeSQSQueueArn:
+    Description: "ARN of the ChimeSQSQueue"
+    Value: !GetAtt MeetingNotificationsQueue.Arn
+    Export:
+      Name: ChimeSQSQueueArn
+
+  DynamodbMeetingsTableArn:
+    Description: "ARN of the Dynamodb Meetings table"
+    Value: !GetAtt Meetings.Arn
+    Export:
+      Name: DynamodbMeetingsTableArn
+
   ApiURL:
     Description: "API endpoint URL for Prod environment"
     Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"


### PR DESCRIPTION
**Issue #:**

**Description of changes:*Added Cloudwatch-Alarms to monitor error rates for lambdas ,Read & Write Capacity for Dynamodb and Messaging QueAge for SQS as per SOC sec controls*

**Testing:*Yes and deployed to Prod-ca*

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

