### PR TITLE
Fix to not log entire background processor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+
 - Match framerate in `DefaultVideoFrameProcessorPipeline` with input stream
+- Fix logging of `options`in `BackgroundBlurProcessorProvided` and `BackgroundReplacementFilter`
 
 ## [3.26.0] - 2024-10-07
 
 ### Added
+
 - Add interface for custom CDN paths for VideoFxProcessor
 
 - Allow setting framerate on `DefaultVideoTransformDevice`

--- a/src/backgroundblurprocessor/BackgroundBlurProcessorProvided.ts
+++ b/src/backgroundblurprocessor/BackgroundBlurProcessorProvided.ts
@@ -48,7 +48,9 @@ export default class BackgroundBlurProcessorProvided
 
     this.logger.info('BackgroundBlur processor successfully created');
     this.logger.info(`BackgroundBlur spec: ${this.stringify(this.spec)}`);
-    this.logger.info(`BackgroundBlur options: ${this.stringify(options)}`);
+    this.logger.info(
+      `BackgroundBlur options: { blurStrength: ${options.blurStrength}, filterCPUUtilization: ${options.filterCPUUtilization}, reportingPeriodMillis: ${options.reportingPeriodMillis}}`
+    );
   }
 
   initOnFirstExecution(): void {

--- a/src/backgroundreplacementprocessor/BackgroundReplacementFilter.ts
+++ b/src/backgroundreplacementprocessor/BackgroundReplacementFilter.ts
@@ -43,7 +43,9 @@ export default class BackgroundReplacementFilter
 
     this.logger.info('BackgroundReplacement processor successfully created');
     this.logger.info(`BackgroundReplacement spec: ${this.stringify(this.spec)}`);
-    this.logger.info(`BackgroundReplacement options: ${this.stringify(options)}`);
+    this.logger.info(
+      `BackgroundReplacement options: { filterCPUUtilization: ${options.filterCPUUtilization}, reportingPeriodMillis: ${options.reportingPeriodMillis}}`
+    );
   }
 
   async setImageBlob(blob: Blob): Promise<void> {


### PR DESCRIPTION
**Issue #:** `options` includes a logger attribute, stringify() can be memory heavy in main thread if a it's a POSTLogger or MultiLogger.

**Description of changes:** Only log valuable options

**Testing:**
Private build tested by QA.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, pack js sdk and get it installed in react component, test the react demo.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?


3. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

