### PR TITLE
fix(statscollector): Skip CPU pressure observe when Permissions Policy disallows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a Chrome `[Violation] Permissions policy violation: compute-pressure is not allowed in this document.` console message by skipping CPU pressure observation when the `compute-pressure` Permissions Policy feature is not allowed (e.g. in cross-origin iframes such as embedded CCP).
+
 ## [3.32.0] - 2026-05-14
 
 ### Added

--- a/src/statscollector/ComputePressureMonitor.ts
+++ b/src/statscollector/ComputePressureMonitor.ts
@@ -39,6 +39,12 @@ export default class ComputePressureMonitor {
       this.logger.debug(() => 'PressureObserver is not available; CPU pressure metric disabled');
       return;
     }
+    if (!this.isComputePressureAllowed()) {
+      this.logger.debug(
+        () => 'compute-pressure is not allowed in this document; CPU pressure metric disabled'
+      );
+      return;
+    }
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.observer = new ctor((records: any[]) => {
@@ -87,5 +93,18 @@ export default class ComputePressureMonitor {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ctor = (globalThis as any).PressureObserver;
     return typeof ctor === 'function' ? ctor : null;
+  }
+
+  private isComputePressureAllowed(): boolean {
+    /* istanbul ignore next */
+    if (typeof document === 'undefined') {
+      return true;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const featurePolicy = (document as any).featurePolicy;
+    if (featurePolicy && typeof featurePolicy.allowsFeature === 'function') {
+      return featurePolicy.allowsFeature('compute-pressure');
+    }
+    return true;
   }
 }

--- a/test/statscollector/ComputePressureMonitor.test.ts
+++ b/test/statscollector/ComputePressureMonitor.test.ts
@@ -5,6 +5,8 @@ import * as chai from 'chai';
 
 import NoOpDebugLogger from '../../src/logger/NoOpDebugLogger';
 import ComputePressureMonitor from '../../src/statscollector/ComputePressureMonitor';
+import DOMMockBehavior from '../dommock/DOMMockBehavior';
+import DOMMockBuilder from '../dommock/DOMMockBuilder';
 
 type PressureRecord = { source: 'cpu'; state: 'nominal' | 'fair' | 'serious' | 'critical' };
 type PressureCallback = (records: PressureRecord[]) => void;
@@ -17,8 +19,10 @@ describe('ComputePressureMonitor', () => {
   const globalScope = globalThis as any;
 
   let savedPressureObserver: unknown;
+  let domMockBuilder: DOMMockBuilder;
 
   beforeEach(() => {
+    domMockBuilder = new DOMMockBuilder(new DOMMockBehavior());
     savedPressureObserver = globalScope.PressureObserver;
   });
 
@@ -28,7 +32,27 @@ describe('ComputePressureMonitor', () => {
     } else {
       globalScope.PressureObserver = savedPressureObserver;
     }
+    domMockBuilder.cleanup();
   });
+
+  function setFeaturePolicy(allowed: boolean | undefined): void {
+    if (allowed === undefined) {
+      Object.defineProperty(document, 'featurePolicy', {
+        configurable: true,
+        value: undefined,
+      });
+      return;
+    }
+    Object.defineProperty(document, 'featurePolicy', {
+      configurable: true,
+      value: {
+        allowsFeature: (feature: string) => {
+          expect(feature).to.equal('compute-pressure');
+          return allowed;
+        },
+      },
+    });
+  }
 
   function installFakeObserver(
     options: {
@@ -165,6 +189,39 @@ describe('ComputePressureMonitor', () => {
     monitor.stop();
     expect(handle.disconnectCount()).to.equal(1);
     expect(monitor.currentState()).to.equal(null);
+  });
+
+  it('does not observe when compute-pressure is disallowed by Permissions Policy', async () => {
+    const handle = installFakeObserver();
+    setFeaturePolicy(false);
+    const monitor = new ComputePressureMonitor(logger);
+    await monitor.start();
+    // observe() was never reached, so no callback was captured and no sample.
+    expect(handle.callback()).to.equal(undefined);
+    expect(monitor.currentState()).to.equal(null);
+    monitor.stop();
+    // Nothing to disconnect since start() bailed before creating an observer.
+    expect(handle.disconnectCount()).to.equal(0);
+  });
+
+  it('observes when compute-pressure is allowed by Permissions Policy', async () => {
+    const handle = installFakeObserver();
+    setFeaturePolicy(true);
+    const monitor = new ComputePressureMonitor(logger);
+    await monitor.start();
+    handle.callback()([{ source: 'cpu', state: 'fair' }]);
+    expect(monitor.currentState()).to.equal('fair');
+    monitor.stop();
+  });
+
+  it('observes when document.featurePolicy is unavailable', async () => {
+    const handle = installFakeObserver();
+    setFeaturePolicy(undefined);
+    const monitor = new ComputePressureMonitor(logger);
+    await monitor.start();
+    handle.callback()([{ source: 'cpu', state: 'serious' }]);
+    expect(monitor.currentState()).to.equal('serious');
+    monitor.stop();
   });
 
   it('treats a non-function PressureObserver as missing', async () => {


### PR DESCRIPTION


**Issue #:**

None

**Description of changes:**

The Compute Pressure API's PressureObserver constructor exists in Chrome even when the compute-pressure Permissions Policy feature is denied, which is the default in cross-origin iframes such as embedded CCP. Calling observe('cpu', ...) there makes Chrome emit a "[Violation] Permissions policy violation: compute-pressure is not allowed in this document." console message that the surrounding try/catch cannot suppress.

Gate start() on document.featurePolicy.allowsFeature('compute-pressure') so the observer is never created when the feature is disallowed, and drop to a debug log instead. When the feature-policy check is unavailable, keep the prior behavior and let observe()'s try/catch handle any rejection.

**Testing:**
N/A
*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*
N/A

**Checklist:**

1. Have you successfully run `npm run build:release` locally?
y

2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?
n

3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?
n

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

