### PR TITLE
[Meeting demo] Enable WebAudio only when VF is supported and desired

### DIFF
--- a/demos/browser/app/meetingV2/meetingV2.html
+++ b/demos/browser/app/meetingV2/meetingV2.html
@@ -141,8 +141,8 @@
             <label for="join-muted-setting" class="form-check-label">Join Muted</label>
           </div>
         <div class="form-check" style="text-align: left;">
-            <input type="checkbox" id="webaudio" class="form-check-input">
-            <label for="webaudio" class="form-check-label">Use WebAudio</label>
+            <input type="checkbox" id="allow-voice-focus" class="form-check-input">
+            <label for="allow-voice-focus" class="form-check-label">Allow Voice Focus</label>
           </div>
           <div class="form-check" id='echo-reduction-checkbox' style="text-align: left; display: none;">
             <input type="checkbox" id="echo-reduction-capability" class="form-check-input">
@@ -445,6 +445,9 @@
         <div id="voice-focus-setting" class="col-12 hidden">
           <input autocomplete="off" type="checkbox" id="add-voice-focus"></input>
           <label style="margin-left: 0.5em" for="voice-focus-setting block">Add Voice Focus</label>
+          <div id="add-voice-focus-info" class="text-muted small" style="margin-left: 1.5em; display: none;">
+            Voice Focus is not supported on this device
+          </div>
         </div>
       </div>
       <div class="row mt-3">

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -338,6 +338,7 @@ export class DemoMeetingApp
   appliedVideoMaxResolution = VideoQualitySettings.VideoResolutionHD;
   appliedContentMaxResolution = VideoQualitySettings.VideoResolutionFHD;
   maxBitrateKbps: number = 1400; // Default to 540p
+  enableWebAudio = false;
   logLevel = LogLevel.INFO;
   videoCodecPreferences: VideoCodecCapability[] | undefined = undefined;
   contentCodecPreferences: VideoCodecCapability[] | undefined = undefined;
@@ -528,6 +529,11 @@ export class DemoMeetingApp
     if (new URL(window.location.href).searchParams.get('max-content-share') === 'true') {
       this.enableMaxContentShare = true;
     }
+
+    if (new URL(window.location.href).searchParams.get('web-audio') === 'true') {
+      this.enableWebAudio = true;
+    }
+
     (document.getElementById('max-content-share') as HTMLInputElement).checked = this.enableMaxContentShare;
 
     if (new URL(window.location.href).searchParams.has('join-info-override')) {
@@ -1861,8 +1867,9 @@ export class DemoMeetingApp
       this.meetingEventPOSTLogger = getPOSTLogger(configuration, 'SDKEvent', `${DemoMeetingApp.BASE_URL}log_meeting_event`, this.logLevel);
     }
     this.eventReporter = await this.setupEventReporter(configuration);
+
     this.deviceController = new DefaultDeviceController(this.meetingLogger, {
-      enableWebAudio: this.allowVoiceFocus && this.supportsVoiceFocus,
+      enableWebAudio: this.enableWebAudio || (this.allowVoiceFocus && this.supportsVoiceFocus),
     });
     const urlParameters = new URL(window.location.href).searchParams;
     const timeoutMs = Number(urlParameters.get('attendee-presence-timeout-ms'));

--- a/demos/browser/app/meetingV2/styleV2.scss
+++ b/demos/browser/app/meetingV2/styleV2.scss
@@ -1090,3 +1090,20 @@ input[type="file"] {
 input[type="file"]:focus + label {
   outline: 2px solid;
 }
+
+
+.add-voice-focus-not-supported {
+  cursor: not-allowed !important;
+
+  label {
+    color: $gray-600
+  }
+  
+  input, label {
+    cursor: not-allowed !important;
+  }
+
+  #add-voice-focus-info {
+    display: block !important;
+  }
+}

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "../..": {
-      "version": "3.28.0",
+      "version": "3.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/demos/browser/webpack.config.hot.js
+++ b/demos/browser/webpack.config.hot.js
@@ -104,10 +104,16 @@ module.exports = env => {
         {
           test: /\.tsx?$/,
           loader: 'ts-loader',
+          options: {
+            compilerOptions: {
+              sourceMap: true,
+            },
+          },
         },
       ],
     },
     mode: 'development',
+    devtool: 'eval-source-map',
     performance: {
       hints: false,
     },


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Replace WebAudio checkbox with Voice Focus permission in meeting demo:

- Rename "Use WebAudio" checkbox to "Allow Voice Focus" 
- Add source map for development webpack config
- Update logic to use allowVoiceFocus flag instead of enableWebAudio
- Add info message when Voice Focus is not supported on device
- Improve Voice Focus initialization and UI setup flow
  - initVoiceFocus before initializeMeetingSession so we can know if VF is supported before creating DeviceController.
- [Enable WebAudio only when VF is allowed and supported in meeting demo](https://github.com/aws/amazon-chime-sdk-js/pull/3094/commits/1df9388acba411e37e4688b56934699bf4e09f6e)

UX update:
<img width="994" height="1061" alt="image" src="https://github.com/user-attachments/assets/d3fe3bd8-a8fd-4df5-a588-5912f1550d5f" />

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Yes, meeting demo. Refer to screen shot.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?

Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

