### PR TITLE
Refactor toast in demo to helper, push toast + 2 second delayed refresh on session end

### DIFF
--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1067,9 +1067,18 @@ a.markdown:active {
 }
 
 #toast-container {
-    bottom: 20px;
-    right: 20px;
-    position: absolute;
+  bottom: 20px;
+  right: 20px;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.toast-message {
+  word-wrap: break-word;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 input[type="file"] { 


### PR DESCRIPTION
**Issue #:** N/A

**Description of changes:**
This makes it easier to see the session end status without having to look at logs + adding different paths for every status. 

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
1. Leave a meeting, verify toast

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

