### PR TITLE
Do not pass custom video file if not needed

### DIFF
--- a/.github/workflows/browser-compatibility-test.yml
+++ b/.github/workflows/browser-compatibility-test.yml
@@ -38,9 +38,13 @@ jobs:
           sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
           browser-compatibility-test: true
       - name: Run Audio Test
+        id: audio_test
+        continue-on-error: true
         working-directory: ./integration
         run: npm run test -- --test-name AudioTest --host saucelabs --test-type browser-compatibility
       - name: Run Video Test
+        id: video_test
+        continue-on-error: true
         working-directory: ./integration
         run: npm run test -- --test-name VideoTest --host saucelabs --test-type browser-compatibility
       # - name: Run Video Processing Test
@@ -59,7 +63,8 @@ jobs:
           node -e "
           const { CloudWatchClient, PutMetricDataCommand } = require('@aws-sdk/client-cloudwatch');
           const client = new CloudWatchClient({ region: 'us-east-1' });
-          const value = '${{ job.status }}' === 'success' ? 1 : 0;
+          const allPassed = '${{ steps.audio_test.outcome }}' === 'success' && '${{ steps.video_test.outcome }}' === 'success';
+          const value = allPassed ? 1 : 0;
           const command = new PutMetricDataCommand({
             Namespace: process.env.METRIC_NAMESPACE,
             MetricData: [{
@@ -75,3 +80,11 @@ jobs:
             process.exit(1);
           });
           "
+      - name: Fail job if any test failed
+        if: always()
+        run: |
+          if [ "${{ steps.audio_test.outcome }}" != "success" ] || [ "${{ steps.video_test.outcome }}" != "success" ]; then
+            echo "One or more browser compatibility tests failed (AudioTest=${{ steps.audio_test.outcome }}, VideoTest=${{ steps.video_test.outcome }})"
+            exit 1
+          fi
+          echo "All browser compatibility tests passed"

--- a/integration/configs/WebDriverBaseConfig.js
+++ b/integration/configs/WebDriverBaseConfig.js
@@ -3,6 +3,23 @@ const getConfig = () => {
   const macVersionMatch = platformName.match(/^macOS\s+(\d+)/);
   const isMacOS14OrHigher = macVersionMatch && parseInt(macVersionMatch[1], 10) >= 14;
 
+  // Only tests that verify pixel output (e.g. background segmentation filters) need a
+  // deterministic fake video source. The file lives on the machine running the test, so it is
+  // only reachable when the browser is on the same host (`--host local`). On remote hosts like
+  // SauceLabs the path does not exist, which breaks video device enumeration for every test.
+  let testName = '';
+  try {
+    testName = (JSON.parse(process.env.TEST || '{}').name) || '';
+  } catch (e) {
+    testName = '';
+  }
+  const testsNeedingCustomVideoFile = ['VideoProcessingTest'];
+  const useCustomVideoFile =
+    process.env.HOST === 'local' && testsNeedingCustomVideoFile.includes(testName);
+  const customVideoFileArgs = useCustomVideoFile
+    ? ['--use-file-for-fake-video-capture=' + require('path').resolve(__dirname, '../fake_stream/output.y4m')]
+    : [];
+
   return {
     firefoxOptions: {
       browserName: 'firefox',
@@ -30,7 +47,7 @@ const getConfig = () => {
             ? [
                 '--use-fake-device-for-media-stream',
                 '--use-fake-ui-for-media-stream',
-                '--use-file-for-fake-video-capture=' + require('path').resolve(__dirname, '../fake_stream/output.y4m'),
+                ...customVideoFileArgs,
                 '--headless=new',
                 '--window-size=1920,1080',
                 '--no-sandbox',
@@ -44,7 +61,7 @@ const getConfig = () => {
                 '--use-fake-device-for-media-stream',
                 '--use-fake-ui-for-media-stream',
                 '--disable-local-discovery',
-                '--use-file-for-fake-video-capture=' + require('path').resolve(__dirname, '../fake_stream/output.y4m'),
+                ...customVideoFileArgs,
                 '--window-size=1920,1080',
               ],
       },


### PR DESCRIPTION

**Description of changes:**
Browser compatiblity test failed since we pass the custom video file link locally which SauceLabs cannot access remotely which made video could not be rendered.

Conditionally pass the flag only for video processing test now.


Also update so that all tests run to the end and do not quit if one test fails.

**Testing:**

*Can these tested using a demo application? Please provide reproducible step-by-step instructions.*


**Checklist:**

1. Have you successfully run `npm run build:release` locally?


2. Do you add, modify, or delete public API definitions? If yes, has that been reviewed and approved?


3. Do you change the wire protocol, e.g. the request method? If yes, has that been reviewed and approved?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

