### PR TITLE
Replace --app= with APP= env var for demo app selection

### DIFF
--- a/demos/browser/README.md
+++ b/demos/browser/README.md
@@ -69,29 +69,29 @@ Browser demo applications are located in the `app` folder. Current demos are:
 To run a specific demo application use:
 
 ```
-npm run start --app=<app>
+APP=<app> npm run start
 ```
 
 For example,
 1. To run the `meetingV2` demo, run:
     ```
-    npm run start --app=meetingV2
+    APP=meetingV2 npm run start
     ```
 2. To run the `meetingReadinessChecker` demo, run:
     ```
-    npm run start --app=meetingReadinessChecker
+    APP=meetingReadinessChecker npm run start
     ```
 3. To run the `messagingSession` demo, run:
     ```
-    npm run start --app=messagingSession
+    APP=messagingSession npm run start
     ```
 
-If you don't specify the `--app` option, it will run the `meetingV2` demo.
+If you don't specify the `APP` variable, it will run the `meetingV2` demo.
 
 After running `start` the first time, you can speed things up on subsequent iterations by using `start:fast`, e.g.
 
 ```
-npm run start:fast (--app=<app>)
+APP=<app> npm run start:fast
 ```
 
 ### Providing a custom application metadata

--- a/demos/browser/api-server.js
+++ b/demos/browser/api-server.js
@@ -15,7 +15,7 @@ const { v4: uuidv4 } = require('uuid');
 const meetingTable = {};
 
 // Load the contents of the web application to be used as the index page.
-const app = process.env.npm_config_app || 'meetingV2';
+const app = process.env.APP || 'meetingV2';
 const indexPagePath = `dist/${app}.html`;
 
 console.info('Using index path', indexPagePath);

--- a/demos/browser/vite.config.ts
+++ b/demos/browser/vite.config.ts
@@ -7,7 +7,7 @@ import { watch } from 'chokidar';
 import { viteSingleFile } from 'vite-plugin-singlefile';
 import ejsSvgPlugin from './plugins/vite-plugin-ejs-svg';
 
-const app = process.env.npm_config_app || process.env.APP || 'meetingV2';
+const app = process.env.APP || 'meetingV2';
 const watchSdk = process.env.SDK_AUTOREFRESH === 'true';
 
 /**

--- a/demos/serverless/deploy.js
+++ b/demos/serverless/deploy.js
@@ -209,7 +209,7 @@ function ensureApp(appName) {
     process.exit(1);
   }
   console.log(`Rebuilding demo app`);
-  spawnOrFail('npm', ['run', 'build', `--app=${appName}`], {cwd: path.join(__dirname, '..', 'browser')});
+  spawnOrFail('npm', ['run', 'build'], {cwd: path.join(__dirname, '..', 'browser'), env: {...process.env, APP: appName}});
 }
 
 function ensureTools() {

--- a/integration/script/run-test.js
+++ b/integration/script/run-test.js
@@ -215,7 +215,7 @@ function startTestDemo() {
   // Build the environment for the demo process
   const demoEnv = { ...process.env };
   if (appName) {
-    demoEnv.npm_config_app = appName;
+    demoEnv.APP = appName;
     logger.log(`Starting demo with app: ${appName}`, LogLevel.INFO);
   }
   


### PR DESCRIPTION
**Issue #:**

**Description of changes:**

npm v9+ no longer exposes arbitrary --key=value flags as npm_config_* environment variables in child scripts (per npm RFC #0021). This broke npm run build --app=meetingReadinessChecker since npm_config_app was never set.

Switch to APP= env var which works reliably across all npm versions: APP=meetingReadinessChecker npm run start

- Update README examples to use APP= syntax
- Update vite.config.ts and api-server.js to prioritize APP env var
- Update deploy.js to pass APP env var instead of --app= flag
- Update integration test runner to set APP instead of npm_config_app
- Remove npm_config_app (package.json requires npm>=10 where it never works)


**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*

Verified below command start the corresponding demo app
```
APP=messagingSession npm run start
APP=meetingReadinessChecker npm run start
APP=meetingV2 npm run start
```

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
N/A

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

