### PR TITLE
clean up and return demo to start when joining from another endpoint

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -3787,6 +3787,13 @@ export class DemoMeetingApp
       onLeftMeeting();
       return;
     }
+
+    if (sessionStatus.statusCode() === MeetingSessionStatusCode.AudioJoinedFromAnotherDevice) {
+      this.log('joined from another endpoint');
+      onLeftMeeting();
+      return;
+    }
+
   }
 
   audioVideoWasDemotedFromPrimaryMeeting(status: any): void {


### PR DESCRIPTION
**Description of changes:**
Properly cleanup and return demo to start when joining from another endpoint.
**Testing:**
Smoke tested
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Join with demo

Join another attendee in another tab.

In another tab, override join info with the info in one of the other tabs.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
no

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

