### PR TITLE
Use serverless demo for browse compatibility tests

### DIFF
--- a/.github/actions/setup-integration-test/action.yml
+++ b/.github/actions/setup-integration-test/action.yml
@@ -115,35 +115,39 @@ runs:
           echo "use_sauce=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
-    - name: Create a Job ID for SauceLabs
-      if: |
-        (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true') 
-        && steps.check-sauce.outputs.use_sauce == 'true'
-      id: create-job-id
-      uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c
-    - name: Set JOB_ID Env Variable for SauceLabs
-      if: |
-        (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true') 
-        && steps.check-sauce.outputs.use_sauce == 'true'
-      run: echo "JOB_ID=${{ steps.create-job-id.outputs.uuid }}" >> $GITHUB_ENV
-      shell: bash
-    - name: Echo Job ID for SauceLabs
-      if: |
-        (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true') 
-        && steps.check-sauce.outputs.use_sauce == 'true'
-      run: echo "${{ steps.create-job-id.outputs.uuid }}"
-      shell: bash
-    - name: Setup Sauce Connect
-      if: |
-        (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true') 
-        && steps.check-sauce.outputs.use_sauce == 'true'
-      uses: saucelabs/sauce-connect-action@v3.0.0
-      with:
-        username: ${{ inputs.sauce-username }}
-        accessKey: ${{ inputs.sauce-access-key }}
-        tunnelName: ${{ steps.create-job-id.outputs.uuid }}
-        region: us
-        proxyLocalhost: direct
+    # TODO: Re-enable JOB_ID and Sauce Connect tunnel once local proxying issue is resolved.
+    # Using TEST_URL (deployed serverless demo) instead for now.
+    # - name: Create a Job ID for SauceLabs
+    #   if: |
+    #     (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true')
+    #     && steps.check-sauce.outputs.use_sauce == 'true'
+    #   id: create-job-id
+    #   uses: filipstefansson/uuid-action@ce29ebbb0981ac2448c2e406e848bfaa30ddf04c
+    # - name: Set JOB_ID Env Variable for SauceLabs
+    #   if: |
+    #     (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true')
+    #     && steps.check-sauce.outputs.use_sauce == 'true'
+    #   run: echo "JOB_ID=${{ steps.create-job-id.outputs.uuid }}" >> $GITHUB_ENV
+    #   shell: bash
+    # - name: Echo Job ID for SauceLabs
+    #   if: |
+    #     (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true')
+    #     && steps.check-sauce.outputs.use_sauce == 'true'
+    #   run: echo "${{ steps.create-job-id.outputs.uuid }}"
+    #   shell: bash
+    # TODO: Re-enable Sauce Connect tunnel once local proxying issue is resolved.
+    # Using TEST_URL (deployed serverless demo) instead for now.
+    # - name: Setup Sauce Connect
+    #   if: |
+    #     (steps.test_needed.outputs.integ_test_required == 'true' || inputs.browser-compatibility-test == 'true')
+    #     && steps.check-sauce.outputs.use_sauce == 'true'
+    #   uses: saucelabs/sauce-connect-action@v3.0.0
+    #   with:
+    #     username: ${{ inputs.sauce-username }}
+    #     accessKey: ${{ inputs.sauce-access-key }}
+    #     tunnelName: ${{ steps.create-job-id.outputs.uuid }}
+    #     region: us
+    #     proxyLocalhost: direct
     - name: Setup Chrome for local testing
       if: |
         steps.test_needed.outputs.integ_test_required == 'true' && 

--- a/.github/workflows/browser-compatibility-test.yml
+++ b/.github/workflows/browser-compatibility-test.yml
@@ -2,8 +2,6 @@ name: Browser Compatibility Test
 
 on:
   schedule:
-    # More information on cron https://crontab.guru/
-    # GitHub actions is using UTC time. Scheduling action at 5 am PST
     - cron: '0 13 * * *'
 
 env:
@@ -11,6 +9,7 @@ env:
   TEST_TYPE: Browser-Compatibility-Test
   SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
   SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
+  TEST_URL: ${{secrets.TEST_URL}}
   MESSAGING_USER_ARN: ${{secrets.MESSAGING_USER_ARN}}
   SLACK_JS_SDK_DEV_CORE_WEBHOOK: ${{secrets.SLACK_JS_SDK_DEV_CORE_WEBHOOK}}
   PRE_RUN_SCRIPT_URL: ${{secrets.PRE_RUN_SCRIPT_URL}}
@@ -44,6 +43,35 @@ jobs:
       - name: Run Video Test
         working-directory: ./integration
         run: npm run test -- --test-name VideoTest --host saucelabs --test-type browser-compatibility
-      - name: Run Video Processing Test
-        working-directory: ./integration
-        run: npm run test -- --test-name VideoProcessingTest --host saucelabs --test-type browser-compatibility
+      # - name: Run Video Processing Test
+      #   working-directory: ./integration
+      #   run: npm run test -- --test-name VideoProcessingTest --host saucelabs --test-type browser-compatibility
+      - name: Configure AWS Credentials for CloudWatch
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SDK_DEV }}
+          aws-region: us-east-1
+      - name: Send Metric to CloudWatch
+        if: always()
+        run: |
+          npm install @aws-sdk/client-cloudwatch
+          node -e "
+          const { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
+          const client = new CloudWatchClient({ region: 'us-east-1' });
+          const value = '${{ job.status }}' === 'success' ? 1 : 0;
+          const command = new PutMetricDataCommand({
+            Namespace: process.env.METRIC_NAMESPACE,
+            MetricData: [{
+              MetricName: process.env.METRIC_NAME,
+              Dimensions: [
+                { Name: 'Platform', Value: 'JS SDK Daily Compatibility' }
+              ],
+              Value: value,
+            }]
+          });
+          client.send(command).then(() => console.log('Daily test result sent to CloudWatch')).catch(err => {
+            console.error('Failed to send metric. Error: ', err);
+            process.exit(1);
+          });
+          "

--- a/integration/README.md
+++ b/integration/README.md
@@ -75,9 +75,10 @@ export SAUCE_USERNAME=<Sauce Labs account username>
 export SAUCE_ACCESS_KEY=<Sauce Labs access key>
 ```
 
+#### Option 1: Using a deployed serverless demo (no tunnel required)
 Sauce Labs will open a browser and load a test url. The following command requires the [Chime SDK serverless demo](https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/serverless) deployed in your AWS account. If you haven't already, follow the [Chime SDK serverless demo instruction](https://github.com/aws/amazon-chime-sdk-js/tree/main/demos/serverless) to deploy the demo. You can set the demo url as an environment variable with the following command:
 ```bash
-export TEST_URL=<Chime SDK for JavaScript serverelss demo URL>
+export TEST_URL=<Chime SDK for JavaScript serverless demo URL>
 ```
 
 The following command can be used to run browser compatibility tests with default settings on Sauce Labs:
@@ -85,6 +86,38 @@ The following command can be used to run browser compatibility tests with defaul
 ```bash
 npm run test -- --test-name AudioTest --host saucelabs --test-type browser-compatibility
 ```
+
+#### Option 2: Using a local Sauce Connect tunnel
+If you want to test against the local demo server (served on `127.0.0.1:8080`), you need to set up a Sauce Connect tunnel so that SauceLabs browsers can reach your local machine.
+
+1. Install Sauce Connect:
+```bash
+brew install sauce-connect
+```
+
+2. Start the tunnel in a separate terminal:
+```bash
+export SAUCE_USERNAME=<Sauce Labs account username>
+export SAUCE_ACCESS_KEY=<Sauce Labs access key>
+export JOB_ID=$(uuidgen)
+
+sc run --username $SAUCE_USERNAME --access-key $SAUCE_ACCESS_KEY --tunnel-name $JOB_ID --tls-passthrough-domains "all" --proxy-localhost allow
+```
+
+- `--tls-passthrough-domains "all"` prevents SauceLabs from intercepting SSL traffic, which is important for WebRTC.
+- `--proxy-localhost allow` permits the tunnel to forward requests to `127.0.0.1` on your machine.
+
+3. In another terminal, make sure `TEST_URL` is **not** set (so the test runner starts the local demo), then run the test:
+```bash
+unset TEST_URL
+export SAUCE_USERNAME=<Sauce Labs account username>
+export SAUCE_ACCESS_KEY=<Sauce Labs access key>
+export JOB_ID=<same UUID used when starting the tunnel>
+
+npm run test -- --test-name AudioTest --host saucelabs --test-type browser-compatibility
+```
+
+The `JOB_ID` must match the `--tunnel-name` used when starting `sc` — this is how SauceLabs routes browser traffic through your tunnel.
 
 There are scenarios where a test might not be compatible with one of the browsers or OS. In that case, the user can provide a custom config with an updated clients array. `sample_test.config.json` is a sample test config already provided. 
 The following command can be used to run a browser compatibility test with a custom config:

--- a/integration/configs/BrowserCompatibilityBrowserConfig.js
+++ b/integration/configs/BrowserCompatibilityBrowserConfig.js
@@ -1,27 +1,27 @@
 const browserCompatibilityConfig = [
+    // {
+    //     "browserName": "chrome",
+    //     "browserVersion": "latest-2",
+    //     "platform": "MAC"
+    // },
+    // {
+    //     "browserName": "chrome",
+    //     "browserVersion": "latest-1",
+    //     "platform": "MAC"
+    // },
+    // {
+    //     "browserName": "chrome",
+    //     "browserVersion": "latest",
+    //     "platform": "MAC"
+    // },
     {
         "browserName": "chrome",
         "browserVersion": "latest-2",
-        "platform": "MAC"
+        "platform": "WINDOWS"
     },
     {
         "browserName": "chrome",
         "browserVersion": "latest-1",
-        "platform": "MAC"
-    },
-    {
-        "browserName": "chrome",
-        "browserVersion": "latest",
-        "platform": "MAC"
-    },
-    {
-        "browserName": "chrome",
-        "browserVersion": "latest-2",
-        "platform": "WINDOWS"
-    },
-    {
-        "browserName": "chrome",
-        "browserVersion": "latest-1",
         "platform": "WINDOWS"
     },
     {
@@ -29,21 +29,21 @@ const browserCompatibilityConfig = [
         "browserVersion": "latest",
         "platform": "WINDOWS"
     },
-    {
-        "browserName": "firefox",
-        "browserVersion": "latest-2",
-        "platform": "MAC"
-    },
-    {
-        "browserName": "firefox",
-        "browserVersion": "latest-1",
-        "platform": "MAC"
-    },
-    {
-        "browserName": "firefox",
-        "browserVersion": "latest",
-        "platform": "MAC"
-    },
+    // {
+    //     "browserName": "firefox",
+    //     "browserVersion": "latest-2",
+    //     "platform": "MAC"
+    // },
+    // {
+    //     "browserName": "firefox",
+    //     "browserVersion": "latest-1",
+    //     "platform": "MAC"
+    // },
+    // {
+    //     "browserName": "firefox",
+    //     "browserVersion": "latest",
+    //     "platform": "MAC"
+    // },
     {
         "browserName": "firefox",
         "browserVersion": "latest-2",
@@ -60,10 +60,20 @@ const browserCompatibilityConfig = [
         "platform": "WINDOWS"
     },
     {
-        "browserName": "safari",
-        "browserVersion": "latest",
-        "platform": "MAC"
-    }
+        "browserName": "chrome",
+        "browserVersion": "beta",
+        "platform": "WINDOWS"
+    },
+    {
+        "browserName": "firefox",
+        "browserVersion": "beta",
+        "platform": "WINDOWS"
+    },
+    // {
+    //     "browserName": "safari",
+    //     "browserVersion": "latest",
+    //     "platform": "MAC"
+    // }
 ];
 
 module.exports = browserCompatibilityConfig;

--- a/integration/configs/IntegrationTestBrowserConfig.js
+++ b/integration/configs/IntegrationTestBrowserConfig.js
@@ -2,7 +2,7 @@ const integrationTestBrowserConfig = [
     {
     browserName: "chrome",
     browserVersion: "latest",
-    platform: "macOS 13"
+    platform: "MAC"
     }
 ];
 

--- a/integration/utils/ClientHelper.js
+++ b/integration/utils/ClientHelper.js
@@ -45,7 +45,7 @@ const getPlatformName = (platform) => {
     case 'MAC':
       return 'macOS 13';
     case 'WINDOWS':
-      return 'Windows 10';
+      return 'Windows 11';
     case 'LINUX':
       return 'Linux Beta';
     case 'IOS':

--- a/integration/utils/SdkBaseTest.js
+++ b/integration/utils/SdkBaseTest.js
@@ -37,8 +37,9 @@ class SdkBaseTest {
     for (let i = 0; i < urlParams.length; i++) {
       if (i === 0) {
         this.url = this.url.concat(`?${urlParams[i]}`);
+      } else {
+        this.url = this.url.concat(`&${urlParams[i]}`);
       }
-      this.url = this.url.concat(`&${urlParams[i]}`);
     }
   }
 }


### PR DESCRIPTION
**Description of changes:**
Current integration tests fail when running with SauceLabs tunnel so switch to use serverless demo.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

