### PR TITLE
Add Microsoft Edge to SauceLabs browser-compatibility matrix

### DIFF
--- a/integration/configs/BrowserCompatibilityBrowserConfig.js
+++ b/integration/configs/BrowserCompatibilityBrowserConfig.js
@@ -69,11 +69,26 @@ const browserCompatibilityConfig = [
         "browserVersion": "beta",
         "platform": "WINDOWS"
     },
-    // {
-    //     "browserName": "safari",
-    //     "browserVersion": "latest",
-    //     "platform": "MAC"
-    // }
+    {
+        "browserName": "MicrosoftEdge",
+        "browserVersion": "latest-2",
+        "platform": "WINDOWS"
+    },
+    {
+        "browserName": "MicrosoftEdge",
+        "browserVersion": "latest-1",
+        "platform": "WINDOWS"
+    },
+    {
+        "browserName": "MicrosoftEdge",
+        "browserVersion": "latest",
+        "platform": "WINDOWS"
+    },
+    {
+        "browserName": "MicrosoftEdge",
+        "browserVersion": "beta",
+        "platform": "WINDOWS"
+    }
 ];
 
 module.exports = browserCompatibilityConfig;

--- a/integration/configs/WebDriverBaseConfig.js
+++ b/integration/configs/WebDriverBaseConfig.js
@@ -50,6 +50,27 @@ const getConfig = () => {
     safariOptions: {
       browserName: 'safari',
     },
+    edgeOptions: {
+      browserName: 'MicrosoftEdge',
+      'ms:edgeOptions': {
+        args:
+          process.env.HEADLESS_MODE === 'true'
+            ? [
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream',
+                '--headless=new',
+                '--window-size=1920,1080',
+                '--no-sandbox',
+                '--disable-dev-shm-usage',
+              ]
+            : [
+                '--use-fake-device-for-media-stream',
+                '--use-fake-ui-for-media-stream',
+                '--window-size=1920,1080',
+              ],
+      },
+      ...(process.env.ENABLE_BROWSER_LOGGING === 'true' && { 'goog:loggingPrefs': { browser: 'ALL' } }),
+    },
     sauceOptions: {
       browserName: process.env.BROWSER_NAME || 'chrome',
       platformName,

--- a/integration/utils/WebDriverFactory.js
+++ b/integration/utils/WebDriverFactory.js
@@ -86,6 +86,9 @@ class WebDriverFactory {
       } else if (client.browserName === 'safari') {
         builder.forBrowser('safari');
         Object.assign(capabilities, config.safariOptions);
+      } else if (client.browserName === 'MicrosoftEdge') {
+        builder.forBrowser('MicrosoftEdge');
+        Object.assign(capabilities, config.edgeOptions);
       } else {
         this.logger.log(
           `browserName: ${client.browserName} defined in the test config is not valid`,


### PR DESCRIPTION
**Issue #:**
Currently the browser compatibility tests do not run on MS Edge. Thus any issues on Edge may go unchecked. This PR adds MS Edge coverage on SauceLabs.

**Description of changes:**
Adds Edge (latest-2, latest-1, latest, beta) on Windows to the daily browser-compatibility tests. Wires `ms:edgeOptions` in `WebDriverBaseConfig` and a MicrosoftEdge branch in `WebDriverFactory`.


**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
Integration tests only. No demo app testing needed.

Tested the changes running the tests on SauceLabs using the latest deployed demo URL and verified video tests pass on SauceLabs.
```
npm run test -- --test-name VideoTest --host saucelabs --test-type browser-compatibility --config edge_only.config.json
```

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
Yes

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
No

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

