### PR TITLE
Export model metrics + update destroy() to do better cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Degrade video codec from VP9/AV1 when there are more than 15 video senders
 - Created new public methods in voicefocus.ts to export model metrics (`getModelMetrics`). These model metrics include SNR, DRR and latencies aggregated for single session.
-- An internal property added to switch between mode of operation for custom model.
+- Using `setMode` to switch between mode of operation for custom model.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Degrade video codec from VP9/AV1 when there are more than 15 video senders
+- Created new public methods in voicefocus.ts to export model metrics (`getModelMetrics`). These model metrics include SNR, DRR and latencies aggregated for single session.
+- An internal property added to switch between mode of operation for custom model.
 
 ### Removed
 
 ### Changed
 - Use default framerate when video track framerate is undefined in `DefaultVideoFrameProcessorPipeline`
 - Use VP9 as default video codec for video and AV1 for content share. This change will provide better video compression efficiency than H.264 (the current default) and improve video quality. While the two codec may be more costly in computation, we already added monitoring for encoding and fallback when there are failures or high CPU usage.
+- Updated destroy method to disconnect the worklet nodes in addition to terminating the worker.
 
 ### Fixed
 

--- a/libs/voicefocus/decider.d.ts
+++ b/libs/voicefocus/decider.d.ts
@@ -12,7 +12,7 @@ export interface Unsupported {
     supported: false;
     reason: string;
 }
-declare type ExecutionDefinition = SupportedExecutionDefinition | Unsupported;
-export declare const measureAndDecideExecutionApproach: (spec: VoiceFocusExecutionSpec, fetchConfig: VoiceFocusFetchConfig, logger?: Logger | undefined, thresholds?: PerformanceThresholds) => Promise<ExecutionDefinition>;
+type ExecutionDefinition = SupportedExecutionDefinition | Unsupported;
+export declare const measureAndDecideExecutionApproach: (spec: VoiceFocusExecutionSpec, fetchConfig: VoiceFocusFetchConfig, logger?: Logger, thresholds?: PerformanceThresholds) => Promise<ExecutionDefinition>;
 export declare const decideModel: ({ category, name, variant, simd, url }: ModelConfig) => string;
 export {};

--- a/libs/voicefocus/decider.js
+++ b/libs/voicefocus/decider.js
@@ -60,7 +60,7 @@ class Estimator {
         this.logger = logger;
         const workerURL = `${fetchConfig.paths.workers}estimator-v1.js`;
         this.fetchBehavior = { headers: fetchConfig.headers, escapedQueryString: fetchConfig.escapedQueryString };
-        this.worker = loader_js_1.loadWorker(workerURL, 'VoiceFocusEstimator', this.fetchBehavior, logger);
+        this.worker = (0, loader_js_1.loadWorker)(workerURL, 'VoiceFocusEstimator', this.fetchBehavior, logger);
     }
     roundtrip(toSend, receive, expectedKey) {
         return new Promise((resolve, reject) => {
@@ -209,7 +209,7 @@ const decideExecutionApproach = ({ supportsSIMD, supportsSAB, duration, executio
                 return workerOption;
             }
             case 'worker': {
-                if (support_js_1.supportsSharedArrayBuffer(globalThis, window, logger)) {
+                if ((0, support_js_1.supportsSharedArrayBuffer)(globalThis, window, logger)) {
                     return reducePreference('worker-sab');
                 }
                 return reducePreference('worker-postMessage');
@@ -256,7 +256,7 @@ const decideExecutionApproach = ({ supportsSIMD, supportsSAB, duration, executio
 const featureCheck = (forceSIMD, fetchConfig, logger, estimator) => __awaiter(void 0, void 0, void 0, function* () {
     const supports = {
         supportsSIMD: forceSIMD,
-        supportsSAB: support_js_1.supportsSharedArrayBuffer(globalThis, window, logger),
+        supportsSAB: (0, support_js_1.supportsSharedArrayBuffer)(globalThis, window, logger),
         duration: -1,
     };
     if (forceSIMD) {
@@ -266,7 +266,7 @@ const featureCheck = (forceSIMD, fetchConfig, logger, estimator) => __awaiter(vo
     const cleanup = !estimator;
     const e = estimator || new Estimator(fetchConfig, logger);
     try {
-        const useSIMD = !support_js_1.isOldChrome(window, logger) && (yield e.supportsSIMD());
+        const useSIMD = !(0, support_js_1.isOldChrome)(window, logger) && (yield e.supportsSIMD());
         logger === null || logger === void 0 ? void 0 : logger.info(`Supports SIMD: ${useSIMD} (force: ${forceSIMD})`);
         supports.supportsSIMD = useSIMD;
         return supports;

--- a/libs/voicefocus/loader.d.ts
+++ b/libs/voicefocus/loader.d.ts
@@ -1,2 +1,2 @@
 import { Logger, VoiceFocusFetchBehavior } from './types.js';
-export declare const loadWorker: (workerURL: string, name: string, fetchBehavior: VoiceFocusFetchBehavior, logger?: Logger | undefined) => Promise<Worker>;
+export declare const loadWorker: (workerURL: string, name: string, fetchBehavior: VoiceFocusFetchBehavior, logger?: Logger) => Promise<Worker>;

--- a/libs/voicefocus/loader.js
+++ b/libs/voicefocus/loader.js
@@ -22,10 +22,10 @@ const loadWorker = (workerURL, name, fetchBehavior, logger) => {
         logger === null || logger === void 0 ? void 0 : logger.error('Could not compare origins.', e);
     }
     if (workerURLIsSameOrigin) {
-        const workerURLWithQuery = fetch_js_1.withQueryString(workerURL, fetchBehavior);
+        const workerURLWithQuery = (0, fetch_js_1.withQueryString)(workerURL, fetchBehavior);
         return Promise.resolve(new Worker(workerURLWithQuery, { name }));
     }
-    return fetch_js_1.fetchWithBehavior(workerURL, WORKER_FETCH_OPTIONS, fetchBehavior).then((res) => {
+    return (0, fetch_js_1.fetchWithBehavior)(workerURL, WORKER_FETCH_OPTIONS, fetchBehavior).then((res) => {
         if (res.ok) {
             return res.blob()
                 .then((blob) => new Worker(window.URL.createObjectURL(blob)));

--- a/libs/voicefocus/support.d.ts
+++ b/libs/voicefocus/support.d.ts
@@ -9,26 +9,26 @@ export declare const isSafari: (global?: LimitedWindow) => boolean;
 export declare const supportsWASMPostMessage: (global?: LimitedWindow) => boolean;
 export declare const supportsVoiceFocusWorker: (scope: {
     Worker?: {
-        new (stringUrl: string | URL, options?: WorkerOptions | undefined): Worker;
+        new (scriptURL: string | URL, options?: WorkerOptions | undefined): Worker;
         prototype: Worker;
     } | undefined;
-} | undefined, fetchConfig: VoiceFocusFetchConfig, logger?: Logger | undefined) => Promise<boolean>;
+} | undefined, fetchConfig: VoiceFocusFetchConfig, logger?: Logger) => Promise<boolean>;
 export declare const supportsWorker: (scope?: {
     Worker?: typeof Worker;
-}, logger?: Logger | undefined) => boolean;
+}, logger?: Logger) => boolean;
 export declare const supportsAudioWorklet: (scope?: {
     AudioWorklet?: typeof AudioWorklet;
     AudioWorkletNode?: typeof AudioWorkletNode;
-}, logger?: Logger | undefined) => boolean;
+}, logger?: Logger) => boolean;
 export declare const supportsWASM: (scope?: {
     WebAssembly?: typeof WebAssembly;
-}, logger?: Logger | undefined) => boolean;
+}, logger?: Logger) => boolean;
 export declare const supportsSharedArrayBuffer: (scope?: {
     crossOriginIsolated?: boolean;
     SharedArrayBuffer?: typeof SharedArrayBuffer;
-}, window?: LimitedWindow, logger?: Logger | undefined) => boolean;
+}, window?: LimitedWindow, logger?: Logger) => boolean;
 export declare const supportsWASMStreaming: (scope?: {
     WebAssembly?: typeof WebAssembly;
-}, logger?: Logger | undefined) => boolean;
-export declare const isOldChrome: (global?: LimitedWindow, logger?: Logger | undefined) => boolean;
+}, logger?: Logger) => boolean;
+export declare const isOldChrome: (global?: LimitedWindow, logger?: Logger) => boolean;
 export {};

--- a/libs/voicefocus/support.js
+++ b/libs/voicefocus/support.js
@@ -26,7 +26,7 @@ const isSafari = (global = globalThis) => {
 };
 exports.isSafari = isSafari;
 const supportsWASMPostMessage = (global = globalThis) => {
-    if (exports.isSafari(global)) {
+    if ((0, exports.isSafari)(global)) {
         return false;
     }
     if (isChrome(global)) {
@@ -37,12 +37,12 @@ const supportsWASMPostMessage = (global = globalThis) => {
 };
 exports.supportsWASMPostMessage = supportsWASMPostMessage;
 const supportsVoiceFocusWorker = (scope = globalThis, fetchConfig, logger) => __awaiter(void 0, void 0, void 0, function* () {
-    if (!exports.supportsWorker(scope, logger)) {
+    if (!(0, exports.supportsWorker)(scope, logger)) {
         return false;
     }
     const workerURL = `${fetchConfig.paths.workers}worker-v1.js`;
     try {
-        const worker = yield loader_js_1.loadWorker(workerURL, 'VoiceFocusTestWorker', fetchConfig, logger);
+        const worker = yield (0, loader_js_1.loadWorker)(workerURL, 'VoiceFocusTestWorker', fetchConfig, logger);
         try {
             worker.terminate();
         }

--- a/libs/voicefocus/types.d.ts
+++ b/libs/voicefocus/types.d.ts
@@ -4,20 +4,21 @@ export interface Logger {
     warn: (...args: any[]) => void;
     error: (...args: any[]) => void;
 }
-export declare type ModelCategory = 'voicefocus';
-export declare type ModelName = 'default' | 'ns_es';
-export declare type ModelVariant = 'c100' | 'c50' | 'c20' | 'c10';
-export declare type SIMDPreference = 'force' | 'disable' | 'detect';
-export declare type ExecutionApproach = 'inline' | 'worker-sab' | 'worker-postMessage';
-export declare type ExecutionPreference = ExecutionApproach | 'worker' | 'auto';
-export declare type UsagePreference = 'quality' | 'interactivity';
-export declare type VariantPreference = ModelVariant | 'auto';
-export declare type ExecutionQuanta = 1 | 2 | 3;
+export type ModelCategory = 'voicefocus';
+export type ModelName = 'default' | 'ns_es';
+export type ModelVariant = 'c100' | 'c50' | 'c20' | 'c10';
+export type SIMDPreference = 'force' | 'disable' | 'detect';
+export type ExecutionApproach = 'inline' | 'worker-sab' | 'worker-postMessage';
+export type ExecutionPreference = ExecutionApproach | 'worker' | 'auto';
+export type UsagePreference = 'quality' | 'interactivity';
+export type VariantPreference = ModelVariant | 'auto';
+export type ExecutionQuanta = 1 | 2 | 3;
 export interface ModelConfig {
     category: ModelCategory;
     name: ModelName;
     variant: ModelVariant;
     simd: boolean;
+    mode?: string;
     url?: string;
 }
 export interface VoiceFocusExecutionSpec {
@@ -55,7 +56,7 @@ export interface VoiceFocusConfigureOptions {
 export interface VoiceFocusDelegate {
     onCPUWarning(): void;
 }
-export declare type VoiceFocusProcessor = 'voicefocus-worker-sab-processor' | 'voicefocus-worker-postMessage-processor' | 'voicefocus-inline-processor';
+export type VoiceFocusProcessor = 'voicefocus-worker-sab-processor' | 'voicefocus-worker-postMessage-processor' | 'voicefocus-inline-processor';
 export interface VoiceFocusNodeOptions extends AudioWorkletNodeOptions {
     worker: Worker;
     processor: VoiceFocusProcessor;
@@ -65,6 +66,7 @@ export interface VoiceFocusNodeOptions extends AudioWorkletNodeOptions {
     fetchBehavior?: VoiceFocusFetchBehavior;
     delegate?: VoiceFocusDelegate;
     logger?: Logger;
+    mode?: string;
 }
 declare const VoiceFocusAudioWorkletNode_base: {
     new (context: BaseAudioContext, name: string, options?: AudioWorkletNodeOptions | undefined): AudioWorkletNode;
@@ -73,7 +75,9 @@ declare const VoiceFocusAudioWorkletNode_base: {
 export declare abstract class VoiceFocusAudioWorkletNode extends VoiceFocusAudioWorkletNode_base {
     abstract enable(): Promise<void>;
     abstract disable(): Promise<void>;
+    abstract setMode(mode: string): Promise<void>;
     abstract stop(): Promise<void>;
+    abstract getModelMetrics(): ModelMetrics | undefined;
 }
 export interface EnabledAGCOptions {
     useVoiceFocusAGC: true;
@@ -84,7 +88,7 @@ export interface DisabledAGCOptions {
     useVoiceFocusAGC: false;
     useBuiltInAGC?: boolean;
 }
-export declare type AGCOptions = EnabledAGCOptions | DisabledAGCOptions;
+export type AGCOptions = EnabledAGCOptions | DisabledAGCOptions;
 export interface ProcessorOptions {
     voiceFocusSampleRate: number;
     enabled: boolean;
@@ -93,10 +97,36 @@ export interface ProcessorOptions {
     agc: AGCOptions;
     executionQuanta?: ExecutionQuanta;
     supportFarendStream?: boolean;
+    mode?: string;
 }
 export interface ProcessorMessageData {
-    message: 'data' | 'cpu' | 'prepare-for-frames';
+    message: 'data' | 'cpu' | 'prepare-for-frames' | 'metrics';
     buffer?: ArrayBuffer;
+    metrics?: ModelMetrics;
+    reason?: 'lateInvoke' | 'longInvoke';
+    count?: number;
+}
+export interface ModelMetrics {
+    latencyMillisAverage: number;
+    snr: {
+        average: number;
+        variance: number;
+        averageActive: number;
+        varianceActive: number;
+    };
+    drr: {
+        average: number;
+        variance: number;
+        averageActive: number;
+        varianceActive: number;
+    };
+    vad: {
+        average: number;
+    };
+    cpu: {
+        lateInvoke: number;
+        longInvoke: number;
+    };
 }
 export interface ProcessorMessage {
     data: ProcessorMessageData;

--- a/libs/voicefocus/voicefocus.d.ts
+++ b/libs/voicefocus/voicefocus.d.ts
@@ -4,7 +4,7 @@ export interface AssetSpec {
     assetGroup?: string;
     revisionID?: string;
 }
-export declare type AssetConfig = {
+export type AssetConfig = {
     assetGroup: string;
 } | {
     revisionID: string;
@@ -19,6 +19,7 @@ export interface VoiceFocusSpec extends AssetSpec {
     usagePreference?: UsagePreference;
     estimatorBudget?: number;
     paths?: VoiceFocusPaths;
+    mode?: string;
     thresholds?: PerformanceThresholds;
 }
 interface SupportedVoiceFocusConfig {
@@ -28,7 +29,7 @@ interface SupportedVoiceFocusConfig {
     executionQuanta?: ExecutionQuanta;
     fetchConfig: VoiceFocusFetchConfig;
 }
-export declare type VoiceFocusConfig = SupportedVoiceFocusConfig | Unsupported;
+export type VoiceFocusConfig = SupportedVoiceFocusConfig | Unsupported;
 export interface NodeArguments {
     voiceFocusSampleRate?: number;
     enabled?: boolean;
@@ -47,8 +48,14 @@ export declare class VoiceFocus {
     private nodeConstructor;
     private nodeOptions;
     private executionQuanta;
+    private logger?;
     private internal;
     private constructor();
+    getModelMetrics(): import("./types.js").ModelMetrics | undefined;
+    enable(): void;
+    disable(): void;
+    setMode(mode: string): void;
+    destroy(): Promise<void>;
     static isSupported(spec?: AssetSpec & {
         paths?: VoiceFocusPaths;
     }, options?: VoiceFocusConfigureOptions): Promise<boolean>;
@@ -67,7 +74,6 @@ export declare class VoiceFocus {
         stream: MediaStream;
     }>;
     applyToSourceNode(source: MediaStreamAudioSourceNode, context: AudioContext, options?: NodeArguments): Promise<VoiceFocusAudioWorkletNode>;
-    destroy(): void;
 }
 export declare const createAudioContext: (contextHint?: {
     latencyHint: number;

--- a/libs/voicefocus/worklet-inline-node.d.ts
+++ b/libs/voicefocus/worklet-inline-node.d.ts
@@ -1,17 +1,21 @@
-import { ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
+import { ModelMetrics, ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
 declare class VoiceFocusInlineNode extends VoiceFocusAudioWorkletNode {
     private delegate?;
     private worker;
     private logger;
     private cpuWarningLastTriggered;
     private cpuWarningCount;
+    private metricsLastRecorded;
+    private metrics;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     onModuleBufferLoaded(buffer: ArrayBuffer, key: string): void;
     onModuleLoaded(module: WebAssembly.Module, key: string): void;
     enable(): Promise<void>;
     disable(): Promise<void>;
+    setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
     onProcessorMessage(event: ProcessorMessage): void;
+    getModelMetrics(): ModelMetrics | undefined;
     onWorkerMessage(event: WorkerMessage): void;
 }
 export default VoiceFocusInlineNode;

--- a/libs/voicefocus/worklet-worker-postMessage-node.d.ts
+++ b/libs/voicefocus/worklet-worker-postMessage-node.d.ts
@@ -1,11 +1,13 @@
-import { ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
+import { ModelMetrics, ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
 declare class VoiceFocusWorkerPostMessageNode extends VoiceFocusAudioWorkletNode {
     private worker;
     private delegate?;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     enable(): Promise<void>;
     disable(): Promise<void>;
+    setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
+    getModelMetrics(): ModelMetrics | undefined;
     onWorkerMessage(event: WorkerMessage): void;
     onProcessorMessage(event: ProcessorMessage): void;
 }

--- a/libs/voicefocus/worklet-worker-postMessage-node.js
+++ b/libs/voicefocus/worklet-worker-postMessage-node.js
@@ -35,7 +35,7 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             model: modelURL,
             supportFarendStream,
         });
-        const message = support_js_1.supportsWASMPostMessage(globalThis) ? 'get-module' : 'get-module-buffer';
+        const message = (0, support_js_1.supportsWASMPostMessage)(globalThis) ? 'get-module' : 'get-module-buffer';
         this.worker.postMessage({
             message,
             key: 'buffer',
@@ -53,6 +53,11 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             this.worker.postMessage({ message: 'disable' });
         });
     }
+    setMode(mode) {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.port.postMessage({ message: 'set-mode', mode });
+        });
+    }
     stop() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
@@ -62,6 +67,9 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             }
             this.disconnect();
         });
+    }
+    getModelMetrics() {
+        return undefined;
     }
     onWorkerMessage(event) {
         var _a;

--- a/libs/voicefocus/worklet-worker-sab-node.d.ts
+++ b/libs/voicefocus/worklet-worker-sab-node.d.ts
@@ -1,4 +1,4 @@
-import { ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
+import { ModelMetrics, ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusNodeOptions, WorkerMessage } from './types.js';
 declare class VoiceFocusWorkerBufferNode extends VoiceFocusAudioWorkletNode {
     private worker;
     private delegate?;
@@ -6,7 +6,9 @@ declare class VoiceFocusWorkerBufferNode extends VoiceFocusAudioWorkletNode {
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     enable(): Promise<void>;
     disable(): Promise<void>;
+    setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
+    getModelMetrics(): ModelMetrics | undefined;
     onWorkerMessage(event: WorkerMessage): void;
     onProcessorMessage(event: ProcessorMessage): void;
 }

--- a/libs/voicefocus/worklet-worker-sab-node.js
+++ b/libs/voicefocus/worklet-worker-sab-node.js
@@ -42,7 +42,7 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             model: modelURL,
             supportFarendStream,
         });
-        const message = support_js_1.supportsWASMPostMessage(globalThis) ? 'get-module' : 'get-module-buffer';
+        const message = (0, support_js_1.supportsWASMPostMessage)(globalThis) ? 'get-module' : 'get-module-buffer';
         this.worker.postMessage({
             message,
             key: 'resampler',
@@ -72,6 +72,11 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             }
         });
     }
+    setMode(mode) {
+        return __awaiter(this, void 0, void 0, function* () {
+            this.port.postMessage({ message: 'set-mode', mode });
+        });
+    }
     stop() {
         return __awaiter(this, void 0, void 0, function* () {
             if (this.state) {
@@ -87,6 +92,9 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             }
             this.disconnect();
         });
+    }
+    getModelMetrics() {
+        return undefined;
     }
     onWorkerMessage(event) {
         var _a;

--- a/test/voicefocus/VoiceFocusDeviceTransformer.test.ts
+++ b/test/voicefocus/VoiceFocusDeviceTransformer.test.ts
@@ -181,7 +181,7 @@ describe('VoiceFocusDeviceTransformer', () => {
             category: 'voicefocus',
             name: 'default',
             variant: 'c20',
-            simd: false,
+            simd: false
           },
           processor: 'voicefocus-inline-processor',
           executionQuanta: 3,
@@ -202,7 +202,7 @@ describe('VoiceFocusDeviceTransformer', () => {
             category: 'voicefocus',
             name: 'ns_es',
             variant: 'c20',
-            simd: false,
+            simd: false
           },
           processor: 'voicefocus-inline-processor',
           executionQuanta: 3,
@@ -707,7 +707,7 @@ describe('VoiceFocusDeviceTransformer', () => {
         processor: undefined,
         audioBufferURL: '',
         resamplerURL: '',
-        modelURL: '',
+        modelURL: ''
       };
 
       init.callsFake(async () => vfEs);


### PR DESCRIPTION
**Issue #:**  N/A

**Description of changes:**
- Created new public methods in voicefocus.ts to export model metrics (`getModelMetrics`). These model metrics include SNR, DRR and latencies aggregated for single session.
- An internal property is added to switch between mode of operation for custom model.
- Updated destroy method to cleanup the worklet nodes in addition to terminating the worker.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

yes, we've updated the webpages in `/examples` to test the model mode selection and model metrics emission.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? Yes


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? No


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

