### PR TITLE
Fix typo: seperate to separate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -904,7 +904,7 @@ more information.
 - Change the serverless demo's `deploy.js` script to rebuild the demo on each run. This should remove a manual step of rebuilding the demo.
 - Disable NScale resolution scaling for Android device due to Android H.264 encoding.
 - Minor clean up of code in `BackgroundBlurProcessorProvided` class.
-- Refactored some video demo components into classes and seperate files.
+- Refactored some video demo components into classes and separate files.
 
 ## [2.21.0] - 2021-11-01
 

--- a/src/audiovideocontroller/AudioVideoControllerState.ts
+++ b/src/audiovideocontroller/AudioVideoControllerState.ts
@@ -237,7 +237,7 @@ export default class AudioVideoControllerState {
     // We don't want to mutate `videoTileController` as most video tiles will still be there on reconnect. We can remove tiles on the
     // first index we receive if they no longer exist
 
-    // `mediaStreamBroker`, `activeAudioInput`, and `activeVideoInput` are cleaned up seperately in `DefaultAudioVideoController.cleanUpMediaStreamsAfterStop`
+    // `mediaStreamBroker`, `activeAudioInput`, and `activeVideoInput` are cleaned up separately in `DefaultAudioVideoController.cleanUpMediaStreamsAfterStop`
     // but only on `stop` or non-reconnectable failures. They are also set to cached `DefaultAudioVideoController` members on restart.
 
     if (this.transceiverController !== undefined) {

--- a/src/contentsharecontroller/ContentShareControllerFacade.ts
+++ b/src/contentsharecontroller/ContentShareControllerFacade.ts
@@ -49,7 +49,7 @@ export default interface ContentShareControllerFacade {
 
   /**
    * Pause content sharing. This (combined with `unpauseContentShare` is a lightweight alternative to stopping and
-   * starting content share which requires use of a seperate peer connection and therefore has increased latency.
+   * starting content share which requires use of a separate peer connection and therefore has increased latency.
    *
    * Remote receivers will continue to subscribe to content share video but there will be nothing transmitting
    * (e.g. it may be a black frame)


### PR DESCRIPTION
Corrects typo where 'seperate' should be 'separate' in CHANGELOG.md, ContentShareControllerFacade.ts, and AudioVideoControllerState.ts.