### PR TITLE
Set VideoPriorityBasedPolicy as default when SVC or simulcast is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored Encoded Transform management into it's own component for better support of non-redundant audio transforms.
 - Add scalability mode fallback when SVC is enabled. Limit SVC for content share to AV1 temporal scalability only.
 - Completed migration to mocha tests
+- Enable VideoPriorityBasedPolicy by default when SVC or simulcast is enabled.
 
 ### Fixed
 

--- a/demos/browser/app/meetingV2/meetingV2.ts
+++ b/demos/browser/app/meetingV2/meetingV2.ts
@@ -1877,12 +1877,12 @@ export class DemoMeetingApp
     configuration.enableSimulcastForUnifiedPlanChromiumBasedBrowsers = this.enableSimulcast;
     configuration.enableSVC = this.enableSVC;
     if (this.usePriorityBasedDownlinkPolicy) {
-        this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger);
+      this.priorityBasedDownlinkPolicy = new VideoPriorityBasedPolicy(this.meetingLogger);
       configuration.videoDownlinkBandwidthPolicy = this.priorityBasedDownlinkPolicy;
       this.priorityBasedDownlinkPolicy.addObserver(this);
     } else {
-        this.allHighestDownlinkPolicy = new AllHighestVideoBandwidthPolicy(configuration.credentials.attendeeId);
-        configuration.videoDownlinkBandwidthPolicy = this.allHighestDownlinkPolicy;
+      this.allHighestDownlinkPolicy = new AllHighestVideoBandwidthPolicy(configuration.credentials.attendeeId);
+      configuration.videoDownlinkBandwidthPolicy = this.allHighestDownlinkPolicy;
     }
     configuration.disablePeriodicKeyframeRequestOnContentSender = this.disablePeriodicKeyframeRequestOnContentSender;
 

--- a/demos/browser/app/meetingV2/video/RemoteVideoManager.ts
+++ b/demos/browser/app/meetingV2/video/RemoteVideoManager.ts
@@ -89,7 +89,7 @@ export default class RemoteVideoManager {
             }
         }
         this.downlinkPolicy.chooseRemoteVideoSources(videoPreferences.build());
-    } else {
+    } else if (this.downlinkPolicy?.chooseRemoteVideoSources){
         // Just convert this list to  the simpler 'VideoSource' class used by all highest policy
         let videoSources: VideoSource[] = [];
         for (const attendeeId of this.attendeeIdToVideoPreference.keys()) {

--- a/src/audiovideocontroller/DefaultAudioVideoController.ts
+++ b/src/audiovideocontroller/DefaultAudioVideoController.ts
@@ -84,8 +84,8 @@ import VideoOnlyTransceiverController from '../transceivercontroller/VideoOnlyTr
 import { Maybe } from '../utils/Types';
 import DefaultVideoCaptureAndEncodeParameter from '../videocaptureandencodeparameter/DefaultVideoCaptureAndEncodeParameter';
 import AllHighestVideoBandwidthPolicy from '../videodownlinkbandwidthpolicy/AllHighestVideoBandwidthPolicy';
-import VideoAdaptiveProbePolicy from '../videodownlinkbandwidthpolicy/VideoAdaptiveProbePolicy';
 import { convertVideoPreferencesToSignalingClientVideoSubscriptionConfiguration } from '../videodownlinkbandwidthpolicy/VideoPreferences';
+import VideoPriorityBasedPolicy from '../videodownlinkbandwidthpolicy/VideoPriorityBasedPolicy';
 import VideoSource from '../videosource/VideoSource';
 import DefaultVideoStreamIdSet from '../videostreamidset/DefaultVideoStreamIdSet';
 import DefaultVideoStreamIndex from '../videostreamindex/DefaultVideoStreamIndex';
@@ -584,12 +584,6 @@ export default class DefaultAudioVideoController
 
       simulcastPolicy.addObserver(this);
 
-      if (!this.meetingSessionContext.videoDownlinkBandwidthPolicy) {
-        this.meetingSessionContext.videoDownlinkBandwidthPolicy = new VideoAdaptiveProbePolicy(
-          this.meetingSessionContext.logger
-        );
-      }
-
       this.meetingSessionContext.videoStreamIndex = new SimulcastVideoStreamIndex(this.logger);
     } else {
       this.meetingSessionContext.enableSimulcast = false;
@@ -605,10 +599,6 @@ export default class DefaultAudioVideoController
           );
         this.meetingSessionContext.videoUplinkBandwidthPolicy.setSVCEnabled(this.enableSVC);
       }
-      if (!this.meetingSessionContext.videoDownlinkBandwidthPolicy) {
-        this.meetingSessionContext.videoDownlinkBandwidthPolicy =
-          new AllHighestVideoBandwidthPolicy(this.configuration.credentials.attendeeId);
-      }
 
       if (
         this.meetingSessionContext.videoUplinkBandwidthPolicy.setTransceiverController &&
@@ -620,6 +610,13 @@ export default class DefaultAudioVideoController
         );
       }
       this.meetingSessionContext.audioProfile = this._audioProfile;
+    }
+
+    if (!this.meetingSessionContext.videoDownlinkBandwidthPolicy) {
+      this.meetingSessionContext.videoDownlinkBandwidthPolicy =
+        this.enableSVC || this.enableSimulcast
+          ? new VideoPriorityBasedPolicy(this.meetingSessionContext.logger)
+          : new AllHighestVideoBandwidthPolicy(this.configuration.credentials.attendeeId);
     }
 
     if (

--- a/test/audiovideocontroller/DefaultAudioVideoController.test.ts
+++ b/test/audiovideocontroller/DefaultAudioVideoController.test.ts
@@ -769,7 +769,7 @@ describe('DefaultAudioVideoController', () => {
       expect(uplink instanceof DefaultSimulcastUplinkPolicy).to.be.true;
       // @ts-ignore
       const downlink = audioVideoController.meetingSessionContext.videoDownlinkBandwidthPolicy;
-      expect(downlink instanceof VideoAdaptiveProbePolicy).to.be.true;
+      expect(downlink instanceof VideoPriorityBasedPolicy).to.be.true;
 
       await sendICEEventAndSubscribeAckFrame();
       await delay(defaultDelay);


### PR DESCRIPTION
**Issue #:**

**Description of changes:**
Set VideoPriorityBasedPolicy as default when SVC or simulcast is enabled

**Testing:**
Smoke tested and verified VideoPriorityBasedPolicy when SVC is enabled

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Not testable in demo app without modification since demo app has downlink policy configured

**Checklist:**

1. Have you successfully run `npm run build:release` locally?


4. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


5. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

