### PR TITLE
Fix transform PPS always zero and content share worker crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added PPS metrics on the Encoded Transform when used.
+- Added PPS metrics on Encoded Transforms when used.
 - Added meeting session lifecycle timing tracking and signaling via `MeetingSessionTimingManager`.
 
 ### Removed

--- a/src/meetingsession/DefaultMeetingSession.ts
+++ b/src/meetingsession/DefaultMeetingSession.ts
@@ -34,6 +34,7 @@ export default class DefaultMeetingSession implements MeetingSession, Destroyabl
   private _deviceController: DeviceController;
   private audioVideoFacade: AudioVideoFacade;
   private encodedTransformWorkerManager: EncodedTransformWorkerManager;
+  private contentShareEncodedTransformWorkerManager: EncodedTransformWorkerManager;
 
   constructor(
     configuration: MeetingSessionConfiguration,
@@ -76,6 +77,9 @@ export default class DefaultMeetingSession implements MeetingSession, Destroyabl
     );
     this._deviceController = deviceController;
     this.logger.info(`MeetingFeatures: ${JSON.stringify(configuration.meetingFeatures)}`);
+    this.contentShareEncodedTransformWorkerManager = new DefaultEncodedTransformWorkerManager(
+      this._logger
+    );
     const contentShareMediaStreamBroker = new ContentShareMediaStreamBroker(this._logger);
     this.contentShareController = new DefaultContentShareController(
       contentShareMediaStreamBroker,
@@ -95,7 +99,7 @@ export default class DefaultMeetingSession implements MeetingSession, Destroyabl
           )
         ),
         undefined, // eventController
-        this.encodedTransformWorkerManager
+        this.contentShareEncodedTransformWorkerManager
       ),
       this.audioVideoController
     );
@@ -149,6 +153,7 @@ export default class DefaultMeetingSession implements MeetingSession, Destroyabl
       await this.eventController.destroy();
     }
     await this.encodedTransformWorkerManager?.stop();
+    await this.contentShareEncodedTransformWorkerManager?.stop();
 
     CSPMonitor.removeLogger(this._logger);
 
@@ -160,6 +165,7 @@ export default class DefaultMeetingSession implements MeetingSession, Destroyabl
     this.contentShareController = undefined;
     this._eventController = undefined;
     this.encodedTransformWorkerManager = undefined;
+    this.contentShareEncodedTransformWorkerManager = undefined;
   }
 
   private checkBrowserSupportAndFeatureConfiguration(): void {

--- a/src/statscollector/StatsCollector.ts
+++ b/src/statscollector/StatsCollector.ts
@@ -68,7 +68,6 @@ export default class StatsCollector
   private remoteRenderFpsMap = new Map<number, number>();
   private encodedTransformMediaMetrics: EncodedTransformMediaMetrics | null = null;
   private encodedTransformMediaMetricsTimestamp: number = 0;
-  private lastEncodedTransformMediaMetricsTimestamp: number = 0;
 
   constructor(
     private audioVideoController: AudioVideoController,
@@ -724,10 +723,7 @@ export default class StatsCollector
    * Adds transform metrics (PPS) to the raw webrtc stats report.
    */
   private maybeAddTransformMetrics(customStatsReports: CustomStatsReport[]): void {
-    if (
-      !this.encodedTransformMediaMetrics ||
-      this.encodedTransformMediaMetricsTimestamp === this.lastEncodedTransformMediaMetricsTimestamp
-    ) {
+    if (!this.encodedTransformMediaMetrics) {
       return;
     }
 
@@ -777,8 +773,6 @@ export default class StatsCollector
         });
       }
     }
-
-    this.lastEncodedTransformMediaMetricsTimestamp = timestamp;
   }
 
   /**

--- a/test/statscollector/StatsCollector.test.ts
+++ b/test/statscollector/StatsCollector.test.ts
@@ -1317,37 +1317,6 @@ describe('StatsCollector', () => {
       statsCollector.start(signalingClient, new DefaultVideoStreamIndex(logger));
     });
 
-    it('does not add transform metrics if already processed', done => {
-      domMockBehavior.rtcPeerConnectionGetStatsReports = [];
-
-      class TestObserver implements AudioVideoObserver {
-        metricsDidReceive(_clientMetricReport: ClientMetricReport): void {
-          const rtcStatsReports = _clientMetricReport.customStatsReports;
-          const transformReport = rtcStatsReports.find(
-            // @ts-ignore
-            report =>
-              report.type === 'outbound-rtp-transform' || report.type === 'inbound-rtp-transform'
-          );
-          expect(transformReport).to.be.undefined;
-          statsCollector.stop();
-          done();
-        }
-      }
-      audioVideoController.addObserver(new TestObserver());
-
-      statsCollector = new StatsCollector(audioVideoController, logger, interval);
-      statsCollector.encodedTransformMediaMetricsDidReceive({
-        audioSendMetrics: { 1001: { ssrc: 1001, packetCount: 100, timestamp: 1000 } },
-        audioReceiveMetrics: {},
-        videoSendMetrics: {},
-        videoReceiveMetrics: {},
-      });
-      // Set the last timestamp to match the current timestamp to simulate already processed
-      statsCollector['lastEncodedTransformMediaMetricsTimestamp'] =
-        statsCollector['encodedTransformMediaMetricsTimestamp'];
-      statsCollector.start(signalingClient, new DefaultVideoStreamIndex(logger));
-    });
-
     it('does not add transform metrics if no metrics received', done => {
       domMockBehavior.rtcPeerConnectionGetStatsReports = [];
 


### PR DESCRIPTION
Issue #: N/A

Description of changes:

Fix two encoded transform bugs:

1. AUDIO_RECEIVED_TRANSFORM_PPS and AUDIO_SENT_TRANSFORM_PPS always reported as 0. The timestamp guard in StatsCollector.maybeAddTransformMetrics skipped injecting the cumulative packetCount when the worker hadn't 
reported new data between stats collection cycles. This caused currentMetrics == previousMetrics, making countPerSecond return 0. Removed the guard so the cumulative value is always injected — countPerSecond 
correctly computes the delta between intervals.

2. "Worker not initialized" crash when toggling content share between attendees. DefaultMeetingSession shared one EncodedTransformWorkerManager between the main session and content share AudioVideoController. When 
content share stopped, it terminated the shared worker. A subsequent track event on the main session's peer connection then called setupVideoReceiverTransform on the stopped manager. Fixed by giving content share 
its own DefaultEncodedTransformWorkerManager.

Testing:

Can these tested using a demo application? Please provide reproducible step-by-step instructions.

Bug 1 (Transform PPS):
1. Run the browser demo with log level set to Debug
2. Join two attendees to the same meeting
3. Observe the sending: debug logs — AUDIO_RECEIVED_TRANSFORM_PPS and AUDIO_SENT_TRANSFORM_PPS should report ~50 (previously always 0)

Bug 2 (Content share worker crash):
1. Join two attendees (Alice and Bob) to the same meeting
2. Alice starts content share
3. Alice stops content share
4. Bob starts content share
5. Previously this caused "Worker not initialized" error on Alice's side — now it works without error

Checklist:

1. Have you successfully run npm run build:release locally?

Yes — 2928 passing, 0 errors.

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?

No.

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.