### PR TITLE
Fix race condition in playTone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix occasional issue with setting encoded transform on video receive streams that would lead to missing video.
+- Fix a race condition in DefaultMeetingReadinessChecker `playTone` and `stopTone` method.
 
 ## [3.29.0] - 2025-06-24
 

--- a/demos/browser/package-lock.json
+++ b/demos/browser/package-lock.json
@@ -384,6 +384,7 @@
       "version": "3.631.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
       "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -562,6 +563,7 @@
       "version": "3.631.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
       "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2417,6 +2419,7 @@
       "version": "12.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -2508,6 +2511,7 @@
       "version": "4.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.18.0",
         "@typescript-eslint/types": "4.18.0",
@@ -2609,6 +2613,7 @@
       "version": "7.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2847,6 +2852,7 @@
       "version": "4.3.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -3220,6 +3226,7 @@
       "version": "7.22.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.0",
@@ -4847,6 +4854,7 @@
       "version": "2.6.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5308,6 +5316,7 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -5350,6 +5359,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
       "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6161,6 +6171,7 @@
       "version": "0.21.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.7",
         "handlebars": "^4.7.7",
@@ -6202,6 +6213,7 @@
       "version": "4.2.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6859,6 +6871,7 @@
       "version": "3.631.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
       "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -6911,6 +6924,7 @@
       "version": "3.631.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
       "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -7407,6 +7421,7 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.7",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -7954,7 +7969,6 @@
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.22.0.tgz",
       "integrity": "sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==",
-      "peer": true,
       "dependencies": {
         "@types/seedrandom": "^2.4.28",
         "seedrandom": "^3.0.5"
@@ -8014,8 +8028,7 @@
     "node_modules/@tensorflow/tfjs-core/node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "peer": true
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -8132,8 +8145,7 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "peer": true
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -8148,8 +8160,7 @@
     "node_modules/@types/offscreencanvas": {
       "version": "2019.3.0",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.3.0.tgz",
-      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==",
-      "peer": true
+      "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -8174,8 +8185,7 @@
     "node_modules/@types/seedrandom": {
       "version": "2.4.34",
       "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.34.tgz",
-      "integrity": "sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==",
-      "peer": true
+      "integrity": "sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -8359,8 +8369,7 @@
     "node_modules/@webgpu/types": {
       "version": "0.1.38",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
-      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
-      "peer": true
+      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA=="
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "1.2.0",
@@ -8442,6 +8451,7 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8737,6 +8747,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -10239,6 +10250,7 @@
       "version": "5.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -10801,8 +10813,7 @@
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "peer": true
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -11014,7 +11025,6 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11496,6 +11506,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -12110,6 +12121,7 @@
       "version": "1.60.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -12179,8 +12191,7 @@
     "node_modules/seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "peer": true
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -12746,8 +12757,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-loader": {
       "version": "9.4.2",
@@ -12853,6 +12863,7 @@
       "version": "4.2.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12988,14 +12999,14 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "peer": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
       "version": "5.96.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
       "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -13041,6 +13052,7 @@
       "version": "4.10.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -13118,6 +13130,7 @@
       "version": "8.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -13225,6 +13238,7 @@
       "version": "8.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -13341,7 +13355,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/docs/classes/defaultmeetingreadinesschecker.html
+++ b/docs/classes/defaultmeetingreadinesschecker.html
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L40">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L41">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioconnectivity">checkAudioConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L271">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:271</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L309">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:309</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -180,7 +180,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudioinput">checkAudioInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L48">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L49">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkaudiooutput">checkAudioOutput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L62">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L63">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcameraresolution">checkCameraResolution</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L168">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L206">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -291,7 +291,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkcontentshareconnectivity">checkContentShareConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L222">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L260">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:260</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworktcpconnectivity">checkNetworkTCPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L426">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:426</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L464">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:464</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checknetworkudpconnectivity">checkNetworkUDPConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L382">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:382</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L420">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:420</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoconnectivity">checkVideoConnectivity</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L335">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:335</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L373">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:373</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -396,7 +396,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/meetingreadinesschecker.html">MeetingReadinessChecker</a>.<a href="../interfaces/meetingreadinesschecker.html#checkvideoinput">checkVideoInput</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L154">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/aws/amazon-chime-sdk-js/blob/main/src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts#L192">src/meetingreadinesschecker/DefaultMeetingReadinessChecker.ts:192</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -702,7 +702,15 @@ export default class DOMMockBuilder {
     };
 
     GlobalAny.Audio = class MockAudio {
+      srcObject: MediaStream | null = null;
+
       constructor(public src?: string) {}
+
+      pause(): void {}
+
+      play(): Promise<void> {
+        return Promise.resolve();
+      }
     };
 
     GlobalAny.Event = class MockEvent {
@@ -1385,6 +1393,12 @@ export default class DOMMockBuilder {
           disconnect(_destinationParam: AudioParam): void {},
           // @ts-ignore
           gain: {
+            value: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            setValueAtTime(value: number, startTime: number): AudioParam {
+              // @ts-ignore
+              return {};
+            },
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             linearRampToValueAtTime(value: number, endTime: number): AudioParam {
               // @ts-ignore
@@ -1395,12 +1409,17 @@ export default class DOMMockBuilder {
       }
 
       createOscillator(): OscillatorNode {
+        const listeners: EventListener[] = [];
         // @ts-ignore
         return {
           context: (this as unknown) as BaseAudioContext,
           // @ts-ignore
           start(_when?: number): void {},
-          stop(): void {},
+          stop(_when?: number): void {
+            setTimeout(() => {
+              listeners.forEach(listener => listener(new Event('ended')));
+            }, 0);
+          },
           // @ts-ignore
           connect(destinationNode: AudioNode, _output?: number, _input?: number): AudioNode {
             return destinationNode;
@@ -1409,6 +1428,9 @@ export default class DOMMockBuilder {
           disconnect(_destinationNode: AudioNode): void {},
           // @ts-ignore
           frequency: {},
+          addEventListener(_type: string, listener: EventListener): void {
+            listeners.push(listener);
+          },
         };
       }
 
@@ -1473,10 +1495,16 @@ export default class DOMMockBuilder {
           disconnect(_destinationParam: AudioParam): void {},
           // @ts-ignore
           gain: {
+            value: 0,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            setValueAtTime(value: number, startTime: number): AudioParam {
+              // @ts-ignore
+              return this;
+            },
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             linearRampToValueAtTime(value: number, endTime: number): AudioParam {
               // @ts-ignore
-              return {};
+              return this;
             },
           },
         };


### PR DESCRIPTION
**Issue #3125 :**

**Description of changes:**
- Fix race condition in playTone. Use setTimeOut to wait until audio tone ramp down before cleaning up resources.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

- Yes, meeting readiness checker. Run it on desktop or mobile Safari browser, when testing speaker - play tone, verify the tone does not continue playing with a crackly quality even after users confirm they can hear it.

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

