### PR TITLE
Send Daily Test Data to Cloudwatch Metrics

### DIFF
--- a/.github/workflows/browser-compatibility-test-previous-major-version.yml
+++ b/.github/workflows/browser-compatibility-test-previous-major-version.yml
@@ -14,6 +14,8 @@ env:
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
   PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
+  METRIC_NAME: ${{ secrets.METRIC_NAME }}
+  METRIC_NAMESPACE: ${{ secrets.METRIC_NAMESPACE }}
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -309,3 +311,28 @@ jobs:
         run: npm install axios
       - name: Send Slack Message
         run: node .github/script/send-test-report.js ${{ secrets.SLACK_JS_SDK_DEV_CORE_PREV_VER_WEBHOOK }} ${{ env.WORKFLOW_URL}} ${{ env.WORKFLOW_JOBS_STATUS }}
+      - name: Send Metric to CloudWatch
+        if: always()
+        run: |
+          node -e "
+          const { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
+          const client = new CloudWatchClient({ region: process.env.REGION });
+
+          const value = '${{ env.WORKFLOW_JOBS_STATUS }}' === 'failure' ? 0 : 1;
+
+          const command = new PutMetricDataCommand({
+            Namespace: process.env.METRIC_NAMESPACE,
+            MetricData: [{
+              MetricName: process.env.METRIC_NAME,
+              Dimensions: [
+                { Name: 'Platform', Value: 'JS SDK Daily PMV Compatibility' }
+              ],
+              Value: value,
+            }]
+          });
+
+          client.send(command).then(() => console.log('Daily test result sent to CloudWatch')).catch(err => {
+            console.error('Failed to send metric. Error: ', err);
+            process.exit(1);
+          });
+          ";

--- a/.github/workflows/browser-compatibility-test.yml
+++ b/.github/workflows/browser-compatibility-test.yml
@@ -15,6 +15,8 @@ env:
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
   SLACK_JS_SDK_DEV_CORE_WEBHOOK: ${{secrets.SLACK_JS_SDK_DEV_CORE_WEBHOOK}}
   PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
+  METRIC_NAME: ${{ secrets.METRIC_NAME }}
+  METRIC_NAMESPACE: ${{ secrets.METRIC_NAMESPACE }}
 
 permissions:
   id-token: write   # This is required for requesting the JWT
@@ -282,3 +284,28 @@ jobs:
         run: npm install axios
       - name: Send Slack Message
         run: node .github/script/send-test-report.js ${{ secrets.SLACK_JS_SDK_DEV_CORE_WEBHOOK }} ${{ env.WORKFLOW_URL}} ${{ env.WORKFLOW_JOBS_STATUS }}
+      - name: Send Metric to CloudWatch
+        if: always()
+        run: |
+          node -e "
+          const { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
+          const client = new CloudWatchClient({ region: process.env.REGION });
+
+          const value = '${{ env.WORKFLOW_JOBS_STATUS }}' === 'failure' ? 0 : 1;
+
+          const command = new PutMetricDataCommand({
+            Namespace: process.env.METRIC_NAMESPACE,
+            MetricData: [{
+              MetricName: process.env.METRIC_NAME,
+              Dimensions: [
+                { Name: 'Platform', Value: 'JS SDK Daily Compatibility' }
+              ],
+              Value: value,
+            }]
+          });
+
+          client.send(command).then(() => console.log('Daily test result sent to CloudWatch')).catch(err => {
+            console.error('Failed to send metric. Error: ', err);
+            process.exit(1);
+          });
+          ";


### PR DESCRIPTION
Send metrics to cloudwatch for daily tests on the JS SDK for Backwards Compatibility test and also for the PMV version of this daily test.