### PR TITLE
ci: add contents: read to webview-ui-test workflow

### DIFF
--- a/.github/workflows/webview-ui-test.yml
+++ b/.github/workflows/webview-ui-test.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   xcuitest:
     runs-on: macos-11


### PR DESCRIPTION
The `webview-ui-test.yml` workflow runs after the Deploy Demo App workflow completes and executes xcuitest E2E tests on macOS. It checks out `aws-samples/amazon-chime-sdk` and runs tests against a `DEPLOYED_MEETING_DEMO` URL. No git pushes, no comments — `contents: read` is the right floor.