### PR TITLE
Use default framerate when video track framerate is undefined in `DefaultVideoFrameProcessorPipeline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- Use default framerate when video track framerate is undefined in `DefaultVideoFrameProcessorPipeline`
 
 ### Fixed
-Fix TypeError when calling unbindVideoElement
+- Fix TypeError when calling unbindVideoElement
 
 ## [3.27.0] - 2024-12-11
 

--- a/src/videoframeprocessor/DefaultVideoFrameProcessorPipeline.ts
+++ b/src/videoframeprocessor/DefaultVideoFrameProcessorPipeline.ts
@@ -73,7 +73,7 @@ export default class DefaultVideoFrameProcessorPipeline implements VideoFramePro
   // A negative framerate will cause `captureStream` to throw `NotSupportedError`.
   // The setter prevents this by switching to the default framerate if less than 0.
   set framerate(value: number) {
-    this.fr = value < 0 ? DEFAULT_FRAMERATE : value;
+    this.fr = value < 0 || value === undefined ? DEFAULT_FRAMERATE : value;
   }
 
   stop(): void {

--- a/test/videoframeprocessor/DefaultVideoFrameProcessorPipeline.test.ts
+++ b/test/videoframeprocessor/DefaultVideoFrameProcessorPipeline.test.ts
@@ -318,6 +318,11 @@ describe('DefaultVideoFrameProcessorPipeline', () => {
       pipe.framerate = -5;
       expect(pipe.framerate).to.equal(15);
     });
+
+    it('setter ignores undefined frame rate', () => {
+      pipe.framerate = undefined;
+      expect(pipe.framerate).to.equal(15);
+    });
   });
 
   describe('addObserver', () => {


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Video track setting may have undefined framerate in certain conditions. Use default framerate rather than 0 in such conditions.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Start a meeting from Firefox browser
2. Change video input to blue and start video
3. Enable the Emojify filter
4. Verify video fps is below 30 fps

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

5. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

6. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

