### PR TITLE
Keep the roster sorted

### DIFF
--- a/demos/browser/app/meetingV2/component/Roster.ts
+++ b/demos/browser/app/meetingV2/component/Roster.ts
@@ -92,6 +92,7 @@ export default class Roster {
         
         attendeeElement.className = 'list-group-item d-flex align-items-center gap-2';
         attendeeElement.id = Roster.ATTENDEE_ELEMENT_PREFIX + attendeeId;
+        attendeeElement.setAttribute("data-sort-key", attendeeName);
         if (allowAttendeeCapabilities) {
             attendeeElement.classList.add('ps-2');
             attendeeElement.appendChild(attendeeCheckbox);
@@ -101,6 +102,14 @@ export default class Roster {
 
         const containerElement: HTMLUListElement = this.getContainerElement();
         containerElement.appendChild(attendeeElement);
+        this.sortRoster();
+    }
+
+    private sortRoster() {
+        const containerElement: HTMLUListElement = this.getContainerElement();
+        const sortedChildren = Array.from(containerElement.children)
+            .sort((a, b) => a.getAttribute("data-sort-key")!.localeCompare(b.getAttribute("data-sort-key")!));
+        sortedChildren.forEach(child => containerElement.appendChild(child));
     }
     
     /**


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:** A slightly silly improvement. Always sort of bothersome that every ones roster is in a different order.

**Testing:**
Tested in demo app, all are in order.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
n

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

