### PR TITLE
ci: Bump Node version from 20 to 26 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
           registry-url: 'https://registry.npmjs.org'
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm


### PR DESCRIPTION
  **Issue #:**
npm@latest now resolves to npm 12.x which requires Node 22.22+ or 24.15+ or 26+. The publish workflow was using Node 20, causing the release to fail with EBADENGINE when running npm install -g npm@latest.

**Description of changes:**
 Bumped the node-version in actions/setup-node to 26 to fix the publish workflow.

**Testing:**
 This is a CI-only change (workflow YAML). Verified that Node 26 (latest: v26.1.0) satisfies the npm 12.x engine requirement (>=26.0.0). The fix will be validated when the release workflow is re-triggered after merge.

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A -  no application code changes.

**Checklist:**

1. Have you successfully run `npm run build:release` locally? **Yes**

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved? **No**


4. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved? **No**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

