### PR TITLE
Upgrade ua-parser-js version

### DIFF
--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -56,7 +56,7 @@
         "pako": "^2.0.4",
         "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^1.0.1"
+        "ua-parser-js": "^1.0.40"
       },
       "devDependencies": {
         "@fluffy-spoon/substitute": "^1.89.0",

--- a/integration/js/app/package-lock.json
+++ b/integration/js/app/package-lock.json
@@ -21,7 +21,7 @@
       }
     },
     "../../..": {
-      "version": "3.26.0",
+      "version": "3.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",
@@ -32,7 +32,7 @@
         "pako": "^2.0.4",
         "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^1.0.1"
+        "ua-parser-js": "^1.0.40"
       },
       "devDependencies": {
         "@fluffy-spoon/substitute": "^1.89.0",
@@ -51,13 +51,13 @@
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-simple-import-sort": "^5.0.3",
         "esm": "^3.2.25",
-        "fetch-mock": "^9.10.7",
+        "fetch-mock": "9.10.7",
         "fs-extra": "^8.1.0",
         "git-rev-sync": "^3.0.2",
         "longjohn": "^0.2.12",
         "mocha": "^10.0.0",
         "node-fetch": "^2.6.1",
-        "nyc": "^15.1.0",
+        "nyc": "^17.1.0",
         "prettier": "^2.1.2",
         "protobufjs-cli": "^1.1.2",
         "rimraf": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "pako": "^2.0.4",
         "protobufjs": "^7.3.0",
         "resize-observer": "^1.0.0",
-        "ua-parser-js": "^1.0.1"
+        "ua-parser-js": "^1.0.40"
       },
       "devDependencies": {
         "@fluffy-spoon/substitute": "^1.89.0",
@@ -6644,9 +6644,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
-      "integrity": "sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==",
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
       "funding": [
         {
           "type": "opencollective",
@@ -6655,8 +6655,15 @@
         {
           "type": "paypal",
           "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "pako": "^2.0.4",
     "protobufjs": "^7.3.0",
     "resize-observer": "^1.0.0",
-    "ua-parser-js": "^1.0.1"
+    "ua-parser-js": "^1.0.40"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
**Issue #: 
https://www.cve.org/CVERecord?id=CVE-2022-25927

Versions of the package ua-parser-js from 0.7.30 and before 0.7.33, from 0.8.1 and before 1.0.33 are vulnerable to Regular Expression Denial of Service (ReDoS) via the trim() function. 

**Description of changes: upgrade to an unaffected version

**Testing:** npm start

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally? Y


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

