### PR TITLE
Add checkbox to enable max content share in meeting demo

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -217,6 +217,10 @@
             <input type="checkbox" id="priority-downlink-policy" class="form-check-input">
             <label for="priority-downlink-policy" class="form-check-label">Enable remote video quality adaptation</label>
           </div>
+          <div class="form-check" style="text-align: left;">
+            <input type="checkbox" id="max-content-share" class="form-check-input">
+            <label for="max-content-share" class="form-check-label">Allow Max Content Shares</label>
+          </div>
           <label id="pagination-title" for="pagination-page-size" style="padding-top:5px">Paginate displayed video tiles</label>
           <select id="pagination-page-size" class="form-select" style="width:100%;">
             <option value="1">1</option>

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -366,6 +366,7 @@ export class DemoMeetingApp
 
   enableLiveTranscription = false;
   noWordSeparatorForTranscription = false;
+  enableMaxContentShare = false;
 
   markdown = require('markdown-it')({ linkify: true });
   lastMessageSender: string | null = null;
@@ -527,6 +528,11 @@ export class DemoMeetingApp
       (document.getElementById('inputMeeting') as HTMLInputElement).focus();
     }
 
+    if (new URL(window.location.href).searchParams.get('max-content-share') === 'true') {
+      this.enableMaxContentShare = true;
+    }
+    (document.getElementById('max-content-share') as HTMLInputElement).checked = this.enableMaxContentShare;
+
     if (new URL(window.location.href).searchParams.has('join-info-override')) {
       const joinInfoOverride = JSON.parse(new URL(window.location.href).searchParams.get('join-info-override'));
       (document.getElementById('create-attendee-override-input') as HTMLTextAreaElement).value = JSON.stringify(joinInfoOverride.JoinInfo.Attendee, null, 4);
@@ -675,6 +681,10 @@ export class DemoMeetingApp
 
     document.getElementById('join-view-only').addEventListener('change', () => {
       this.isViewOnly = (document.getElementById('join-view-only') as HTMLInputElement).checked;
+    });
+
+    document.getElementById('max-content-share').addEventListener('change', e => {
+      this.enableMaxContentShare = (document.getElementById('max-content-share') as HTMLInputElement).checked;
     });
 
     document.getElementById('priority-downlink-policy').addEventListener('change', e => {
@@ -4120,11 +4130,7 @@ export class DemoMeetingApp
   }
 
   allowMaxContentShare(): boolean {
-    const allowed = new URL(window.location.href).searchParams.get('max-content-share') === 'true';
-    if (allowed) {
-      return true;
-    }
-    return false;
+    return this.enableMaxContentShare;
   }
 
   connectionDidBecomePoor(): void {

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "../..": {
-      "version": "3.27.0",
+      "version": "3.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

- Add a checkbox to enable max(2) content share in meeting demo. It is already available via search parameter in URL today.

**Testing:**
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
- MeetingV2, yes verified it works e2e locally.
![image](https://github.com/user-attachments/assets/363cb44b-693b-4dbd-8ca8-f4e7fc4b6afa)


**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

