### PR TITLE
[Integ test] Increase timeout when waiting for creating meeting and join

### DIFF
--- a/integration/mocha-tests/configs/BaseConfig.js
+++ b/integration/mocha-tests/configs/BaseConfig.js
@@ -44,7 +44,7 @@ const config = {
       accessKey: process.env.SAUCE_ACCESS_KEY,
       noSSLBumpDomains: 'all',
       extendedDebugging: true,
-      screenResolution: '1280x960',
+      screenResolution: '1920x1440',
     },
   },
 };

--- a/integration/mocha-tests/pages/MeetingPage.js
+++ b/integration/mocha-tests/pages/MeetingPage.js
@@ -84,7 +84,7 @@ class MeetingPage {
   }
 
   async waitForUserAuthentication() {
-    await this.driver.wait(until.elementIsVisible(this.driver.findElement(elements.joinButton)), DEFAULT_TIMEOUT_MS);
+    await this.driver.wait(until.elementIsVisible(this.driver.findElement(elements.joinButton)), DEFAULT_TIMEOUT_MS*3);
   }
 
   async joinMeeting() {
@@ -94,7 +94,7 @@ class MeetingPage {
   }
 
   async waitForUserJoin() {
-    await this.driver.wait(until.elementIsVisible(this.driver.findElement(elements.meetingFlow)), DEFAULT_TIMEOUT_MS);
+    await this.driver.wait(until.elementIsVisible(this.driver.findElement(elements.meetingFlow)), DEFAULT_TIMEOUT_MS*2);
   }
 
   async clickMicrophoneButton() {


### PR DESCRIPTION
**Description of changes:**
- Increase timeout when waiting for creating meeting and join. When run with serverless demo, it may takes sometimes for the page to load and create meeting which could lead to the tests to be terminated due to timeout.
- Also increase the resolution to avoid the join button from being hidden in SauceLabs.
**Testing:**
- Run with serverless demo successfully.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

