### PR TITLE
Update publish to use NPM OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,8 @@ on:
     types: [published]
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
+  id-token: write  # Required for OIDC
+  contents: read
 
 jobs:
   publish:
@@ -16,10 +17,13 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Setup Node environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
       - name: NPM Install
         run: npm install
       - name: NPM run build
@@ -32,8 +36,6 @@ jobs:
           echo "npm_tag=$npm_publish_tag" >> $GITHUB_OUTPUT
       - name: Publish to NPM with tag
         run: npm publish --tag ${{ steps.npm_tag.outputs.npm_tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
   deploy_chime_prod_demo:
     needs: publish
     name: Deploy Meeting Demos with the latest NPM release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add RetryCount attributes to AttendeePresenceReceived to know how many times it takes to connect so we can differentiate whether the duration is caused by reconnection.
 ### Fixed
 
 ## [3.28.0] - 2025-02-13


### PR DESCRIPTION
**Description of changes:**
Following https://docs.npmjs.com/trusted-publishers to switch to use GitHub OIDC instead of using NPM token

**Testing:**
N/A. Will test in the next release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

