### PR TITLE
Add register-meeting REST API in meeting demo

### DIFF
--- a/demos/browser/server.js
+++ b/demos/browser/server.js
@@ -437,6 +437,33 @@ function serve(host = '127.0.0.1:8080') {
             AttendeeId: requestUrl.query.id,
           });
         respond(response, 200, 'application/json', JSON.stringify(getAttendeeResponse));      
+      } else if (request.method === 'POST' && requestUrl.pathname === '/register_meeting') {
+        // Parse the request body to get the meeting information
+        let body = '';
+        request.on('data', chunk => {
+          body += chunk.toString();
+        });
+        request.on('end', async () => {
+          try {
+            const meetingInfo = JSON.parse(body);
+            
+            // Extract the meeting and external meeting ID
+            const meeting = meetingInfo.Meeting;
+            const externalMeetingId = meeting.ExternalMeetingId;
+            
+            // Store the meeting in the table using the external meeting ID as the key
+            meetingTable[externalMeetingId] = meeting;
+            
+            respond(response, 200, 'application/json', JSON.stringify({ 
+              success: true, 
+              message: `Meeting registered with title: ${externalMeetingId}` 
+            }));
+          } catch (error) {
+            respond(response, 400, 'application/json', JSON.stringify({ 
+              error: `Failed to register meeting: ${error.message}` 
+            }));
+          }
+        });
       } else {
         respond(response, 404, 'text/html', '404 Not Found');
       }

--- a/demos/serverless/src/handlers.js
+++ b/demos/serverless/src/handlers.js
@@ -546,6 +546,25 @@ exports.fetch_credentials = async (event, context) => {
   return response(200, 'application/json', JSON.stringify(awsCredentials));
 };
 
+exports.register_meeting = async (event, context) => {
+  try {
+    const body = JSON.parse(event.body);
+    const meeting = body.Meeting;
+    const externalMeetingId = meeting.ExternalMeetingId;
+    await putMeeting(externalMeetingId, { Meeting: meeting });
+    
+    return response(200, 'application/json', JSON.stringify({ 
+      success: true, 
+      message: `Meeting registered with title: ${externalMeetingId}` 
+    }));
+  } catch (error) {
+    console.error('Failed to register meeting:', error);
+    return response(400, 'application/json', JSON.stringify({ 
+      error: `Failed to register meeting: ${error.message}` 
+    }));
+  }
+};
+
 exports.logs = async (event, context) => {
   return putLogEvents(event, BROWSER_LOG_GROUP_NAME, (logs, meetingId, attendeeId) => {
     const logEvents = [];

--- a/demos/serverless/template.yaml
+++ b/demos/serverless/template.yaml
@@ -106,7 +106,8 @@ Resources:
         - Ref: ChimeSdkEndLiveConnectorLambdaRole
         - Ref: ChimeSdkUpdateAttendeeCapabilitiesLambdaRole
         - Ref: ChimeSdkBatchUpdateAttendeeCapabilitiesExceptLambdaRole
-        - Ref: ChimeSdkGetAttendeeLambdaRole        
+        - Ref: ChimeSdkGetAttendeeLambdaRole
+        - Ref: ChimeSdkRegisterMeetingLambdaRole
   ChimeMessagingAccessPolicy:
     Type: AWS::IAM::Policy
     Condition: ShouldDeployFetchCredentialLambda
@@ -719,6 +720,20 @@ Resources:
           Properties:
             Path: /get_attendee
             Method: GET
+  ChimeSdkRegisterMeetingLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers.register_meeting
+      CodeUri: src/
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Meetings
+      Events:
+        Api1:
+          Type: Api
+          Properties:
+            Path: /register_meeting
+            Method: POST
 Outputs:
   ApiURL:
     Description: "API endpoint URL for Prod environment"


### PR DESCRIPTION
**Issue #:**
In today's meeting demo, when joining a meeting using "override join info", the meeting info is not being stored on the server. This prevents server-dependent functionalities from working properly, such as end meeting and create media capture pipelines (No meeting title found in table).

**Description of changes:**
In meeting demo:
- Implemented a new register-meeting REST API
- Added a call to register-meeting API when joining meetings via override join information. This resolves the issue where end meeting and media capture pipeline features were not functioning, as they depend on server-stored data.

**Testing:**

*Can these be tested using a demo application? Please provide reproducible step-by-step instructions.*

1. Verified locally that meetings are successfully added to the local server and the end meeting functionality works as expected.
2. Deployed a serverless demo to verify both the basic functionality and media capture pipeline operation.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A - Demo changes only.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A - Demo changes only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.