### PR TITLE
Use header extension API to avoid ID conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed event ordering race condition when updating high entropy values in DefaultEventController.
+- Use `setHeaderExtensionsToNegotiate` API to configure video RTP header extensions instead of SDP munging when available. Falls back to SDP munging on browsers without the API.
 
 ## [3.30.0] - 2025-09-18
 

--- a/src/task/SetLocalDescriptionTask.ts
+++ b/src/task/SetLocalDescriptionTask.ts
@@ -4,6 +4,7 @@
 import AudioVideoControllerState from '../audiovideocontroller/AudioVideoControllerState';
 import DefaultBrowserBehavior from '../browserbehavior/DefaultBrowserBehavior';
 import SDP from '../sdp/SDP';
+import DefaultTransceiverController from '../transceivercontroller/DefaultTransceiverController';
 import BaseTask from './BaseTask';
 
 /*
@@ -33,7 +34,15 @@ export default class SetLocalDescriptionTask extends BaseTask {
     const sdpOfferInit = this.context.sdpOfferInit;
     let sdp = sdpOfferInit.sdp;
 
-    if (this.context.browserBehavior.supportsVideoLayersAllocationRtpHeaderExtension()) {
+    // When the transceiver header extension API is available (Chrome 117+), extensions
+    // are configured via setHeaderExtensionsToNegotiate in the transceiver controller,
+    // so SDP munging is not needed.
+    const skipHeaderExtensionMunging = DefaultTransceiverController.canUseHeaderExtensionApi(peer);
+
+    if (
+      !skipHeaderExtensionMunging &&
+      this.context.browserBehavior.supportsVideoLayersAllocationRtpHeaderExtension()
+    ) {
       // This will be negotiatiated with backend, and we will only use it to skip resubscribes
       // if we confirm support/negotiation via `RTCRtpTranceiver.sender.getParams`
       sdp = new SDP(sdp).withVideoLayersAllocationRtpHeaderExtension(
@@ -44,6 +53,7 @@ export default class SetLocalDescriptionTask extends BaseTask {
     // browsers will not remove it from the send section. We don't do it here, so that we don't lose track of
     // the header extension IDs being used when we store `this.context.previousSdpOffer`.
     if (
+      !skipHeaderExtensionMunging &&
       this.context.browserBehavior.supportsDependencyDescriptorRtpHeaderExtension() &&
       this.context.videoUplinkBandwidthPolicy.wantsVideoDependencyDescriptorRtpHeaderExtension !==
         undefined &&

--- a/src/transceivercontroller/DefaultTransceiverController.ts
+++ b/src/transceivercontroller/DefaultTransceiverController.ts
@@ -10,6 +10,11 @@ import VideoStreamIdSet from '../videostreamidset/VideoStreamIdSet';
 import VideoStreamIndex from '../videostreamindex/VideoStreamIndex';
 import TransceiverController from './TransceiverController';
 
+const videoLayersAllocationUrl =
+  'http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00';
+const dependencyDescriptorUrl =
+  'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension';
+
 export default class DefaultTransceiverController implements TransceiverController {
   protected _localCameraTransceiver: RTCRtpTransceiver | null = null;
   protected _localAudioTransceiver: RTCRtpTransceiver | null = null;
@@ -187,12 +192,66 @@ export default class DefaultTransceiverController implements TransceiverControll
         direction: 'inactive',
         streams: [this.defaultMediaStream],
       });
+      this.configureLocalCameraHeaderExtensions();
 
       if (this.encodedTransformWorkerManager?.isEnabled()) {
         this.encodedTransformWorkerManager.setupVideoSenderTransform(
           this._localCameraTransceiver.sender
         );
       }
+    }
+  }
+
+  /**
+   * Returns true if the peer connection supports the header extension negotiation
+   * API (`getHeaderExtensionsToNegotiate` / `setHeaderExtensionsToNegotiate`),
+   * which allows configuring RTP header extensions without SDP munging.
+   */
+  static canUseHeaderExtensionApi(peer: RTCPeerConnection): boolean {
+    const transceivers = peer.getTransceivers?.();
+    if (!transceivers?.length) {
+      return false;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = transceivers[0] as any;
+    return (
+      typeof t.getHeaderExtensionsToNegotiate === 'function' &&
+      typeof t.setHeaderExtensionsToNegotiate === 'function'
+    );
+  }
+
+  protected configureLocalCameraHeaderExtensions(): void {
+    if (!DefaultTransceiverController.canUseHeaderExtensionApi(this.peer)) {
+      return;
+    }
+
+    const policy = this.meetingSessionContext
+      ? this.meetingSessionContext.videoUplinkBandwidthPolicy
+      : undefined;
+    const wantsDependencyDescriptor =
+      policy?.wantsVideoDependencyDescriptorRtpHeaderExtension !== undefined &&
+      policy.wantsVideoDependencyDescriptorRtpHeaderExtension();
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const t = this._localCameraTransceiver as any;
+      const extensions = t.getHeaderExtensionsToNegotiate();
+      let modified = false;
+      for (const extension of extensions) {
+        if (
+          extension.direction === 'stopped' &&
+          (extension.uri === videoLayersAllocationUrl ||
+            (wantsDependencyDescriptor && extension.uri === dependencyDescriptorUrl))
+        ) {
+          extension.direction = 'sendrecv';
+          modified = true;
+        }
+      }
+      if (modified) {
+        t.setHeaderExtensionsToNegotiate(extensions);
+      }
+    } catch (e) {
+      this.logger.warn(`Failed to configure video header extensions: ${e.message}`);
     }
   }
 

--- a/src/transceivercontroller/SimulcastTransceiverController.ts
+++ b/src/transceivercontroller/SimulcastTransceiverController.ts
@@ -123,6 +123,7 @@ export default class SimulcastTransceiverController extends DefaultTransceiverCo
         streams: [this.defaultMediaStream],
         sendEncodings: encodingParams,
       });
+      this.configureLocalCameraHeaderExtensions();
 
       if (this.encodedTransformWorkerManager?.isEnabled()) {
         this.encodedTransformWorkerManager.setupVideoSenderTransform(

--- a/src/transceivercontroller/VideoOnlyTransceiverController.ts
+++ b/src/transceivercontroller/VideoOnlyTransceiverController.ts
@@ -31,6 +31,7 @@ export default class VideoOnlyTransceiverController extends DefaultTransceiverCo
         direction: 'inactive',
         streams: [this.defaultMediaStream],
       });
+      this.configureLocalCameraHeaderExtensions();
     }
   }
 }

--- a/test/dommock/DOMMockBehavior.ts
+++ b/test/dommock/DOMMockBehavior.ts
@@ -25,6 +25,7 @@ export default class DOMMockBehavior {
   navigatorProduct: string = '';
   undefinedDocument: boolean = false;
   supportsAudioRedCodec: boolean = true;
+  supportsHeaderExtensionApi: boolean = false;
 
   FakeTURNCredentialsBody: Promise<object> = new Promise((resolve, _reject) => {
     const obj = new Object({

--- a/test/dommock/DOMMockBuilder.ts
+++ b/test/dommock/DOMMockBuilder.ts
@@ -1098,6 +1098,35 @@ export default class DOMMockBuilder {
       }
     };
 
+    if (mockBehavior.supportsHeaderExtensionApi) {
+      const defaultHeaderExtensions = [
+        { uri: 'urn:ietf:params:rtp-hdrext:ssrc-audio-level', direction: 'sendrecv' },
+        {
+          uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time',
+          direction: 'sendrecv',
+        },
+        {
+          uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00',
+          direction: 'stopped',
+        },
+        {
+          uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+          direction: 'stopped',
+        },
+      ];
+      const origConstructor = GlobalAny.RTCRtpTransceiver;
+      GlobalAny.RTCRtpTransceiver = class extends origConstructor {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        private headerExtensions: any[] = defaultHeaderExtensions.map(e => ({ ...e }));
+        getHeaderExtensionsToNegotiate(): { uri: string; direction: string }[] {
+          return this.headerExtensions.map((e: { uri: string; direction: string }) => ({ ...e }));
+        }
+        setHeaderExtensionsToNegotiate(extensions: { uri: string; direction: string }[]): void {
+          this.headerExtensions = extensions.map(e => ({ ...e }));
+        }
+      };
+    }
+
     GlobalAny.RTCRtpReceiver = class MockRTCRtpReceiver {
       readonly track: MediaStreamTrack;
       // @ts-ignore

--- a/test/transceivercontroller/DefaultTransceiverController.test.ts
+++ b/test/transceivercontroller/DefaultTransceiverController.test.ts
@@ -1311,4 +1311,152 @@ describe('DefaultTransceiverController', () => {
       errorSpy.restore();
     });
   });
+
+  describe('canUseHeaderExtensionApi', () => {
+    it('returns false when getTransceivers is not available', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const peer = {} as any;
+      expect(DefaultTransceiverController.canUseHeaderExtensionApi(peer)).to.be.false;
+    });
+
+    it('returns false when peer has no transceivers', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const peer = { getTransceivers: (): RTCRtpTransceiver[] => [] } as any;
+      expect(DefaultTransceiverController.canUseHeaderExtensionApi(peer)).to.be.false;
+    });
+
+    it('returns false when transceiver lacks the API', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const peer = { getTransceivers: (): { mid: string }[] => [{ mid: '0' }] } as any;
+      expect(DefaultTransceiverController.canUseHeaderExtensionApi(peer)).to.be.false;
+    });
+
+    it('returns false when transceiver only has getter', () => {
+      const peer = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getTransceivers: (): any[] => [
+          { getHeaderExtensionsToNegotiate: (): { uri: string; direction: string }[] => [] },
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+      expect(DefaultTransceiverController.canUseHeaderExtensionApi(peer)).to.be.false;
+    });
+
+    it('returns true when transceiver has both getter and setter', () => {
+      const peer = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getTransceivers: (): any[] => [
+          {
+            getHeaderExtensionsToNegotiate: (): { uri: string; direction: string }[] => [],
+            setHeaderExtensionsToNegotiate: (): void => {},
+          },
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+      expect(DefaultTransceiverController.canUseHeaderExtensionApi(peer)).to.be.true;
+    });
+  });
+
+  describe('configureLocalCameraHeaderExtensions', () => {
+    const layersUrl = 'http://www.webrtc.org/experiments/rtp-hdrext/video-layers-allocation00';
+    const ddUrl =
+      'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension';
+
+    it('enables video-layers-allocation without meeting context', () => {
+      domMockBehavior.supportsHeaderExtensionApi = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      const localTc = new DefaultTransceiverController(logger, new DefaultBrowserBehavior());
+      localTc.setPeer(new RTCPeerConnection());
+      localTc.setupLocalTransceivers();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const extensions = (localTc.localVideoTransceiver() as any).getHeaderExtensionsToNegotiate();
+      const layers = extensions.find(
+        (e: { uri: string; direction: string }) => e.uri === layersUrl
+      );
+      expect(layers.direction).to.equal('sendrecv');
+    });
+
+    it('enables video-layers-allocation without dependency descriptor policy', () => {
+      domMockBehavior.supportsHeaderExtensionApi = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      const localContext = new AudioVideoControllerState();
+      localContext.browserBehavior = new DefaultBrowserBehavior();
+      localContext.audioProfile = new AudioProfile();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      localContext.videoUplinkBandwidthPolicy = {} as any;
+      const localTc = new DefaultTransceiverController(
+        logger,
+        localContext.browserBehavior,
+        localContext
+      );
+      localTc.setPeer(new RTCPeerConnection());
+      localTc.setupLocalTransceivers();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const extensions = (localTc.localVideoTransceiver() as any).getHeaderExtensionsToNegotiate();
+      const layers = extensions.find(
+        (e: { uri: string; direction: string }) => e.uri === layersUrl
+      );
+      expect(layers.direction).to.equal('sendrecv');
+      const dd = extensions.find((e: { uri: string; direction: string }) => e.uri === ddUrl);
+      expect(dd.direction).to.equal('stopped');
+    });
+
+    it('enables video-layers-allocation via the API', () => {
+      domMockBehavior.supportsHeaderExtensionApi = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      tc = new DefaultTransceiverController(logger, new DefaultBrowserBehavior(), context);
+      tc.setPeer(new RTCPeerConnection());
+      tc.setupLocalTransceivers();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const extensions = (tc.localVideoTransceiver() as any).getHeaderExtensionsToNegotiate();
+      const layers = extensions.find(
+        (e: { uri: string; direction: string }) => e.uri === layersUrl
+      );
+      expect(layers.direction).to.equal('sendrecv');
+    });
+
+    it('enables dependency descriptor when uplink policy wants it', () => {
+      domMockBehavior.supportsHeaderExtensionApi = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      context.videoUplinkBandwidthPolicy = {
+        wantsVideoDependencyDescriptorRtpHeaderExtension: (): boolean => true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+      tc = new DefaultTransceiverController(logger, new DefaultBrowserBehavior(), context);
+      tc.setPeer(new RTCPeerConnection());
+      tc.setupLocalTransceivers();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const extensions = (tc.localVideoTransceiver() as any).getHeaderExtensionsToNegotiate();
+      const dd = extensions.find((e: { uri: string; direction: string }) => e.uri === ddUrl);
+      expect(dd.direction).to.equal('sendrecv');
+    });
+
+    it('falls back gracefully when API throws', () => {
+      domMockBehavior.supportsHeaderExtensionApi = true;
+      domMockBuilder = new DOMMockBuilder(domMockBehavior);
+      tc = new DefaultTransceiverController(logger, new DefaultBrowserBehavior(), context);
+      tc.setPeer(new RTCPeerConnection());
+
+      const origAddTransceiver = RTCPeerConnection.prototype.addTransceiver;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      RTCPeerConnection.prototype.addTransceiver = function (...args: any[]): RTCRtpTransceiver {
+        const t = origAddTransceiver.apply(this, args);
+        if (t.getHeaderExtensionsToNegotiate) {
+          t.setHeaderExtensionsToNegotiate = (): void => {
+            throw new Error('mock API error');
+          };
+        }
+        return t;
+      };
+
+      tc.setupLocalTransceivers();
+      RTCPeerConnection.prototype.addTransceiver = origAddTransceiver;
+
+      expect(tc.localVideoTransceiver()).to.not.be.null;
+    });
+  });
 });


### PR DESCRIPTION
Use setHeaderExtensionsToNegotiate API (Chrome 117+) to configure video-layers-allocation and dependency-descriptor RTP header extensions instead of SDP munging. This avoids extension ID reassignment failures caused by WebRTC-HeaderExtensionNegotiateMemory in Chromium 148 that was reverted, but may come back in the future.

Falls back to existing SDP munging for browsers without the API.

**Issue #:** N/A

**Description of changes:** See above

**Testing:**

  Testing                                                                                                                                              
                                                                                                                                                       
  Verified end-to-end on Chrome 147                                                                                       
                                                                                                                                                       
  - ✅ Extension present in local offer, server answer, and sender.getParameters().headerExtensions                                                    
  - ✅ VP8 simulcast: 3 layers (hi/mid/low) active, server received HandleVideoLayersAllocation updates                                                
  - ✅ Under sender uplink constraint: hi+mid layers disabled, server adapted to low layer                                                         
  - ✅ Zero client resubscribes — server adapted autonomously using layers allocation data   

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

