### PR TITLE
Optimizing applyToStream to resuse existing voice focus node in WebAudio graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.1] - 2025-11-19
+
+### Added
+
+### Removed
+
+### Changed
+
+- This fix addresses the memory footprint problem in Chrome by re-using existing AudioWorklet node and re-attaching to new media stream source and destination in web audio graph.
+- It also has minor changes to reset model metrics when clients invoke `reset` call.
+
 ## [3.30.0] - 2025-09-18
 
 ### Added

--- a/libs/voicefocus/types.d.ts
+++ b/libs/voicefocus/types.d.ts
@@ -78,6 +78,8 @@ export declare abstract class VoiceFocusAudioWorkletNode extends VoiceFocusAudio
     abstract setMode(mode: string): Promise<void>;
     abstract stop(): Promise<void>;
     abstract getModelMetrics(): ModelMetrics | undefined;
+    abstract reset(): void;
+    abstract isEnabled(): boolean;
 }
 export interface EnabledAGCOptions {
     useVoiceFocusAGC: true;

--- a/libs/voicefocus/voicefocus.d.ts
+++ b/libs/voicefocus/voicefocus.d.ts
@@ -52,6 +52,7 @@ export declare class VoiceFocus {
     private internal;
     private constructor();
     getModelMetrics(): import("./types.js").ModelMetrics | undefined;
+    reset(): void;
     enable(): void;
     disable(): void;
     setMode(mode: string): void;
@@ -67,7 +68,7 @@ export declare class VoiceFocus {
         logger?: Logger;
     }): Promise<VoiceFocus>;
     createNode(context: AudioContext, options?: NodeArguments): Promise<VoiceFocusAudioWorkletNode>;
-    applyToStream(stream: MediaStream, context: AudioContext, options?: NodeArguments): Promise<{
+    applyToStream(stream: MediaStream, context: AudioContext, options?: NodeArguments, useExistingNode?: boolean): Promise<{
         node: VoiceFocusAudioWorkletNode;
         source: MediaStreamAudioSourceNode;
         destination: MediaStreamAudioDestinationNode;

--- a/libs/voicefocus/worklet-inline-node.d.ts
+++ b/libs/voicefocus/worklet-inline-node.d.ts
@@ -7,6 +7,7 @@ declare class VoiceFocusInlineNode extends VoiceFocusAudioWorkletNode {
     private cpuWarningCount;
     private metricsLastRecorded;
     private metrics;
+    private enabled;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     onModuleBufferLoaded(buffer: ArrayBuffer, key: string): void;
     onModuleLoaded(module: WebAssembly.Module, key: string): void;
@@ -14,6 +15,8 @@ declare class VoiceFocusInlineNode extends VoiceFocusAudioWorkletNode {
     disable(): Promise<void>;
     setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
+    reset(): void;
+    isEnabled(): boolean;
     onProcessorMessage(event: ProcessorMessage): void;
     getModelMetrics(): ModelMetrics | undefined;
     onWorkerMessage(event: WorkerMessage): void;

--- a/libs/voicefocus/worklet-inline-node.js
+++ b/libs/voicefocus/worklet-inline-node.js
@@ -42,6 +42,7 @@ class VoiceFocusInlineNode extends types_js_1.VoiceFocusAudioWorkletNode {
                 longInvoke: 0,
             },
         };
+        this.enabled = false;
         this.channelCountMode = 'explicit';
         this.channelCount = 1;
         const { modelURL, worker, fetchBehavior, logger, delegate, } = options;
@@ -59,6 +60,7 @@ class VoiceFocusInlineNode extends types_js_1.VoiceFocusAudioWorkletNode {
             fetchBehavior,
             path: modelURL,
         });
+        this.enabled = true;
     }
     onModuleBufferLoaded(buffer, key) {
         this.port.postMessage({ message: 'module-buffer', buffer, key });
@@ -69,11 +71,13 @@ class VoiceFocusInlineNode extends types_js_1.VoiceFocusAudioWorkletNode {
     enable() {
         return __awaiter(this, void 0, void 0, function* () {
             this.port.postMessage({ message: 'enable' });
+            this.enabled = true;
         });
     }
     disable() {
         return __awaiter(this, void 0, void 0, function* () {
             this.port.postMessage({ message: 'disable' });
+            this.enabled = false;
         });
     }
     setMode(mode) {
@@ -92,7 +96,36 @@ class VoiceFocusInlineNode extends types_js_1.VoiceFocusAudioWorkletNode {
                 console.error("failed to terminate worker:", e);
             }
             this.disconnect();
+            this.enabled = false;
         });
+    }
+    reset() {
+        this.metrics = {
+            latencyMillisAverage: 0,
+            snr: {
+                average: 0,
+                averageActive: 0,
+                variance: 0,
+                varianceActive: 0,
+            },
+            drr: {
+                average: 0,
+                variance: 0,
+                averageActive: 0,
+                varianceActive: 0,
+            },
+            vad: {
+                average: 0,
+            },
+            cpu: {
+                lateInvoke: 0,
+                longInvoke: 0,
+            },
+        };
+        this.port.postMessage({ message: 'reset' });
+    }
+    isEnabled() {
+        return this.enabled;
     }
     onProcessorMessage(event) {
         var _a, _b, _c, _d, _e, _f;

--- a/libs/voicefocus/worklet-worker-postMessage-node.d.ts
+++ b/libs/voicefocus/worklet-worker-postMessage-node.d.ts
@@ -2,12 +2,15 @@ import { ModelMetrics, ProcessorMessage, VoiceFocusAudioWorkletNode, VoiceFocusN
 declare class VoiceFocusWorkerPostMessageNode extends VoiceFocusAudioWorkletNode {
     private worker;
     private delegate?;
+    private enabled;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     enable(): Promise<void>;
     disable(): Promise<void>;
     setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
     getModelMetrics(): ModelMetrics | undefined;
+    reset(): void;
+    isEnabled(): boolean;
     onWorkerMessage(event: WorkerMessage): void;
     onProcessorMessage(event: ProcessorMessage): void;
 }

--- a/libs/voicefocus/worklet-worker-postMessage-node.js
+++ b/libs/voicefocus/worklet-worker-postMessage-node.js
@@ -17,6 +17,7 @@ const types_js_1 = require("./types.js");
 class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletNode {
     constructor(context, options) {
         super(context, options.processor, options);
+        this.enabled = false;
         this.channelCountMode = 'explicit';
         this.channelCount = 1;
         const { modelURL, audioBufferURL, worker, fetchBehavior, delegate, } = options;
@@ -42,15 +43,18 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             fetchBehavior,
             path: audioBufferURL,
         });
+        this.enabled = true;
     }
     enable() {
         return __awaiter(this, void 0, void 0, function* () {
             this.worker.postMessage({ message: 'enable' });
+            this.enabled = true;
         });
     }
     disable() {
         return __awaiter(this, void 0, void 0, function* () {
             this.worker.postMessage({ message: 'disable' });
+            this.enabled = false;
         });
     }
     setMode(mode) {
@@ -66,10 +70,16 @@ class VoiceFocusWorkerPostMessageNode extends types_js_1.VoiceFocusAudioWorkletN
             catch (e) {
             }
             this.disconnect();
+            this.enabled = false;
         });
     }
     getModelMetrics() {
         return undefined;
+    }
+    reset() {
+    }
+    isEnabled() {
+        return this.enabled;
     }
     onWorkerMessage(event) {
         var _a;

--- a/libs/voicefocus/worklet-worker-sab-node.d.ts
+++ b/libs/voicefocus/worklet-worker-sab-node.d.ts
@@ -3,12 +3,15 @@ declare class VoiceFocusWorkerBufferNode extends VoiceFocusAudioWorkletNode {
     private worker;
     private delegate?;
     private state;
+    private enabled;
     constructor(context: AudioContext, options: VoiceFocusNodeOptions);
     enable(): Promise<void>;
     disable(): Promise<void>;
     setMode(mode: string): Promise<void>;
     stop(): Promise<void>;
     getModelMetrics(): ModelMetrics | undefined;
+    reset(): void;
+    isEnabled(): boolean;
     onWorkerMessage(event: WorkerMessage): void;
     onProcessorMessage(event: ProcessorMessage): void;
 }

--- a/libs/voicefocus/worklet-worker-sab-node.js
+++ b/libs/voicefocus/worklet-worker-sab-node.js
@@ -26,6 +26,7 @@ const STATES = {
 class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
     constructor(context, options) {
         super(context, options.processor, options);
+        this.enabled = false;
         this.channelCountMode = 'explicit';
         this.channelCount = 1;
         const { modelURL, resamplerURL, worker, fetchBehavior, delegate, } = options;
@@ -49,6 +50,7 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             fetchBehavior,
             path: resamplerURL,
         });
+        this.enabled = true;
     }
     enable() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -59,6 +61,7 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             else {
                 this.worker.postMessage({ message: 'enable' });
             }
+            this.enabled = true;
         });
     }
     disable() {
@@ -70,6 +73,7 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
             else {
                 this.worker.postMessage({ message: 'disable' });
             }
+            this.enabled = false;
         });
     }
     setMode(mode) {
@@ -91,10 +95,16 @@ class VoiceFocusWorkerBufferNode extends types_js_1.VoiceFocusAudioWorkletNode {
                 }
             }
             this.disconnect();
+            this.enabled = false;
         });
     }
     getModelMetrics() {
         return undefined;
+    }
+    reset() {
+    }
+    isEnabled() {
+        return this.enabled;
     }
     onWorkerMessage(event) {
         var _a;


### PR DESCRIPTION


**Issue #:**
In the current voicefocus code, we always create new web audio AudioWorklet node to enhance the audio. In case of Connect, this is creating a new node (and thus artifacts along with it) for every call. Even after calling `destroy` method, these artifacts are still there in browser (web worker and wasm files) due to a Chrome bug [https://issues.chromium.org/issues/41435286], these resources are never cleaned up from browser and increasing the browser memory foot print. 

**Description of changes:**

- This fix addresses the memory footprint problem by reusing existing AudioWorklet node and re-attaching to new media stream source and destination in web audio graph.
- It also has minor changes to reset model metrics when clients invoke `reset` call.

**Testing:**
- The changes are tested internally by changing code in local `node_modules`. 

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Yes, the voice focus behaviour must be unchanged for first and any subsequent calls.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
yes

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

