### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/browser-compatibility-test-previous-major-version.yml
+++ b/.github/workflows/browser-compatibility-test-previous-major-version.yml
@@ -28,7 +28,7 @@ jobs:
       previous_version_number: ${{ steps.get-version.outputs.version-number }}
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get Version
@@ -46,7 +46,7 @@ jobs:
       job-status: ${{ job.status }}
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
           fetch-depth: 0
@@ -183,7 +183,7 @@ jobs:
 
     steps:
         - name: Checkout Package
-          uses: actions/checkout@v2
+          uses: actions/checkout@v6
           with:
             ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
             fetch-depth: 0
@@ -207,7 +207,7 @@ jobs:
 
     steps:
         - name: Checkout Package
-          uses: actions/checkout@v2
+          uses: actions/checkout@v6
           with:
             ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
             fetch-depth: 0
@@ -231,7 +231,7 @@ jobs:
 
     steps:
         - name: Checkout Package
-          uses: actions/checkout@v2
+          uses: actions/checkout@v6
           with:
             ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
             fetch-depth: 0
@@ -255,7 +255,7 @@ jobs:
       
     steps:
         - name: Checkout Package
-          uses: actions/checkout@v2
+          uses: actions/checkout@v6
           with:
             ref: "release-${{ needs.get-previous-version.outputs.previous_version_number }}.x"
             fetch-depth: 0
@@ -282,11 +282,11 @@ jobs:
 
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js - 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Gather Job Status Data

--- a/.github/workflows/browser-compatibility-test.yml
+++ b/.github/workflows/browser-compatibility-test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup GitHub Actions Host

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Using Node.js 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Clean Install
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup GitHub Actions Host
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup GitHub Actions Host

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           role-session-name: deploy-demo-app
           aws-region: us-east-1
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install SAM CLI
@@ -52,7 +52,7 @@ jobs:
           role-session-name: deploy-demo-app
           aws-region: us-east-1
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install SAM CLI

--- a/.github/workflows/prev-version-integration.yaml
+++ b/.github/workflows/prev-version-integration.yaml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
       - name: Setup Node.js - 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get previous version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -80,7 +80,7 @@ jobs:
           role-session-name: publish-demo-deployment
           aws-region: us-east-1
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Install SDK

--- a/.github/workflows/release-backwards-compatiblity.yml
+++ b/.github/workflows/release-backwards-compatiblity.yml
@@ -31,7 +31,7 @@ jobs:
       run-check: ${{ steps.version-check.outputs.run-check }}
     steps:
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Version check for backward compatibility check
@@ -45,11 +45,11 @@ jobs:
     if: contains(needs.check-backward-compatibility-run.outputs.run-check, 'Run backward compatibility checks')
     steps:
       - name: Setup Node.js - 20.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Checkout Package
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Pack the Chime SDK and install the tarball into the previous version Demo

--- a/.github/workflows/webview-ui-test.yml
+++ b/.github/workflows/webview-ui-test.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout amazon-chime-sdk repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: 'aws-samples/amazon-chime-sdk'
       - name: Insert  meeting demo URL
@@ -35,14 +35,16 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout amazon-chime-sdk repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: 'aws-samples/amazon-chime-sdk'
       - name: Insert Android meeting demo URL
         run: |
           sed -i '' -e 's@PLACEHOLDER@${{secrets.DEPLOYED_MEETING_DEMO}}@' ./app/src/main/java/com/amazonaws/android_webview_sample/AppConfig.kt
       - name: Set Up JDK 11.0.11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
+          with:
+            distribution: temurin  # Added for actions/setup-java v2+ compatibility
         with:
           java-version: 11.0.11
       - name: Build the App


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v2`](https://github.com/actions/checkout/releases/tag/v2) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | browser-compatibility-test-previous-major-version.yml, browser-compatibility-test.yml, continuous-integration.yml, deploy.yml, prev-version-integration.yaml, publish.yml, release-backwards-compatiblity.yml, webview-ui-test.yml |
| `actions/setup-java` | [`v1`](https://github.com/actions/setup-java/releases/tag/v1) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | webview-ui-test.yml |
| `actions/setup-node` | [`v1`](https://github.com/actions/setup-node/releases/tag/v1), [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | browser-compatibility-test-previous-major-version.yml, continuous-integration.yml, prev-version-integration.yaml, publish.yml, release-backwards-compatiblity.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/setup-java**: Starting from v2, 'distribution' is required. Common options: temurin, zulu, corretto, microsoft
  - ✅ Auto-added: `distribution: temurin`
  - You may want to customize this value based on your project's requirements.

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
