### PR TITLE
Version bump for amazon-chime-sdk-js@3.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.0] - 2025-09-18
+
+### Added
+
+### Removed
+
+### Changed
+
+### Fixed
+
 ## [3.29.0] - 2025-06-24
 
 ### Added

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -93,8 +93,8 @@
         "typescript": "^4.2.3"
       },
       "engines": {
-        "node": "^18 || ^19 || ^20 || ^22",
-        "npm": "^8 || ^9 || ^10"
+        "node": ">=18",
+        "npm": ">=8"
       }
     },
     "../../node_modules/@aws-crypto/sha256-browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amazon-chime-sdk-js",
-      "version": "3.29.0",
+      "version": "3.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-chime-sdk-js",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "description": "Amazon Chime SDK for JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -12,7 +12,7 @@
   ],
   "engines": {
     "node": ">=18",
-    "npm": ">=8" 
+    "npm": ">=8"
   },
   "scripts": {
     "clean": "rimraf .nyc_output build node_modules",


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

Will be releasing 3.29.0 - so pre-emptively bumping to 3.30.0.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

