### PR TITLE
Fix TypeError when calling unbindVideoElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+Fix TypeError when calling unbindVideoElement
 
 ## [3.27.0] - 2024-12-11
 

--- a/src/videotile/DefaultVideoElementResolutionMonitor.ts
+++ b/src/videotile/DefaultVideoElementResolutionMonitor.ts
@@ -7,7 +7,7 @@ import VideoElementResolutionMonitor, {
 export default class DefaultVideoElementResolutionMonitor implements VideoElementResolutionMonitor {
   private observerQueue = new Set<VideoElementResolutionObserver>();
   private resizeObserver: ResizeObserver;
-  private element?: HTMLVideoElement;
+  private element: HTMLVideoElement | null = null;
 
   constructor() {
     this.resizeObserver = new ResizeObserver(entries => {
@@ -32,12 +32,15 @@ export default class DefaultVideoElementResolutionMonitor implements VideoElemen
     this.observerQueue.delete(observer);
   }
 
-  bindVideoElement(newElement: HTMLVideoElement): void {
-    this.element = newElement;
-    if (!this.element) {
-      this.resizeObserver.unobserve(this.element);
+  bindVideoElement(newElement: HTMLVideoElement | null): void {
+    if (!newElement) {
+      if (this.element) {
+        this.resizeObserver.unobserve(this.element);
+      }
+      this.element = newElement;
       return;
     }
+    this.element = newElement;
     this.resizeObserver.observe(this.element);
   }
 }

--- a/src/videotile/DefaultVideoElementResolutionMonitor.ts
+++ b/src/videotile/DefaultVideoElementResolutionMonitor.ts
@@ -33,14 +33,15 @@ export default class DefaultVideoElementResolutionMonitor implements VideoElemen
   }
 
   bindVideoElement(newElement: HTMLVideoElement | null): void {
-    if (!newElement) {
-      if (this.element) {
-        this.resizeObserver.unobserve(this.element);
-      }
-      this.element = newElement;
+    if (this.element === newElement) {
       return;
     }
+    if (this.element) {
+      this.resizeObserver.unobserve(this.element);
+    }
     this.element = newElement;
-    this.resizeObserver.observe(this.element);
+    if (this.element) {
+      this.resizeObserver.observe(this.element);
+    }
   }
 }

--- a/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
+++ b/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
@@ -79,7 +79,7 @@ describe('DefaultVideoElementResolutionMonitor', () => {
       monitor.bindVideoElement(null);
     });
 
-    it('should skip unobserve if no element is being beserved', () => {
+    it('should skip unobserve if no element is being observed', () => {
       monitor.bindVideoElement(null);
     });
   });

--- a/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
+++ b/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
@@ -15,6 +15,8 @@ describe('DefaultVideoElementResolutionMonitor', () => {
   let domMockBuilder: DOMMockBuilder;
   let monitor: DefaultVideoElementResolutionMonitor;
   let resizeCallback: (entries: ResizeObserverEntry[]) => void;
+  let observeCalled = false;
+  let unobserveCalled = false;
 
   beforeEach(() => {
     behavior = new DOMMockBehavior();
@@ -24,8 +26,12 @@ describe('DefaultVideoElementResolutionMonitor', () => {
       constructor(callback: (entries: ResizeObserverEntry[]) => void) {
         resizeCallback = callback;
       }
-      observe(_target: Element): void {}
-      unobserve(_target: Element): void {}
+      observe(_target: Element): void {
+        observeCalled = true;
+      }
+      unobserve(_target: Element): void {
+        unobserveCalled = true;
+      }
       disconnect(): void {}
     } as typeof ResizeObserver;
   });
@@ -47,6 +53,8 @@ describe('DefaultVideoElementResolutionMonitor', () => {
     let height: number;
 
     beforeEach(() => {
+      observeCalled = false;
+      unobserveCalled = false;
       monitor = new DefaultVideoElementResolutionMonitor();
       mockObserver = {
         videoElementResolutionChanged: (newWidth: number, newHeight: number): void => {
@@ -76,11 +84,15 @@ describe('DefaultVideoElementResolutionMonitor', () => {
       const videoElementFactory = new NoOpVideoElementFactory();
       const videoElement = videoElementFactory.create();
       expect(() => monitor.bindVideoElement(videoElement)).to.not.throw();
+      expect(observeCalled).to.be.true;
       expect(() => monitor.bindVideoElement(null)).to.not.throw();
+      expect(unobserveCalled).to.be.true;
     });
 
     it('should skip unobserve if no element is being observed', () => {
       expect(() => monitor.bindVideoElement(null)).to.not.throw();
+      expect(observeCalled).to.be.false;
+      expect(unobserveCalled).to.be.false;
     });
   });
 });

--- a/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
+++ b/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
@@ -3,6 +3,7 @@
 
 import * as chai from 'chai';
 
+import NoOpVideoElementFactory from '../../src/videoelementfactory/NoOpVideoElementFactory';
 import DefaultVideoElementResolutionMonitor from '../../src/videotile/DefaultVideoElementResolutionMonitor';
 import { VideoElementResolutionObserver } from '../../src/videotile/VideoElementResolutionMonitor';
 import DOMMockBehavior from '../dommock/DOMMockBehavior';
@@ -69,6 +70,17 @@ describe('DefaultVideoElementResolutionMonitor', () => {
       expect(height).to.equal(720);
 
       monitor.removeObserver(mockObserver);
+    });
+
+    it('should bind and unbind video elements', () => {
+      const videoElementFactory = new NoOpVideoElementFactory();
+      const videoElement = videoElementFactory.create();
+      monitor.bindVideoElement(videoElement);
+      monitor.bindVideoElement(null);
+    });
+
+    it('should skip unobserve if no element is being beserved', () => {
+      monitor.bindVideoElement(null);
     });
   });
 });

--- a/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
+++ b/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
@@ -75,12 +75,12 @@ describe('DefaultVideoElementResolutionMonitor', () => {
     it('should bind and unbind video elements', () => {
       const videoElementFactory = new NoOpVideoElementFactory();
       const videoElement = videoElementFactory.create();
-      monitor.bindVideoElement(videoElement);
-      monitor.bindVideoElement(null);
+      expect(() => monitor.bindVideoElement(videoElement)).to.not.throw();
+      expect(() => monitor.bindVideoElement(null)).to.not.throw();
     });
 
     it('should skip unobserve if no element is being observed', () => {
-      monitor.bindVideoElement(null);
+      expect(() => monitor.bindVideoElement(null)).to.not.throw();
     });
   });
 });

--- a/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
+++ b/test/videotile/DefaultVideoElementResolutionMonitor.test.ts
@@ -85,7 +85,22 @@ describe('DefaultVideoElementResolutionMonitor', () => {
       const videoElement = videoElementFactory.create();
       expect(() => monitor.bindVideoElement(videoElement)).to.not.throw();
       expect(observeCalled).to.be.true;
+      expect(unobserveCalled).to.be.false;
+      observeCalled = false;
+      unobserveCalled = false;
+      expect(() => monitor.bindVideoElement(videoElement)).to.not.throw();
+      expect(observeCalled).to.be.false;
+      expect(unobserveCalled).to.be.false;
+      observeCalled = false;
+      unobserveCalled = false;
+      const newVideoElement = videoElementFactory.create();
+      expect(() => monitor.bindVideoElement(newVideoElement)).to.not.throw();
+      expect(observeCalled).to.be.true;
+      expect(unobserveCalled).to.be.true;
+      observeCalled = false;
+      unobserveCalled = false;
       expect(() => monitor.bindVideoElement(null)).to.not.throw();
+      expect(observeCalled).to.be.false;
       expect(unobserveCalled).to.be.true;
     });
 


### PR DESCRIPTION
**Issue #:** https://github.com/aws/amazon-chime-sdk-js/issues/3042

**Description of changes:**
Fix TypeError when calling unbindVideoElement

**Testing:**
Smoke test and verified TypeError is not thrown when calling unbindVideoElement

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
No, unbindVideoElement is not used in demo application

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

