### PR TITLE
Ensure content share resolution is always within limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Ensure content share resolution is always within limits
 
 - Match framerate in `DefaultVideoFrameProcessorPipeline` with input stream
 - Fix logging of `options`in `BackgroundBlurProcessorProvided` and `BackgroundReplacementFilter`

--- a/docs/classes/receivevideoinputtask.html
+++ b/docs/classes/receivevideoinputtask.html
@@ -130,7 +130,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L14">src/task/ReceiveVideoInputTask.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L13">src/task/ReceiveVideoInputTask.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -161,7 +161,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#taskname">taskName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L14">src/task/ReceiveVideoInputTask.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L13">src/task/ReceiveVideoInputTask.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L64">src/task/ReceiveVideoInputTask.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L58">src/task/ReceiveVideoInputTask.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/receivevideoinputtask.html
+++ b/docs/classes/receivevideoinputtask.html
@@ -295,7 +295,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="basetask.html">BaseTask</a>.<a href="basetask.html#run">run</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L58">src/task/ReceiveVideoInputTask.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/task/ReceiveVideoInputTask.ts#L62">src/task/ReceiveVideoInputTask.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/task/ReceiveVideoInputTask.ts
+++ b/src/task/ReceiveVideoInputTask.ts
@@ -40,6 +40,10 @@ export default class ReceiveVideoInputTask extends BaseTask {
     }
 
     const constraint: MediaTrackConstraints = {
+      // Chrome may scale content share to the maximum possible resolution within
+      // max width and height even if input resolution is already under the limits.
+      // Adding ideal resizeMode as none to use the original resoluion when possible
+      // and avoid unexpected scaling.
       resizeMode: { ideal: 'none' },
       width: { max: videoQualitySettings.videoWidth },
       height: { max: videoQualitySettings.videoHeight },

--- a/src/task/ReceiveVideoInputTask.ts
+++ b/src/task/ReceiveVideoInputTask.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
-import VideoQualitySettings from '../devicecontroller/VideoQualitySettings';
 import DefaultModality from '../modality/DefaultModality';
 import { SdkStreamServiceType } from '../signalingprotocol/SignalingProtocol.js';
 import BaseTask from './BaseTask';
@@ -24,40 +23,35 @@ export default class ReceiveVideoInputTask extends BaseTask {
     height: number,
     frameRate: number
   ): Promise<void> {
-    const trackSettings = mediaStreamTrack.getSettings();
-    let videoQualitySettings: VideoQualitySettings;
+    const videoQualitySettings = isContentAttendee
+      ? this.context.meetingSessionConfiguration.meetingFeatures.contentMaxResolution
+      : this.context.meetingSessionConfiguration.meetingFeatures.videoMaxResolution;
 
-    if (isContentAttendee) {
-      videoQualitySettings = this.context.meetingSessionConfiguration.meetingFeatures
-        .contentMaxResolution;
-    } else {
-      videoQualitySettings = this.context.meetingSessionConfiguration.meetingFeatures
-        .videoMaxResolution;
-    }
     if (
-      width > videoQualitySettings.videoWidth ||
-      height > videoQualitySettings.videoHeight ||
-      frameRate > videoQualitySettings.videoFrameRate
+      !isContentAttendee &&
+      width <= videoQualitySettings.videoWidth &&
+      height <= videoQualitySettings.videoHeight &&
+      frameRate <= videoQualitySettings.videoFrameRate
     ) {
-      const constraint: MediaTrackConstraints = {
-        width: { ideal: videoQualitySettings.videoWidth },
-        height: { ideal: videoQualitySettings.videoHeight },
-        frameRate: { ideal: videoQualitySettings.videoFrameRate },
-      };
-      this.context.logger.warn(
-        `Video track (content = ${isContentAttendee}) will be constrained to: ${JSON.stringify(
-          constraint
-        )} to remain below configured video quality settings, trackSettings: ${JSON.stringify(
-          trackSettings
-        )}`
+      // Skip applying constraints if the current video track settings are already
+      // lower than the limit except for content share. Always apply constraint for
+      // content attendees because content share resolution may change.
+      return;
+    }
+
+    const constraint: MediaTrackConstraints = {
+      resizeMode: { ideal: 'none' },
+      width: { max: videoQualitySettings.videoWidth },
+      height: { max: videoQualitySettings.videoHeight },
+      frameRate: { ideal: frameRate, max: videoQualitySettings.videoFrameRate },
+    };
+
+    try {
+      await mediaStreamTrack.applyConstraints(constraint);
+    } catch (error) {
+      this.context.logger.info(
+        `Could not apply constraint for video track (content = ${isContentAttendee})`
       );
-      try {
-        await mediaStreamTrack.applyConstraints(constraint);
-      } catch (error) {
-        this.context.logger.info(
-          `Could not apply constraint for video track (content = ${isContentAttendee})`
-        );
-      }
     }
   }
 

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -53,12 +53,14 @@ export default class DOMMockBehavior {
     deviceId?: string;
     facingMode?: string;
     groupId?: string;
+    frameRate?: number;
   } = {
     width: 0,
     height: 0,
     deviceId: 'test',
     facingMode: 'user',
     groupId: '',
+    frameRate: 0,
   };
   deviceCounter: number = 0;
   enumerateDevicesSucceeds: boolean = true;

--- a/test/task/ReceiveVideoInputTask.test.ts
+++ b/test/task/ReceiveVideoInputTask.test.ts
@@ -195,14 +195,15 @@ describe('ReceiveVideoInputTask', () => {
       expect(context.activeVideoInput.getVideoTracks()).to.be.empty;
     });
 
-    it('will not apply constraint if content does not exceed limit', async () => {
+    it('will not apply constraint if video does not exceed limit', async () => {
       domMockBehavior.mediaStreamTrackSettings = {
-        width: 2560,
-        height: 1440,
+        width: 1280,
+        height: 720,
+        frameRate: 15,
         deviceId: '',
       };
       context.videoStreamIndex = new SimulcastVideoStreamIndex(new NoOpLogger());
-      context.meetingSessionConfiguration.credentials.attendeeId = 'attendee#content';
+      context.meetingSessionConfiguration.credentials.attendeeId = 'attendee';
       context.videoUplinkBandwidthPolicy = new DefaultSimulcastUplinkPolicy(
         'attendee',
         new NoOpLogger()
@@ -212,8 +213,8 @@ describe('ReceiveVideoInputTask', () => {
         acquireVideoInputDeviceSucceeds: true,
         useMockedVideoStream: true,
       });
-      context.meetingSessionConfiguration.meetingFeatures.contentMaxResolution =
-        VideoQualitySettings.VideoResolutionUHD;
+      context.meetingSessionConfiguration.meetingFeatures.videoMaxResolution =
+        VideoQualitySettings.VideoResolutionHD;
       const task = new ReceiveVideoInputTask(context);
       await task.run();
       assert.exists(context.activeVideoInput);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Video track constraint is checked and applied when the video starts. Because content share resolution may change in the middle of a meeting and the current logic does not apply constraint if resolution is within limits at the beginning, content resolution may go above the limit when content is scaled up and trigger resolution enforcements. To avoid this problem after content resolution change, we always apply constraint for content share and use a constraint that will not unnecessarily scale content when resolution is within the limit.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Start a meeting with `FHD 1080p` selected as `Meeting Maximum Content Share Resolution`
2. Let an attendee join the meeting and start a content share pointing to a window with width and height below 1920 and 1080, respectively
3. Scale the window above width of 1920 and height of 1080
4. Ensure encoding width and height are always within 1920 and 1080, respectively

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

5. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

6. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

