### PR TITLE
Update to latest Mac and re-enable browser compatibility test for Mac

### DIFF
--- a/integration/configs/BrowserCompatibilityBrowserConfig.js
+++ b/integration/configs/BrowserCompatibilityBrowserConfig.js
@@ -1,19 +1,19 @@
 const browserCompatibilityConfig = [
-    // {
-    //     "browserName": "chrome",
-    //     "browserVersion": "latest-2",
-    //     "platform": "MAC"
-    // },
-    // {
-    //     "browserName": "chrome",
-    //     "browserVersion": "latest-1",
-    //     "platform": "MAC"
-    // },
-    // {
-    //     "browserName": "chrome",
-    //     "browserVersion": "latest",
-    //     "platform": "MAC"
-    // },
+    {
+        "browserName": "chrome",
+        "browserVersion": "latest-2",
+        "platform": "MAC"
+    },
+    {
+        "browserName": "chrome",
+        "browserVersion": "latest-1",
+        "platform": "MAC"
+    },
+    {
+        "browserName": "chrome",
+        "browserVersion": "latest",
+        "platform": "MAC"
+    },
     {
         "browserName": "chrome",
         "browserVersion": "latest-2",
@@ -29,21 +29,21 @@ const browserCompatibilityConfig = [
         "browserVersion": "latest",
         "platform": "WINDOWS"
     },
-    // {
-    //     "browserName": "firefox",
-    //     "browserVersion": "latest-2",
-    //     "platform": "MAC"
-    // },
-    // {
-    //     "browserName": "firefox",
-    //     "browserVersion": "latest-1",
-    //     "platform": "MAC"
-    // },
-    // {
-    //     "browserName": "firefox",
-    //     "browserVersion": "latest",
-    //     "platform": "MAC"
-    // },
+    {
+        "browserName": "firefox",
+        "browserVersion": "latest-2",
+        "platform": "MAC"
+    },
+    {
+        "browserName": "firefox",
+        "browserVersion": "latest-1",
+        "platform": "MAC"
+    },
+    {
+        "browserName": "firefox",
+        "browserVersion": "latest",
+        "platform": "MAC"
+    },
     {
         "browserName": "firefox",
         "browserVersion": "latest-2",

--- a/integration/configs/WebDriverBaseConfig.js
+++ b/integration/configs/WebDriverBaseConfig.js
@@ -1,64 +1,69 @@
-const config = {
-  firefoxOptions: {
-    browserName: 'firefox',
-    'moz:firefoxOptions': {
-      args: process.env.HEADLESS_MODE === 'true' ? 
-        ['-start-debugger-server', '9222', '-headless'] : 
-        ['-start-debugger-server', '9222'],
-      prefs: {
-        'media.navigator.streams.fake': true,
-        'media.navigator.permission.disabled': true,
-        'media.peerconnection.video.h264_enabled': true,
-        'media.webrtc.hw.h264.enabled': true,
-        'media.webrtc.platformencoder': true,
-        'devtools.chrome.enabled': true,
-        'devtools.debugger.prompt-connection': false,
-        'devtools.debugger.remote-enabled': true,
+const getConfig = () => {
+  const platformName = process.env.PLATFORM_NAME || 'macOS 13';
+  const macVersionMatch = platformName.match(/^macOS\s+(\d+)/);
+  const isMacOS14OrHigher = macVersionMatch && parseInt(macVersionMatch[1], 10) >= 14;
+
+  return {
+    firefoxOptions: {
+      browserName: 'firefox',
+      'moz:firefoxOptions': {
+        args: process.env.HEADLESS_MODE === 'true'
+          ? ['-start-debugger-server', '9222', '-headless']
+          : ['-start-debugger-server', '9222'],
+        prefs: {
+          'media.navigator.streams.fake': true,
+          'media.navigator.permission.disabled': true,
+          'media.peerconnection.video.h264_enabled': true,
+          'media.webrtc.hw.h264.enabled': true,
+          'media.webrtc.platformencoder': true,
+          'devtools.chrome.enabled': true,
+          'devtools.debugger.prompt-connection': false,
+          'devtools.debugger.remote-enabled': true,
+        },
       },
     },
-  },
-  chromeOptions: {
-    browserName: 'chrome',
-    'goog:chromeOptions': {
-      args:
-        process.env.HEADLESS_MODE === 'true'
-          ? [
-              '--use-fake-device-for-media-stream',
-              '--use-fake-ui-for-media-stream',
-              '--headless=new',
-              '--window-size=1920,1080',
-              '--no-sandbox',
-              '--disable-dev-shm-usage',
-              '--enable-webgl',
-              '--enable-webgl2-compute-context',
-              '--use-gl=angle',
-              '--use-angle=swiftshader',
-            ]
-          : [
-              '--use-fake-device-for-media-stream',
-              '--use-fake-ui-for-media-stream',
-              '--window-size=1920,1080',
-            ],
+    chromeOptions: {
+      browserName: 'chrome',
+      'goog:chromeOptions': {
+        args:
+          process.env.HEADLESS_MODE === 'true'
+            ? [
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream',
+                '--headless=new',
+                '--window-size=1920,1080',
+                '--no-sandbox',
+                '--disable-dev-shm-usage',
+                '--enable-webgl',
+                '--enable-webgl2-compute-context',
+                '--use-gl=angle',
+                '--use-angle=swiftshader',
+              ]
+            : [
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream',
+                '--window-size=1920,1080',
+              ],
+      },
+      ...(process.env.ENABLE_BROWSER_LOGGING === 'true' && { 'goog:loggingPrefs': { browser: 'ALL' } }),
     },
-    ...(process.env.ENABLE_BROWSER_LOGGING === 'true' && { 'goog:loggingPrefs': { browser: 'ALL' } }),
-  },
-  safariOptions: {
-    browserName: 'safari',
-    // Safari doesn't support headless mode
-  },
-  sauceOptions: {
-    browserName: process.env.BROWSER_NAME || 'chrome',
-    platformName: process.env.PLATFORM_NAME || 'macOS 13',
-    browserVersion: process.env.BROWSER_VERSION || 'latest',
-    'sauce:options': {
-      tunnelName: process.env.JOB_ID,
-      username: process.env.SAUCE_USERNAME,
-      accessKey: process.env.SAUCE_ACCESS_KEY,
-      noSSLBumpDomains: 'all',
-      extendedDebugging: true,
-      screenResolution: '1920x1440',
+    safariOptions: {
+      browserName: 'safari',
     },
-  },
+    sauceOptions: {
+      browserName: process.env.BROWSER_NAME || 'chrome',
+      platformName,
+      browserVersion: process.env.BROWSER_VERSION || 'latest',
+      'sauce:options': {
+        tunnelName: process.env.JOB_ID,
+        username: process.env.SAUCE_USERNAME,
+        accessKey: process.env.SAUCE_ACCESS_KEY,
+        noSSLBumpDomains: 'all',
+        extendedDebugging: !isMacOS14OrHigher,
+        screenResolution: '1920x1440',
+      },
+    },
+  };
 };
 
-module.exports = config;
+module.exports = getConfig;

--- a/integration/utils/ClientHelper.js
+++ b/integration/utils/ClientHelper.js
@@ -43,7 +43,7 @@ function determineSessionCount(client, logger) {
 const getPlatformName = (platform) => {
   switch (platform) {
     case 'MAC':
-      return 'macOS 13';
+      return 'macOS 26';
     case 'WINDOWS':
       return 'Windows 11';
     case 'LINUX':

--- a/integration/utils/WebDriverFactory.js
+++ b/integration/utils/WebDriverFactory.js
@@ -1,6 +1,6 @@
 const { Builder } = require('selenium-webdriver');
 const { Logger, LogLevel, Log } = require('./Logger');
-const config = require('../configs/WebDriverBaseConfig');
+const getConfig = require('../configs/WebDriverBaseConfig');
 const { DeviceFarmClient, CreateTestGridUrlCommand } = require('@aws-sdk/client-device-farm');
 
 class WebDriverFactory {
@@ -24,6 +24,7 @@ class WebDriverFactory {
   }
 
   async configure() {
+    const config = getConfig();
     let builder = new Builder();
     let client;
     let capabilities = {};


### PR DESCRIPTION
**Description of changes:**
Update to latest Mac and re-enable browser compatibility test for Mac.

Previously the tests failed in Mac after 14 due to audio permission popped up even with fake media stream enabled.
Disable extendedDebugging seems to fix the issue.

**Testing:**

Manually ran audio/video tests in SauceLabs and verified that tests passed. 

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

